### PR TITLE
replaces galcom with english

### DIFF
--- a/code/datums/quirks/neutral.dm
+++ b/code/datums/quirks/neutral.dm
@@ -33,8 +33,8 @@
 	desc = "You're not from around here. You don't know English!" //MOJAVE EDIT FROM - 	desc = "You're not from around here. You don't know Galactic Common!"
 	value = 0
 	gain_text = "<span class='notice'>The words being spoken around you don't make any sense."
-	lose_text = "<span class='notice'>You've developed fluency in English." //MOJAVE EDIT FROM - lose_text = "<span class='notice'>You've developed fluency in Galactic Common."
-	medical_record_text = "Patient does not speak English and may require an interpreter." //MOJAVE EDIT FROM - medical_record_text = "Patient does not speak Galactic Common and may require an interpreter."
+	lose_text = "<span class='notice'>You've developed fluency in English." //MOJAVE EDIT CHANGE - lose_text = "<span class='notice'>You've developed fluency in Galactic Common."
+	medical_record_text = "Patient does not speak English and may require an interpreter." //MOJAVE EDIT CHANGE - medical_record_text = "Patient does not speak Galactic Common and may require an interpreter."
 
 /datum/quirk/foreigner/add()
 	var/mob/living/carbon/human/human_holder = quirk_holder

--- a/code/datums/quirks/neutral.dm
+++ b/code/datums/quirks/neutral.dm
@@ -30,11 +30,11 @@
 
 /datum/quirk/foreigner
 	name = "Foreigner"
-	desc = "You're not from around here. You don't know Galactic Common!"
+	desc = "You're not from around here. You don't know English!" //MOJAVE EDIT FROM - 	desc = "You're not from around here. You don't know Galactic Common!"
 	value = 0
 	gain_text = "<span class='notice'>The words being spoken around you don't make any sense."
-	lose_text = "<span class='notice'>You've developed fluency in Galactic Common."
-	medical_record_text = "Patient does not speak Galactic Common and may require an interpreter."
+	lose_text = "<span class='notice'>You've developed fluency in English." //MOJAVE EDIT FROM - lose_text = "<span class='notice'>You've developed fluency in Galactic Common."
+	medical_record_text = "Patient does not speak English and may require an interpreter." //MOJAVE EDIT FROM - medical_record_text = "Patient does not speak Galactic Common and may require an interpreter."
 
 /datum/quirk/foreigner/add()
 	var/mob/living/carbon/human/human_holder = quirk_holder

--- a/code/modules/language/common.dm
+++ b/code/modules/language/common.dm
@@ -1,7 +1,7 @@
 // 'basic' language; spoken by default.
 /datum/language/common
-	name = "English" //MOJAVE EDIT FROM - name = "Galactic Common"
-	desc = "The most commonly spoken language in America, both before and after the apocalypse" //MOJAVE EDIT FROM - desc = "The common galactic tongue."
+	name = "English" //MOJAVE EDIT CHANGE - name = "Galactic Common"
+	desc = "The most commonly spoken language in America, both before and after the apocalypse" //MOJAVE EDIT CHANGE - desc = "The common galactic tongue."
 	key = "0"
 	flags = TONGUELESS_SPEECH | LANGUAGE_HIDE_ICON_IF_UNDERSTOOD
 	default_priority = 100

--- a/code/modules/language/common.dm
+++ b/code/modules/language/common.dm
@@ -1,7 +1,7 @@
 // 'basic' language; spoken by default.
 /datum/language/common
-	name = "Galactic Common"
-	desc = "The common galactic tongue."
+	name = "English" //MOJAVE EDIT FROM - name = "Galactic Common"
+	desc = "The most commonly spoken language in America, both before and after the apocalypse" //MOJAVE EDIT FROM - desc = "The common galactic tongue."
 	key = "0"
 	flags = TONGUELESS_SPEECH | LANGUAGE_HIDE_ICON_IF_UNDERSTOOD
 	default_priority = 100


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR simply replaces the name of the Galactic Common language with English, as well as edits it's description

## Why It's Good For The Game

Galactic Common isn't a thing in the Fallout universe, English is still used in America

## Changelog
:cl:
add: Replaces Galactic Common with English

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
