### PR TITLE
12.7mm SMG can be fired in one hand and stored in bags

### DIFF
--- a/mojave/items/guns/weapons/ballistic/automatic.dm
+++ b/mojave/items/guns/weapons/ballistic/automatic.dm
@@ -194,6 +194,8 @@
 	desc = "A heavy duty submachine gun chambered in 12.7mm, can't hold a lot of rounds, but they sure do pack a punch."
 	icon_state = "smg12mm"
 	inhand_icon_state = "smg12mm"
+	w_class = WEIGHT_CLASS_NORMAL
+	weapon_weight = WEAPON_MEDIUM
 	mag_type = /obj/item/ammo_box/magazine/ms13/smg12mm
 	fire_sound = 'mojave/sound/ms13weapons/gunsounds/12mm/m12mm2.ogg'
 	can_suppress = FALSE


### PR DESCRIPTION
## About The Pull Request

Was always meant to be like this and is balanced around it. Not sure when this was removed or if I just forgot to make it like that. Potentially it works as is with the base flags but I doubt it, this is just to make sure and for consistency sake.

## Why It's Good For The Game

12.7mm SMG if it can't fit in a bag or be fired in one hand is quite bad.