### PR TITLE
Faction map updates/BoS spawner fix/ PA fix

### DIFF
--- a/_maps/map_files/CombatArena/CombatArena_Faction.dmm
+++ b/_maps/map_files/CombatArena/CombatArena_Faction.dmm
@@ -786,9 +786,6 @@
 	},
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
-"tO" = (
-/turf/open/floor/plating/ms13/ice,
-/area/ms13/underground/mountain)
 "uj" = (
 /obj/effect/landmark/start/ms13/scribe,
 /turf/open/floor/iron/ms13/concrete/small,
@@ -1356,12 +1353,6 @@
 	},
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/raiders/building)
-"Gi" = (
-/obj/structure/table/ms13/low_wall/wood,
-/obj/structure/window/fulltile/ms13/glass,
-/obj/structure/table/ms13/low_wall/wood,
-/turf/open/floor/wood/ms13/wide,
-/area/ms13/town)
 "Gk" = (
 /obj/structure/table/ms13/low_wall/brick/alt,
 /obj/structure/window/fulltile/ms13/glass,
@@ -1478,11 +1469,6 @@
 	},
 /turf/open/floor/plating/ms13/ground/mountain,
 /area/ms13/raiders/building)
-"Jo" = (
-/obj/structure/table/ms13/low_wall/wood,
-/obj/effect/spawner/lootdrop/ms13/melee/lowrandom,
-/turf/open/floor/plating/ms13/ground/mountain,
-/area/ms13/town)
 "Jp" = (
 /obj/structure/table/ms13/no_smooth/large/wood/desk{
 	dir = 8
@@ -1869,10 +1855,6 @@
 /obj/effect/landmark/start/ms13/radioman,
 /turf/open/floor/wood/ms13/mosaic,
 /area/ms13/ncr/building)
-"SI" = (
-/obj/structure/table/ms13/low_wall/wood,
-/turf/open/floor/plating/ms13/ground/mountain,
-/area/ms13/town)
 "SK" = (
 /obj/structure/ms13/rug/rubber,
 /turf/open/floor/wood/ms13/carpet/shaggy,
@@ -6623,8 +6605,8 @@ Eo
 Eo
 bi
 Eo
-tO
-tO
+bi
+bi
 Eo
 Eo
 Eo
@@ -6749,12 +6731,12 @@ Eo
 Eo
 bi
 bi
-tO
-tO
-tO
-tO
-tO
-tO
+bi
+bi
+bi
+bi
+bi
+bi
 Eo
 Eo
 Eo
@@ -6876,13 +6858,13 @@ Eo
 Eo
 bi
 bi
-tO
-tO
-tO
-tO
-tO
-tO
-tO
+bi
+bi
+bi
+bi
+bi
+bi
+bi
 Eo
 Eo
 Eo
@@ -7004,13 +6986,13 @@ Eo
 bi
 bi
 bi
-tO
-tO
-tO
-tO
-tO
-tO
-tO
+bi
+bi
+bi
+bi
+bi
+bi
+bi
 bi
 bi
 bi
@@ -7132,13 +7114,13 @@ bi
 bi
 bi
 bi
-tO
-tO
-tO
-tO
-tO
-tO
-tO
+bi
+bi
+bi
+bi
+bi
+bi
+bi
 bi
 bi
 bi
@@ -7259,13 +7241,13 @@ bi
 bi
 bi
 bi
-tO
-tO
-tO
-tO
-tO
-tO
-tO
+bi
+bi
+bi
+bi
+bi
+bi
+bi
 bi
 bi
 bi
@@ -7388,12 +7370,12 @@ bi
 bi
 bi
 bi
-tO
-tO
-tO
-tO
-tO
-tO
+bi
+bi
+bi
+bi
+bi
+bi
 bi
 bi
 nb
@@ -7516,11 +7498,11 @@ bi
 bi
 bi
 bi
-tO
-tO
-tO
-tO
-tO
+bi
+bi
+bi
+bi
+bi
 bi
 bi
 le
@@ -7643,9 +7625,9 @@ bi
 bi
 bi
 bi
-tO
-tO
-tO
+bi
+bi
+bi
 bi
 bi
 bi
@@ -7772,7 +7754,7 @@ bi
 bi
 bi
 bi
-tO
+bi
 bi
 bi
 bi
@@ -18943,9 +18925,9 @@ ZB
 dn
 dn
 dn
-bd
-Jo
-bd
+KJ
+KJ
+KJ
 KJ
 dn
 dn
@@ -19070,9 +19052,9 @@ ZB
 dn
 dn
 dn
-SI
-SZ
-SI
+KJ
+KJ
+KJ
 KJ
 dn
 dn
@@ -19197,9 +19179,9 @@ ZB
 dn
 dn
 dn
-bd
-SI
-bd
+KJ
+KJ
+KJ
 KJ
 dn
 dn
@@ -22447,7 +22429,7 @@ ty
 ty
 ty
 ty
-Gi
+nj
 tm
 tm
 tm

--- a/mojave/code/modules/clothing/spacesuits/power_armor.dm
+++ b/mojave/code/modules/clothing/spacesuits/power_armor.dm
@@ -29,6 +29,7 @@
 	icon_state = "frame"
 	worn_icon = 'mojave/icons/mob/large-worn-icons/32x48/armor.dmi'
 	worn_icon_state = "frame"
+	allowed = list(/obj/item/storage/box/matches,/obj/item/lighter,/obj/item/clothing/mask/cigarette,/obj/item/storage/fancy/cigarettes,/obj/item/flashlight,/obj/item/gun,/obj/item/ammo_box,/obj/item/ammo_casing)
 	density = TRUE //It's a suit of armor man
 	anchored = TRUE
 	strip_delay = 200

--- a/mojave/jobs/job_types/bos/head_paladin.dm
+++ b/mojave/jobs/job_types/bos/head_paladin.dm
@@ -1,5 +1,5 @@
 /datum/job/ms13/bos/head_paladin
-	title = "_BoS Head Paladin"
+	title = "BoS Head Paladin"
 	department_head = list("Brotherhood High Command")
 	total_positions = 1
 	spawn_positions = 1

--- a/mojave/jobs/job_types/bos/head_scribe.dm
+++ b/mojave/jobs/job_types/bos/head_scribe.dm
@@ -1,5 +1,5 @@
 /datum/job/ms13/bos/head_scribe
-	title = "_BoS Head Scribe"
+	title = "BoS Head Scribe"
 	department_head = list("Brotherhood High Command")
 	total_positions = 1
 	spawn_positions = 1

--- a/mojave/jobs/job_types/bos/initiate.dm
+++ b/mojave/jobs/job_types/bos/initiate.dm
@@ -1,5 +1,5 @@
 /datum/job/ms13/bos/initiate
-	title = "_BoS Initiate"
+	title = "BoS Initiate"
 	total_positions = 3
 	spawn_positions = 3
 	supervisors = "Knights, Scribes, and above"

--- a/mojave/jobs/job_types/bos/knight.dm
+++ b/mojave/jobs/job_types/bos/knight.dm
@@ -1,5 +1,5 @@
 /datum/job/ms13/bos/knight
-	title = "_BoS Knight"
+	title = "BoS Knight"
 	department_head = list("Head Paladin")
 	total_positions = 3
 	spawn_positions = 3

--- a/mojave/jobs/job_types/bos/paladin.dm
+++ b/mojave/jobs/job_types/bos/paladin.dm
@@ -1,5 +1,5 @@
 /datum/job/ms13/bos/paladin
-	title = "_BoS Paladin"
+	title = "BoS Paladin"
 	department_head = list("Head Paladin")
 	total_positions = 1
 	spawn_positions = 1

--- a/mojave/jobs/job_types/bos/scribe.dm
+++ b/mojave/jobs/job_types/bos/scribe.dm
@@ -1,5 +1,5 @@
 /datum/job/ms13/bos/scribe
-	title = "_BoS Scribe"
+	title = "BoS Scribe"
 	department_head = list("Head Scribe")
 	total_positions = 2
 	spawn_positions = 2


### PR DESCRIPTION
Fixes a stacked low wall on the faction combat test. Fixes PA suit slot storage. ALSO Fixes the BOS spawners via un-scuffing the role ids.