### PR TITLE
Gives faction arena bases ammo

### DIFF
--- a/_maps/map_files/CombatArena/CombatArena_Faction.dmm
+++ b/_maps/map_files/CombatArena/CombatArena_Faction.dmm
@@ -65,7 +65,7 @@
 /area/ms13/ncr/building)
 "cg" = (
 /obj/structure/table/ms13/no_smooth/large/wood/desk,
-/obj/effect/spawner/lootdrop/ms13/ammo/lowrandom,
+/obj/effect/spawner/lootdrop/ms13/ammo/tier2,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/raiders/building)
 "cj" = (
@@ -268,6 +268,10 @@
 "iq" = (
 /turf/closed/wall/ms13/craftable/scrap,
 /area/ms13/raiders/building)
+"iu" = (
+/obj/item/clothing/glasses/ms13/cool,
+/turf/open/floor/wood/ms13/common,
+/area/ms13/ncr/building)
 "ix" = (
 /obj/structure/ms13/foundation/wide/variantone{
 	dir = 10
@@ -706,7 +710,6 @@
 "sn" = (
 /obj/effect/spawner/lootdrop/ms13/medical/tier1,
 /obj/structure/closet/ms13/wall/firstaid,
-/obj/effect/spawner/lootdrop/ms13/medical/tier1,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/raiders/building)
 "sr" = (
@@ -1039,10 +1042,6 @@
 /obj/effect/spawner/lootdrop/ms13/ammo/highrandom,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
-"zv" = (
-/obj/item/clothing/glasses/ms13/cool,
-/turf/open/floor/wood/ms13/common,
-/area/ms13/ncr/building)
 "zw" = (
 /obj/structure/ms13/storage/bookshelf{
 	dir = 1
@@ -1076,7 +1075,6 @@
 /obj/structure/table/ms13/no_smooth/counter/wood/straight{
 	dir = 8
 	},
-/obj/effect/spawner/lootdrop/ms13/gun/tier1,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/raiders/building)
 "Aj" = (
@@ -1487,6 +1485,8 @@
 /obj/structure/ms13/storage/shelf/rust{
 	dir = 1
 	},
+/obj/effect/spawner/lootdrop/ms13/ammo/tier2,
+/obj/effect/spawner/lootdrop/ms13/ammo/tier2,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/raiders/building)
 "IE" = (
@@ -1905,10 +1905,7 @@
 /turf/open/floor/wood/ms13/mosaic,
 /area/ms13/ncr/building)
 "SI" = (
-/obj/structure/ms13/storage/large/shelf/rust{
-	dir = 1
-	},
-/obj/effect/spawner/lootdrop/ms13/gun/tier1,
+/obj/effect/spawner/lootdrop/ms13/ammo/tier2,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/raiders/building)
 "SK" = (
@@ -2095,6 +2092,13 @@
 /obj/effect/landmark/start/ms13/staffsergeant,
 /turf/open/floor/wood/ms13/mosaic,
 /area/ms13/ncr/building)
+"VY" = (
+/obj/structure/ms13/storage/large/shelf/rust{
+	dir = 1
+	},
+/obj/effect/spawner/lootdrop/ms13/gun/tier1,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/raiders/building)
 "Wa" = (
 /obj/effect/turf_decal/MS13/road/horizontalline,
 /turf/open/floor/plating/ms13/ground/road,
@@ -2301,6 +2305,8 @@
 /area/ms13/town)
 "ZT" = (
 /obj/structure/table/ms13/no_smooth/large/wood/square,
+/obj/effect/spawner/lootdrop/ms13/ammo/tier2,
+/obj/effect/spawner/lootdrop/ms13/ammo/tier2,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/raiders/building)
 
@@ -18555,7 +18561,7 @@ LG
 LG
 LG
 qd
-zv
+iu
 OP
 dn
 dn
@@ -25366,7 +25372,7 @@ fY
 NE
 NE
 NE
-SI
+VY
 YP
 wo
 wo
@@ -25480,7 +25486,7 @@ NE
 NE
 NE
 NE
-Jo
+SI
 NE
 xF
 iq
@@ -25731,7 +25737,7 @@ NE
 NE
 NE
 NE
-NE
+SI
 NE
 NE
 NE
@@ -25863,7 +25869,7 @@ cg
 zg
 NE
 NE
-NE
+SI
 YP
 dn
 dn

--- a/_maps/map_files/CombatArena/CombatArena_Faction.dmm
+++ b/_maps/map_files/CombatArena/CombatArena_Faction.dmm
@@ -65,6 +65,7 @@
 /area/ms13/ncr/building)
 "cg" = (
 /obj/structure/table/ms13/no_smooth/large/wood/desk,
+/obj/effect/spawner/lootdrop/ms13/ammo/lowrandom,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/raiders/building)
 "cj" = (
@@ -786,6 +787,22 @@
 	},
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
+"tO" = (
+/obj/structure/table/ms13/metal/heavy,
+/obj/item/stock_parts/cell/ms13/mfc,
+/obj/item/stock_parts/cell/ms13/mfc,
+/obj/item/stock_parts/cell/ms13/mfc,
+/obj/item/stock_parts/cell/ms13/mfc,
+/obj/item/stock_parts/cell/ms13/mfc,
+/obj/item/stock_parts/cell/ms13/mfc,
+/obj/item/stock_parts/cell/ms13/mfc,
+/obj/item/stock_parts/cell/ms13/mfc,
+/obj/item/stock_parts/cell/ms13/mfc,
+/obj/item/stock_parts/cell/ms13/mfc,
+/obj/item/stock_parts/cell/ms13/mfc,
+/obj/item/stock_parts/cell/ms13/mfc,
+/turf/open/floor/iron/ms13/concrete/small,
+/area/ms13/underground/bos)
 "uj" = (
 /obj/effect/landmark/start/ms13/scribe,
 /turf/open/floor/iron/ms13/concrete/small,
@@ -1022,6 +1039,10 @@
 /obj/effect/spawner/lootdrop/ms13/ammo/highrandom,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
+"zv" = (
+/obj/item/clothing/glasses/ms13/cool,
+/turf/open/floor/wood/ms13/common,
+/area/ms13/ncr/building)
 "zw" = (
 /obj/structure/ms13/storage/bookshelf{
 	dir = 1
@@ -1190,7 +1211,16 @@
 /obj/structure/table/ms13/no_smooth/counter/wood/straight{
 	dir = 4
 	},
-/obj/item/clothing/glasses/ms13/cool,
+/obj/item/ammo_box/magazine/ms13/m9mm,
+/obj/item/ammo_box/magazine/ms13/m9mm,
+/obj/item/ammo_box/magazine/ms13/m9mm,
+/obj/item/ammo_box/magazine/ms13/m9mm,
+/obj/item/ammo_box/magazine/ms13/m9mm,
+/obj/item/ammo_box/magazine/ms13/m9mm,
+/obj/item/ammo_box/magazine/ms13/m9mm,
+/obj/item/ammo_box/magazine/ms13/m9mm,
+/obj/item/ammo_box/magazine/ms13/m9mm,
+/obj/item/ammo_box/magazine/ms13/m9mm,
 /turf/open/floor/wood/ms13/carpet/shaggy,
 /area/ms13/ncr/building)
 "CN" = (
@@ -1232,6 +1262,7 @@
 /obj/structure/table/ms13/no_smooth/large/wood/square{
 	dir = 4
 	},
+/obj/effect/spawner/lootdrop/ms13/ammo/lowrandom,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/raiders/building)
 "Dp" = (
@@ -1353,6 +1384,20 @@
 	},
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/raiders/building)
+"Gi" = (
+/obj/structure/table/ms13/metal/heavy,
+/obj/item/ammo_box/magazine/ms13/m10mm,
+/obj/item/ammo_box/magazine/ms13/m10mm,
+/obj/item/ammo_box/magazine/ms13/m10mm,
+/obj/item/ammo_box/magazine/ms13/m10mm,
+/obj/item/ammo_box/magazine/ms13/m10mm,
+/obj/item/ammo_box/magazine/ms13/m10mm,
+/obj/item/ammo_box/magazine/ms13/m10mm,
+/obj/item/ammo_box/magazine/ms13/m10mm,
+/obj/item/ammo_box/magazine/ms13/m10mm,
+/obj/item/ammo_box/magazine/ms13/m10mm,
+/turf/open/floor/iron/ms13/concrete/small,
+/area/ms13/underground/bos)
 "Gk" = (
 /obj/structure/table/ms13/low_wall/brick/alt,
 /obj/structure/window/fulltile/ms13/glass,
@@ -1468,6 +1513,10 @@
 	dir = 10
 	},
 /turf/open/floor/plating/ms13/ground/mountain,
+/area/ms13/raiders/building)
+"Jo" = (
+/obj/effect/spawner/lootdrop/ms13/ammo/lowrandom,
+/turf/open/floor/wood/ms13/wide,
 /area/ms13/raiders/building)
 "Jp" = (
 /obj/structure/table/ms13/no_smooth/large/wood/desk{
@@ -1855,6 +1904,13 @@
 /obj/effect/landmark/start/ms13/radioman,
 /turf/open/floor/wood/ms13/mosaic,
 /area/ms13/ncr/building)
+"SI" = (
+/obj/structure/ms13/storage/large/shelf/rust{
+	dir = 1
+	},
+/obj/effect/spawner/lootdrop/ms13/gun/tier1,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/raiders/building)
 "SK" = (
 /obj/structure/ms13/rug/rubber,
 /turf/open/floor/wood/ms13/carpet/shaggy,
@@ -1962,7 +2018,6 @@
 /obj/structure/table/ms13/no_smooth/counter/wood/straight{
 	dir = 4
 	},
-/obj/item/ammo_box/magazine/ms13/r20,
 /obj/item/ammo_box/magazine/ms13/r20,
 /obj/item/ammo_box/magazine/ms13/r20,
 /obj/item/ammo_box/magazine/ms13/r20,
@@ -18500,7 +18555,7 @@ LG
 LG
 LG
 qd
-qd
+zv
 OP
 dn
 dn
@@ -19024,8 +19079,8 @@ Gn
 Gn
 Gn
 Gn
-Gn
-Gn
+tO
+Gi
 Gn
 Gn
 Gn
@@ -24394,7 +24449,7 @@ Eo
 Eo
 Eo
 NE
-NE
+Jo
 Dm
 YP
 dn
@@ -25311,7 +25366,7 @@ fY
 NE
 NE
 NE
-aJ
+SI
 YP
 wo
 wo
@@ -25425,7 +25480,7 @@ NE
 NE
 NE
 NE
-NE
+Jo
 NE
 xF
 iq


### PR DESCRIPTION
And so she said. "Let them eat lead." This PR adds in ammo to the faction arena bases, as the title says. NCR/BOS get static spawns. Raiders jut get a few other scattered low/randoms. Speedmerge time