### PR TITLE
Buffs a bunch of spawners in the combat map / Fixes metal round table icons

### DIFF
--- a/_maps/map_files/CombatArena/CombatArena_Faction.dmm
+++ b/_maps/map_files/CombatArena/CombatArena_Faction.dmm
@@ -129,6 +129,11 @@
 	},
 /turf/open/floor/wood/ms13/common,
 /area/ms13/ncr/building)
+"dv" = (
+/obj/structure/table/ms13/no_smooth/large/wood/square,
+/obj/effect/spawner/lootdrop/ms13/medical/highrandom,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/town)
 "dI" = (
 /obj/structure/stairs/south,
 /turf/open/floor/wood/ms13/wide,
@@ -181,7 +186,7 @@
 /area/ms13/underground/mountain)
 "fh" = (
 /obj/structure/closet/ms13/wall/firstaid,
-/obj/effect/spawner/lootdrop/ms13/ammo/tier1,
+/obj/effect/spawner/lootdrop/ms13/medical/highrandom,
 /turf/open/floor/iron/ms13/tile/large/white,
 /area/ms13/town)
 "fH" = (
@@ -239,6 +244,13 @@
 /obj/effect/spawner/lootdrop/ms13/medical/highrandom,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/raiders/building)
+"hx" = (
+/obj/structure/ms13/storage/store{
+	dir = 4
+	},
+/obj/effect/spawner/lootdrop/ms13/ammo/highrandom,
+/turf/open/floor/iron/ms13/tile/large/cafeteria,
+/area/ms13/town)
 "hC" = (
 /obj/structure/ms13/road_barrier/concrete,
 /turf/open/floor/plating/ms13/ground/snow,
@@ -263,8 +275,8 @@
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/raiders/building)
 "il" = (
-/obj/effect/spawner/lootdrop/ms13/medical/tier1,
 /obj/structure/table/ms13/no_smooth/large/wood/square,
+/obj/effect/spawner/lootdrop/ms13/medical/lowrandom,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "in" = (
@@ -365,7 +377,7 @@
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/raiders/building)
 "kW" = (
-/obj/effect/spawner/lootdrop/ms13/medical/tier1,
+/obj/effect/spawner/lootdrop/ms13/medical/highrandom,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "la" = (
@@ -440,7 +452,7 @@
 /obj/structure/ms13/storage/store{
 	dir = 8
 	},
-/obj/effect/spawner/lootdrop/ms13/ammo/tier1,
+/obj/effect/spawner/lootdrop/ms13/ammo/highrandom,
 /turf/open/floor/iron/ms13/tile/large/cafeteria,
 /area/ms13/town)
 "mV" = (
@@ -557,8 +569,7 @@
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/raiders/building)
 "oZ" = (
-/obj/structure/ms13/storage/large/shelf/rust,
-/obj/effect/spawner/lootdrop/ms13/medical/tier1,
+/obj/effect/spawner/lootdrop/ms13/medical/highrandom,
 /turf/open/floor/iron/ms13/concrete,
 /area/ms13/town)
 "pm" = (
@@ -928,6 +939,14 @@
 	dir = 4
 	},
 /turf/open/floor/wood/ms13/carpet/shaggy,
+/area/ms13/town)
+"wU" = (
+/obj/structure/ms13/storage/shelf/rust{
+	dir = 1
+	},
+/obj/effect/spawner/lootdrop/ms13/medical/lowrandom,
+/obj/effect/spawner/lootdrop/ms13/medical/highrandom,
+/turf/open/floor/iron/ms13/tile/large/white,
 /area/ms13/town)
 "wW" = (
 /obj/effect/turf_decal/MS13/road/verticalline,
@@ -1328,9 +1347,11 @@
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "Er" = (
-/obj/structure/ms13/storage/store,
+/obj/structure/table/ms13/no_smooth/counter/wood/end{
+	dir = 6
+	},
 /obj/effect/spawner/lootdrop/ms13/medical/lowrandom,
-/turf/open/floor/iron/ms13/tile/navy,
+/turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "EE" = (
 /obj/effect/turf_decal/arrows/red{
@@ -1441,7 +1462,7 @@
 /area/ms13/town)
 "Gy" = (
 /obj/structure/ms13/storage/store,
-/obj/effect/spawner/lootdrop/ms13/medical/tier1,
+/obj/effect/spawner/lootdrop/ms13/medical/highrandom,
 /turf/open/floor/iron/ms13/tile/navy,
 /area/ms13/town)
 "GA" = (
@@ -1690,6 +1711,11 @@
 	},
 /turf/open/floor/wood/ms13/common,
 /area/ms13/ncr/building)
+"MN" = (
+/obj/structure/table/ms13/low_wall/wood,
+/obj/effect/spawner/lootdrop/ms13/medical/highrandom,
+/turf/open/floor/plating/ms13/ground/mountain,
+/area/ms13/town)
 "MS" = (
 /obj/structure/ms13/storage/large/shelf/rust{
 	dir = 8
@@ -1712,13 +1738,18 @@
 /obj/effect/spawner/lootdrop/ms13/medical/lowrandom,
 /turf/open/floor/wood/ms13/common,
 /area/ms13/ncr/building)
+"Nq" = (
+/obj/structure/ms13/storage/store,
+/obj/effect/spawner/lootdrop/ms13/medical/lowrandom,
+/turf/open/floor/iron/ms13/tile/navy,
+/area/ms13/town)
 "Nu" = (
 /obj/structure/toilet,
 /turf/open/floor/iron/ms13/tile/long,
 /area/ms13/ncr/building)
 "Nx" = (
 /obj/structure/ms13/storage/shelf/rust,
-/obj/effect/spawner/lootdrop/ms13/medical/lowrandom,
+/obj/effect/spawner/lootdrop/ms13/medical/highrandom,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "NE" = (
@@ -1834,7 +1865,7 @@
 /obj/structure/table/ms13/no_smooth/counter/wood/straight{
 	dir = 1
 	},
-/obj/effect/spawner/lootdrop/ms13/medical/tier1,
+/obj/effect/spawner/lootdrop/ms13/medical/highrandom,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "Qg" = (
@@ -1866,6 +1897,14 @@
 	},
 /turf/open/floor/iron/ms13/concrete/small,
 /area/ms13/underground/bos)
+"QF" = (
+/obj/structure/ms13/storage/shelf/rust{
+	dir = 1
+	},
+/obj/effect/spawner/lootdrop/ms13/medical/highrandom,
+/obj/effect/spawner/lootdrop/ms13/medical/highrandom,
+/turf/open/floor/iron/ms13/tile/large/white,
+/area/ms13/town)
 "QM" = (
 /obj/structure/toilet{
 	dir = 4
@@ -7505,7 +7544,7 @@ Eo
 Eo
 aX
 Fk
-Fk
+oZ
 Fk
 Fk
 Fk
@@ -7885,7 +7924,7 @@ Eo
 Eo
 Eo
 aX
-oZ
+nc
 Fk
 Fk
 Fk
@@ -8014,7 +8053,7 @@ Eo
 aX
 Fk
 Fk
-Fk
+oZ
 Fk
 Fk
 rE
@@ -17042,7 +17081,7 @@ lb
 lb
 lb
 Rb
-FW
+hx
 FW
 FW
 Rb
@@ -19156,7 +19195,7 @@ dn
 dn
 dQ
 SZ
-dQ
+MN
 dn
 dn
 dn
@@ -19195,7 +19234,7 @@ Re
 Rb
 lb
 lb
-YJ
+QF
 Rb
 tm
 tm
@@ -19440,7 +19479,7 @@ SD
 SD
 Wn
 Rb
-vU
+Nq
 Sy
 Sy
 Sy
@@ -19567,7 +19606,7 @@ IK
 SD
 Wn
 Rb
-Er
+vU
 Sy
 Sy
 zq
@@ -19830,7 +19869,7 @@ Sy
 Rb
 lb
 lb
-kj
+wU
 Rb
 tm
 tm
@@ -20818,7 +20857,7 @@ tm
 tm
 tm
 tm
-bd
+Iz
 cZ
 cZ
 cZ
@@ -21562,7 +21601,7 @@ Nx
 bJ
 ty
 ty
-vl
+Er
 fS
 bd
 dn
@@ -22148,7 +22187,7 @@ bq
 bq
 bd
 TS
-Am
+dv
 Oi
 bd
 wo

--- a/_maps/map_files/CombatArena/CombatArena_Faction.dmm
+++ b/_maps/map_files/CombatArena/CombatArena_Faction.dmm
@@ -39,7 +39,7 @@
 /obj/structure/table/ms13/metal/heavy,
 /obj/effect/spawner/lootdrop/ms13/medical/lowrandom,
 /obj/effect/spawner/lootdrop/ms13/medical/lowrandom,
-/obj/effect/spawner/lootdrop/ms13/medical/lowrandom,
+/obj/effect/spawner/lootdrop/ms13/medical/highrandom,
 /turf/open/floor/iron/ms13/concrete/small,
 /area/ms13/underground/bos)
 "aX" = (
@@ -129,11 +129,6 @@
 	},
 /turf/open/floor/wood/ms13/common,
 /area/ms13/ncr/building)
-"dv" = (
-/obj/structure/table/ms13/no_smooth/large/wood/square,
-/obj/effect/spawner/lootdrop/ms13/medical/highrandom,
-/turf/open/floor/wood/ms13/wide,
-/area/ms13/town)
 "dI" = (
 /obj/structure/stairs/south,
 /turf/open/floor/wood/ms13/wide,
@@ -244,13 +239,6 @@
 /obj/effect/spawner/lootdrop/ms13/medical/highrandom,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/raiders/building)
-"hx" = (
-/obj/structure/ms13/storage/store{
-	dir = 4
-	},
-/obj/effect/spawner/lootdrop/ms13/ammo/highrandom,
-/turf/open/floor/iron/ms13/tile/large/cafeteria,
-/area/ms13/town)
 "hC" = (
 /obj/structure/ms13/road_barrier/concrete,
 /turf/open/floor/plating/ms13/ground/snow,
@@ -740,6 +728,11 @@
 /obj/structure/closet/ms13/wall/firstaid,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/raiders/building)
+"sq" = (
+/obj/structure/table/ms13/no_smooth/large/wood/square,
+/obj/effect/spawner/lootdrop/ms13/medical/highrandom,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/town)
 "sr" = (
 /obj/structure/closet/crate/ms13/woodcrate,
 /obj/effect/spawner/lootdrop/ms13/ammo/lowrandom,
@@ -940,14 +933,6 @@
 	},
 /turf/open/floor/wood/ms13/carpet/shaggy,
 /area/ms13/town)
-"wU" = (
-/obj/structure/ms13/storage/shelf/rust{
-	dir = 1
-	},
-/obj/effect/spawner/lootdrop/ms13/medical/lowrandom,
-/obj/effect/spawner/lootdrop/ms13/medical/highrandom,
-/turf/open/floor/iron/ms13/tile/large/white,
-/area/ms13/town)
 "wW" = (
 /obj/effect/turf_decal/MS13/road/verticalline,
 /turf/open/floor/plating/ms13/ground/road,
@@ -1017,6 +1002,11 @@
 	},
 /turf/open/floor/plating/ms13/ground/snow,
 /area/ms13/snow/forest)
+"xZ" = (
+/obj/structure/table/ms13/low_wall/wood,
+/obj/effect/spawner/lootdrop/ms13/medical/highrandom,
+/turf/open/floor/plating/ms13/ground/mountain,
+/area/ms13/town)
 "yd" = (
 /obj/structure/table/ms13/metal/heavy,
 /obj/effect/spawner/lootdrop/ms13/medical/lowrandom,
@@ -1347,12 +1337,13 @@
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "Er" = (
-/obj/structure/table/ms13/no_smooth/counter/wood/end{
-	dir = 6
-	},
+/obj/structure/table/ms13/metal/heavy,
 /obj/effect/spawner/lootdrop/ms13/medical/lowrandom,
-/turf/open/floor/wood/ms13/wide,
-/area/ms13/town)
+/obj/effect/spawner/lootdrop/ms13/medical/lowrandom,
+/obj/effect/spawner/lootdrop/ms13/medical/lowrandom,
+/obj/effect/spawner/lootdrop/ms13/medical/highrandom,
+/turf/open/floor/iron/ms13/concrete/small,
+/area/ms13/underground/bos)
 "EE" = (
 /obj/effect/turf_decal/arrows/red{
 	dir = 8
@@ -1369,6 +1360,7 @@
 /obj/structure/ms13/storage/large/shelf/rust{
 	dir = 4
 	},
+/obj/effect/spawner/lootdrop/ms13/medical/highrandom,
 /turf/open/floor/iron/ms13/concrete/small,
 /area/ms13/underground/bos)
 "Fg" = (
@@ -1469,6 +1461,14 @@
 /obj/effect/landmark/start/ms13/head_paladin,
 /turf/open/floor/iron/ms13/metal/plate,
 /area/ms13/underground/bos)
+"GB" = (
+/obj/structure/ms13/storage/shelf/rust{
+	dir = 1
+	},
+/obj/effect/spawner/lootdrop/ms13/medical/highrandom,
+/obj/effect/spawner/lootdrop/ms13/medical/highrandom,
+/turf/open/floor/iron/ms13/tile/large/white,
+/area/ms13/town)
 "GT" = (
 /obj/structure/chair/ms13/metal/red,
 /turf/open/floor/wood/ms13/wide,
@@ -1531,6 +1531,14 @@
 /obj/structure/window/fulltile/ms13/glass,
 /turf/open/floor/wood/ms13/carpet/shaggy/blue,
 /area/ms13/town)
+"IA" = (
+/obj/structure/ms13/storage/shelf/rust{
+	dir = 1
+	},
+/obj/effect/spawner/lootdrop/ms13/medical/lowrandom,
+/obj/effect/spawner/lootdrop/ms13/medical/highrandom,
+/turf/open/floor/iron/ms13/tile/large/white,
+/area/ms13/town)
 "IB" = (
 /obj/structure/ms13/storage/shelf/rust{
 	dir = 1
@@ -1547,6 +1555,13 @@
 /obj/effect/landmark/observer_start,
 /turf/open/floor/plating/ms13/ground/road,
 /area/ms13)
+"IN" = (
+/obj/structure/table/ms13/no_smooth/counter/wood/end{
+	dir = 6
+	},
+/obj/effect/spawner/lootdrop/ms13/medical/lowrandom,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/town)
 "IO" = (
 /turf/closed/wall/ms13/concrete,
 /area/ms13/underground/mountain)
@@ -1620,6 +1635,13 @@
 /obj/item/clothing/suit/space/hardsuit/ms13/power_armor/t51,
 /turf/open/floor/iron/ms13/metal/warning,
 /area/ms13/underground/bos)
+"KR" = (
+/obj/structure/ms13/storage/store{
+	dir = 4
+	},
+/obj/effect/spawner/lootdrop/ms13/ammo/highrandom,
+/turf/open/floor/iron/ms13/tile/large/cafeteria,
+/area/ms13/town)
 "KX" = (
 /obj/structure/ms13/storage/shelf/rust{
 	dir = 8
@@ -1692,6 +1714,7 @@
 /area/ms13/town)
 "Mq" = (
 /obj/structure/table/ms13/no_smooth/large/wood/square,
+/obj/effect/spawner/lootdrop/ms13/medical/highrandom,
 /turf/open/floor/wood/ms13/common,
 /area/ms13/ncr/building)
 "Ms" = (
@@ -1711,11 +1734,6 @@
 	},
 /turf/open/floor/wood/ms13/common,
 /area/ms13/ncr/building)
-"MN" = (
-/obj/structure/table/ms13/low_wall/wood,
-/obj/effect/spawner/lootdrop/ms13/medical/highrandom,
-/turf/open/floor/plating/ms13/ground/mountain,
-/area/ms13/town)
 "MS" = (
 /obj/structure/ms13/storage/large/shelf/rust{
 	dir = 8
@@ -1738,11 +1756,10 @@
 /obj/effect/spawner/lootdrop/ms13/medical/lowrandom,
 /turf/open/floor/wood/ms13/common,
 /area/ms13/ncr/building)
-"Nq" = (
-/obj/structure/ms13/storage/store,
-/obj/effect/spawner/lootdrop/ms13/medical/lowrandom,
-/turf/open/floor/iron/ms13/tile/navy,
-/area/ms13/town)
+"Nl" = (
+/obj/effect/spawner/lootdrop/ms13/medical/highrandom,
+/turf/open/floor/wood/ms13/common,
+/area/ms13/ncr/building)
 "Nu" = (
 /obj/structure/toilet,
 /turf/open/floor/iron/ms13/tile/long,
@@ -1861,6 +1878,11 @@
 /obj/effect/spawner/lootdrop/ms13/gun/highrandom,
 /turf/open/floor/iron/ms13/tile/large/cafeteria,
 /area/ms13/town)
+"PF" = (
+/obj/structure/ms13/storage/store,
+/obj/effect/spawner/lootdrop/ms13/medical/lowrandom,
+/turf/open/floor/iron/ms13/tile/navy,
+/area/ms13/town)
 "PY" = (
 /obj/structure/table/ms13/no_smooth/counter/wood/straight{
 	dir = 1
@@ -1897,14 +1919,6 @@
 	},
 /turf/open/floor/iron/ms13/concrete/small,
 /area/ms13/underground/bos)
-"QF" = (
-/obj/structure/ms13/storage/shelf/rust{
-	dir = 1
-	},
-/obj/effect/spawner/lootdrop/ms13/medical/highrandom,
-/obj/effect/spawner/lootdrop/ms13/medical/highrandom,
-/turf/open/floor/iron/ms13/tile/large/white,
-/area/ms13/town)
 "QM" = (
 /obj/structure/toilet{
 	dir = 4
@@ -17081,7 +17095,7 @@ lb
 lb
 lb
 Rb
-hx
+KR
 FW
 FW
 Rb
@@ -17997,7 +18011,7 @@ wW
 wW
 Wn
 OP
-qd
+Nl
 qd
 qd
 OP
@@ -18274,7 +18288,7 @@ Eo
 sG
 yd
 xx
-aW
+Er
 sG
 EE
 Gn
@@ -19148,7 +19162,7 @@ qd
 LG
 LG
 LG
-qd
+Nl
 FJ
 OP
 dn
@@ -19195,7 +19209,7 @@ dn
 dn
 dQ
 SZ
-MN
+xZ
 dn
 dn
 dn
@@ -19234,7 +19248,7 @@ Re
 Rb
 lb
 lb
-QF
+GB
 Rb
 tm
 tm
@@ -19479,7 +19493,7 @@ SD
 SD
 Wn
 Rb
-Nq
+PF
 Sy
 Sy
 Sy
@@ -19869,7 +19883,7 @@ Sy
 Rb
 lb
 lb
-wU
+IA
 Rb
 tm
 tm
@@ -21542,29 +21556,29 @@ ZB
 ZB
 ZB
 ZB
-wo
-wo
-wo
-wo
-wo
-wo
-wo
-wo
-wo
-wo
-wo
-wo
-wo
-wo
-wo
-wo
-wo
-wo
-wo
-wo
-wo
-wo
-wo
+tm
+tm
+tm
+tm
+tm
+tm
+tm
+tm
+tm
+tm
+tm
+tm
+tm
+tm
+tm
+tm
+tm
+tm
+tm
+tm
+tm
+tm
+tm
 Eo
 Eo
 "}
@@ -21601,7 +21615,7 @@ Nx
 bJ
 ty
 ty
-Er
+IN
 fS
 bd
 dn
@@ -21667,31 +21681,31 @@ wo
 wo
 ZB
 ZB
-wo
-wo
-wo
-wo
-wo
-wo
-wo
-wo
-wo
-wo
-wo
-wo
-wo
-wo
-wo
-wo
-wo
-wo
-wo
-wo
-wo
-wo
-wo
-wo
-wo
+tm
+tm
+tm
+tm
+tm
+tm
+tm
+tm
+tm
+tm
+tm
+tm
+tm
+tm
+tm
+tm
+tm
+tm
+tm
+tm
+tm
+tm
+tm
+tm
+tm
 Eo
 Eo
 "}
@@ -21794,31 +21808,31 @@ wo
 wo
 wo
 wo
-wo
-wo
-wo
-wo
-wo
-wo
-wo
-wo
-wo
-wo
-wo
-wo
-wo
-wo
-wo
-wo
-wo
-wo
-wo
-wo
-wo
-wo
-wo
-wo
-wo
+tm
+tm
+tm
+tm
+tm
+tm
+tm
+tm
+tm
+tm
+tm
+tm
+tm
+tm
+tm
+tm
+tm
+tm
+tm
+tm
+tm
+tm
+tm
+tm
+tm
 Eo
 Eo
 "}
@@ -21917,7 +21931,7 @@ wo
 wo
 wo
 wo
-LL
+wo
 wo
 wo
 wo
@@ -22042,10 +22056,10 @@ tm
 wo
 wo
 wo
-LL
-LL
+wo
+wo
 gU
-LL
+wo
 wo
 wo
 bd
@@ -22168,7 +22182,7 @@ tm
 tm
 wo
 wo
-LL
+wo
 gU
 yM
 gU
@@ -22187,7 +22201,7 @@ bq
 bq
 bd
 TS
-dv
+sq
 Oi
 bd
 wo
@@ -22294,7 +22308,7 @@ dn
 tm
 tm
 wo
-LL
+wo
 gU
 yM
 iK
@@ -22427,7 +22441,7 @@ Hg
 iK
 iK
 yM
-LL
+dn
 wo
 bd
 Og
@@ -22554,7 +22568,7 @@ iK
 iK
 Hg
 gU
-LL
+dn
 tm
 bd
 bd
@@ -22571,14 +22585,14 @@ ty
 ty
 ty
 nj
-tm
-tm
-tm
-tm
-tm
-tm
-tm
-tm
+wo
+wo
+wo
+wo
+wo
+wo
+wo
+wo
 Eo
 Eo
 Eo
@@ -22680,8 +22694,8 @@ gU
 gU
 gU
 gU
-LL
-LL
+dn
+dn
 tm
 tm
 tm
@@ -22698,14 +22712,14 @@ ty
 ty
 la
 bd
-tm
-tm
-tm
-tm
-tm
-tm
-tm
-tm
+wo
+wo
+wo
+wo
+wo
+wo
+wo
+wo
 Eo
 Eo
 Eo
@@ -22805,10 +22819,10 @@ tm
 tm
 gU
 gU
-LL
-LL
-LL
-LL
+dn
+dn
+dn
+dn
 dn
 dn
 dn
@@ -22825,15 +22839,15 @@ pV
 pV
 pV
 bd
-dn
-tm
-tm
-tm
-tm
-tm
-tm
-tm
-tm
+wo
+wo
+wo
+wo
+wo
+wo
+wo
+wo
+wo
 Eo
 Eo
 Eo
@@ -22930,10 +22944,10 @@ ZB
 ZB
 tm
 tm
-LL
-LL
-LL
-LL
+dn
+dn
+dn
+dn
 dn
 dn
 dn
@@ -22952,15 +22966,15 @@ bd
 nj
 bd
 bd
-dn
-tm
-tm
-tm
-tm
-tm
-tm
-tm
-tm
+wo
+wo
+wo
+wo
+wo
+wo
+wo
+wo
+wo
 Eo
 Eo
 Eo

--- a/_maps/map_files/CombatArena/CombatArena_Faction.dmm
+++ b/_maps/map_files/CombatArena/CombatArena_Faction.dmm
@@ -4,6 +4,13 @@
 /obj/structure/bed/ms13/sleepingbag/red,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
+"aw" = (
+/obj/structure/table/ms13/no_smooth/counter/wood/end{
+	dir = 6
+	},
+/obj/effect/spawner/lootdrop/ms13/medical/lowrandom,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/town)
 "ax" = (
 /obj/structure/bed/ms13/mattress/dirty,
 /obj/effect/landmark/start/ms13/raider,
@@ -351,6 +358,13 @@
 /obj/machinery/door/unpowered/ms13/wood,
 /turf/open/floor/wood/ms13/carpet/shaggy/blue,
 /area/ms13/town)
+"ks" = (
+/obj/structure/ms13/storage/store{
+	dir = 4
+	},
+/obj/effect/spawner/lootdrop/ms13/ammo/highrandom,
+/turf/open/floor/iron/ms13/tile/large/cafeteria,
+/area/ms13/town)
 "kE" = (
 /obj/structure/filingcabinet/ms13/empty,
 /turf/open/floor/wood/ms13/wide,
@@ -524,6 +538,11 @@
 	},
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
+"op" = (
+/obj/structure/ms13/storage/store,
+/obj/effect/spawner/lootdrop/ms13/medical/lowrandom,
+/turf/open/floor/iron/ms13/tile/navy,
+/area/ms13/town)
 "ox" = (
 /obj/effect/spawner/lootdrop/ms13/medical/lowrandom,
 /obj/effect/spawner/lootdrop/ms13/medical/lowrandom,
@@ -652,6 +671,10 @@
 	},
 /turf/open/floor/iron/ms13/concrete,
 /area/ms13/town)
+"qM" = (
+/obj/effect/spawner/lootdrop/ms13/medical/highrandom,
+/turf/open/floor/wood/ms13/common,
+/area/ms13/ncr/building)
 "qR" = (
 /obj/machinery/door/unpowered/ms13/metal/alt,
 /turf/open/floor/iron/ms13/tile/long,
@@ -728,11 +751,6 @@
 /obj/structure/closet/ms13/wall/firstaid,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/raiders/building)
-"sq" = (
-/obj/structure/table/ms13/no_smooth/large/wood/square,
-/obj/effect/spawner/lootdrop/ms13/medical/highrandom,
-/turf/open/floor/wood/ms13/wide,
-/area/ms13/town)
 "sr" = (
 /obj/structure/closet/crate/ms13/woodcrate,
 /obj/effect/spawner/lootdrop/ms13/ammo/lowrandom,
@@ -827,6 +845,11 @@
 /obj/item/stock_parts/cell/ms13/mfc,
 /turf/open/floor/iron/ms13/concrete/small,
 /area/ms13/underground/bos)
+"tP" = (
+/obj/structure/table/ms13/low_wall/wood,
+/obj/effect/spawner/lootdrop/ms13/medical/highrandom,
+/turf/open/floor/plating/ms13/ground/mountain,
+/area/ms13/town)
 "uj" = (
 /obj/effect/landmark/start/ms13/scribe,
 /turf/open/floor/iron/ms13/concrete/small,
@@ -966,6 +989,14 @@
 	dir = 1
 	},
 /area/ms13/underground/bos)
+"xp" = (
+/obj/structure/ms13/storage/shelf/rust{
+	dir = 1
+	},
+/obj/effect/spawner/lootdrop/ms13/medical/lowrandom,
+/obj/effect/spawner/lootdrop/ms13/medical/highrandom,
+/turf/open/floor/iron/ms13/tile/large/white,
+/area/ms13/town)
 "xx" = (
 /obj/structure/table/ms13/metal/heavy,
 /obj/effect/spawner/lootdrop/ms13/medical/lowrandom,
@@ -1002,11 +1033,6 @@
 	},
 /turf/open/floor/plating/ms13/ground/snow,
 /area/ms13/snow/forest)
-"xZ" = (
-/obj/structure/table/ms13/low_wall/wood,
-/obj/effect/spawner/lootdrop/ms13/medical/highrandom,
-/turf/open/floor/plating/ms13/ground/mountain,
-/area/ms13/town)
 "yd" = (
 /obj/structure/table/ms13/metal/heavy,
 /obj/effect/spawner/lootdrop/ms13/medical/lowrandom,
@@ -1461,14 +1487,6 @@
 /obj/effect/landmark/start/ms13/head_paladin,
 /turf/open/floor/iron/ms13/metal/plate,
 /area/ms13/underground/bos)
-"GB" = (
-/obj/structure/ms13/storage/shelf/rust{
-	dir = 1
-	},
-/obj/effect/spawner/lootdrop/ms13/medical/highrandom,
-/obj/effect/spawner/lootdrop/ms13/medical/highrandom,
-/turf/open/floor/iron/ms13/tile/large/white,
-/area/ms13/town)
 "GT" = (
 /obj/structure/chair/ms13/metal/red,
 /turf/open/floor/wood/ms13/wide,
@@ -1531,14 +1549,6 @@
 /obj/structure/window/fulltile/ms13/glass,
 /turf/open/floor/wood/ms13/carpet/shaggy/blue,
 /area/ms13/town)
-"IA" = (
-/obj/structure/ms13/storage/shelf/rust{
-	dir = 1
-	},
-/obj/effect/spawner/lootdrop/ms13/medical/lowrandom,
-/obj/effect/spawner/lootdrop/ms13/medical/highrandom,
-/turf/open/floor/iron/ms13/tile/large/white,
-/area/ms13/town)
 "IB" = (
 /obj/structure/ms13/storage/shelf/rust{
 	dir = 1
@@ -1555,13 +1565,6 @@
 /obj/effect/landmark/observer_start,
 /turf/open/floor/plating/ms13/ground/road,
 /area/ms13)
-"IN" = (
-/obj/structure/table/ms13/no_smooth/counter/wood/end{
-	dir = 6
-	},
-/obj/effect/spawner/lootdrop/ms13/medical/lowrandom,
-/turf/open/floor/wood/ms13/wide,
-/area/ms13/town)
 "IO" = (
 /turf/closed/wall/ms13/concrete,
 /area/ms13/underground/mountain)
@@ -1635,13 +1638,6 @@
 /obj/item/clothing/suit/space/hardsuit/ms13/power_armor/t51,
 /turf/open/floor/iron/ms13/metal/warning,
 /area/ms13/underground/bos)
-"KR" = (
-/obj/structure/ms13/storage/store{
-	dir = 4
-	},
-/obj/effect/spawner/lootdrop/ms13/ammo/highrandom,
-/turf/open/floor/iron/ms13/tile/large/cafeteria,
-/area/ms13/town)
 "KX" = (
 /obj/structure/ms13/storage/shelf/rust{
 	dir = 8
@@ -1679,6 +1675,14 @@
 "LG" = (
 /turf/open/floor/wood/ms13/carpet/shaggy,
 /area/ms13/ncr/building)
+"LI" = (
+/obj/structure/ms13/storage/shelf/rust{
+	dir = 1
+	},
+/obj/effect/spawner/lootdrop/ms13/medical/highrandom,
+/obj/effect/spawner/lootdrop/ms13/medical/highrandom,
+/turf/open/floor/iron/ms13/tile/large/white,
+/area/ms13/town)
 "LL" = (
 /turf/open/floor/plating/ms13/ground/snow,
 /area/ms13)
@@ -1756,10 +1760,6 @@
 /obj/effect/spawner/lootdrop/ms13/medical/lowrandom,
 /turf/open/floor/wood/ms13/common,
 /area/ms13/ncr/building)
-"Nl" = (
-/obj/effect/spawner/lootdrop/ms13/medical/highrandom,
-/turf/open/floor/wood/ms13/common,
-/area/ms13/ncr/building)
 "Nu" = (
 /obj/structure/toilet,
 /turf/open/floor/iron/ms13/tile/long,
@@ -1790,6 +1790,11 @@
 "Ob" = (
 /turf/open/ms13/water/shallow,
 /area/ms13)
+"Od" = (
+/obj/structure/table/ms13/no_smooth/large/wood/square,
+/obj/effect/spawner/lootdrop/ms13/medical/highrandom,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/town)
 "Og" = (
 /obj/structure/bed/ms13/bedframe/wood,
 /obj/structure/bed/ms13/mattress/old,
@@ -1877,11 +1882,6 @@
 	},
 /obj/effect/spawner/lootdrop/ms13/gun/highrandom,
 /turf/open/floor/iron/ms13/tile/large/cafeteria,
-/area/ms13/town)
-"PF" = (
-/obj/structure/ms13/storage/store,
-/obj/effect/spawner/lootdrop/ms13/medical/lowrandom,
-/turf/open/floor/iron/ms13/tile/navy,
 /area/ms13/town)
 "PY" = (
 /obj/structure/table/ms13/no_smooth/counter/wood/straight{
@@ -17095,7 +17095,7 @@ lb
 lb
 lb
 Rb
-KR
+ks
 FW
 FW
 Rb
@@ -18011,7 +18011,7 @@ wW
 wW
 Wn
 OP
-Nl
+qM
 qd
 qd
 OP
@@ -19162,7 +19162,7 @@ qd
 LG
 LG
 LG
-Nl
+qM
 FJ
 OP
 dn
@@ -19209,7 +19209,7 @@ dn
 dn
 dQ
 SZ
-xZ
+tP
 dn
 dn
 dn
@@ -19248,7 +19248,7 @@ Re
 Rb
 lb
 lb
-GB
+LI
 Rb
 tm
 tm
@@ -19493,7 +19493,7 @@ SD
 SD
 Wn
 Rb
-PF
+op
 Sy
 Sy
 Sy
@@ -19883,7 +19883,7 @@ Sy
 Rb
 lb
 lb
-IA
+xp
 Rb
 tm
 tm
@@ -20871,12 +20871,12 @@ tm
 tm
 tm
 tm
-Iz
+bd
 cZ
 cZ
 cZ
 cZ
-Iz
+bd
 dn
 dn
 dn
@@ -21127,8 +21127,8 @@ tm
 tm
 bd
 bd
-bd
-bd
+Iz
+Iz
 bd
 bd
 dn
@@ -21615,7 +21615,7 @@ Nx
 bJ
 ty
 ty
-IN
+aw
 fS
 bd
 dn
@@ -22201,7 +22201,7 @@ bq
 bq
 bd
 TS
-sq
+Od
 Oi
 bd
 wo

--- a/mojave/structures/table.dm
+++ b/mojave/structures/table.dm
@@ -131,7 +131,7 @@
 /obj/structure/table/ms13/no_smooth/metal/Initialize(mapload)
 	. = ..()
 	if(prob(35))
-		icon_state = "(initial[icon_state]-[rand(1,2)]"
+		icon_state = "[initial(icon_state)]-[rand(1,2)]"
 
 // Large tables //
 


### PR DESCRIPTION
Does as the title says. Pretty simple PR. I'd show the map file but you wouldn't really see the difference. Most of it is just upgrading spawners to a higher tier. Namely medical items. Round metal tables had a messed up init icon swap. I fixed it.