### PR TITLE
Post 9/19 combat test tweaks

### DIFF
--- a/mojave/code/modules/clothing/spacesuits/power_armor.dm
+++ b/mojave/code/modules/clothing/spacesuits/power_armor.dm
@@ -6,7 +6,7 @@
 	icon_state = "null"
 	worn_icon = 'mojave/icons/mob/large-worn-icons/32x48/head.dmi'
 	worn_icon_state = "null"
-	strip_delay = 200
+	strip_delay = 15 SECONDS
 	max_integrity = 500
 	resistance_flags = FIRE_PROOF | ACID_PROOF
 	armor = list(MELEE = 80, BULLET = 80, LASER = 80, ENERGY = 80, BOMB = 80, BIO = 100, RAD = 100, FIRE = 100, ACID = 100, WOUND = 25) //Make the armor the same as the hardsuit one for consistancy
@@ -32,7 +32,7 @@
 	allowed = list(/obj/item/storage/box/matches,/obj/item/lighter,/obj/item/clothing/mask/cigarette,/obj/item/storage/fancy/cigarettes,/obj/item/flashlight,/obj/item/gun,/obj/item/ammo_box,/obj/item/ammo_casing)
 	density = TRUE //It's a suit of armor man
 	anchored = TRUE
-	strip_delay = 200
+	strip_delay = 15 SECONDS
 	max_integrity = 500
 	resistance_flags = FIRE_PROOF | ACID_PROOF
 	armor = list(MELEE = 80, BULLET = 80, LASER = 80, ENERGY = 80, BOMB = 80, BIO = 100, RAD = 100, FIRE = 100, ACID = 100, WOUND = 25) //Make the armor the same as the hardsuit one for consistancy
@@ -131,10 +131,10 @@
 	else
 		if(user.wear_suit == src)
 			to_chat(user, "You begin exiting the [src].")
-			if(do_after(user, 6 SECONDS, target = user))
+			if(do_after(user, 8 SECONDS, target = user))
 				if(get_dist(user, src) > 1) //Anti-afterimage check
 					return FALSE
-			if(do_after(user, 6 SECONDS, target = user) && density != TRUE)
+			if(do_after(user, 8 SECONDS, target = user) && density != TRUE)
 				GetOutside(user)
 				return TRUE
 			return FALSE
@@ -142,7 +142,7 @@
 	if(!CheckEquippedClothing(user) || get_dist(user, src) > 1)
 		return FALSE
 	to_chat(user, "You begin entering the [src].")
-	if(do_after(user, 6 SECONDS, target = user) && CheckEquippedClothing(user) && density == TRUE)
+	if(do_after(user, 8 SECONDS, target = user) && CheckEquippedClothing(user) && density == TRUE)
 		GetInside(user)
 		return TRUE
 	return FALSE

--- a/mojave/effects/spawners/lootdrop/medicalloot.dm
+++ b/mojave/effects/spawners/lootdrop/medicalloot.dm
@@ -46,7 +46,6 @@
 	lootcount = 1
 
 	loot = list(
-			/obj/effect/spawner/lootdrop/ms13/medical/tier1 = 10,
-			/obj/effect/spawner/lootdrop/ms13/medical/tier2 = 40,
-			/obj/effect/spawner/lootdrop/ms13/medical/tier3 = 50
+			/obj/effect/spawner/lootdrop/ms13/medical/tier2 = 55,
+			/obj/effect/spawner/lootdrop/ms13/medical/tier3 = 45
 			)

--- a/mojave/items/clothing/suits/armor.dm
+++ b/mojave/items/clothing/suits/armor.dm
@@ -189,11 +189,12 @@
 
 /obj/item/clothing/suit/armor/ms13/assassin
 	name = "assassin armor"
-	desc = "A prototype pre-war lightweight suit of armor that is so light and optimized that it can serve to speed the wearer up."
+	desc = "A prototype pre-war lightweight suit of armor that is so light and optimized that it can serve to speed the wearer up and mask the sound of footsteps."
 	icon_state = "assassin"
 	inhand_icon_state = "assassin"
 	armor = list("melee" = 35, "bullet" = 30, "laser" = 20, "energy" = 15, "bomb" = 20, "bio" = 15, "rad" = 15, "fire" = 15, "acid" = 15, "wound" = 5)
 	slowdown = -0.3
+	clothing_traits = list(TRAIT_SILENT_FOOTSTEPS)
 
 /obj/item/clothing/suit/armor/ms13/tesla
 	name = "tesla armor"

--- a/mojave/items/guns/projectiles/energy-proj.dm
+++ b/mojave/items/guns/projectiles/energy-proj.dm
@@ -5,7 +5,8 @@
 	var/damage_constant = 1
 	damage = 0
 	armour_penetration = 0
-	wound_bonus = 0
+	wound_bonus = -5
+	bare_wound_bonus = 5
 
 /obj/projectile/beam/ms13/laser
 	name = "laser beam"
@@ -34,7 +35,7 @@
 
 /obj/projectile/beam/ms13/laser/sniper
 	name = "laser beam"
-	range = 40
+	range = 36
 
 /obj/projectile/beam/ms13/laser/pistol
 	name = "laser beam"

--- a/mojave/items/guns/weapons/ballistic/revolver.dm
+++ b/mojave/items/guns/weapons/ballistic/revolver.dm
@@ -6,6 +6,7 @@
 	inhand_icon_state = "caravan"
 	force = 20
 	fire_delay = 0.4 SECONDS
+	slot_flags = ITEM_SLOT_BACK
 	recoil = 1.5
 	slowdown = 0.75
 	mag_type = /obj/item/ammo_box/magazine/internal/shot/ms13/caravan
@@ -20,17 +21,19 @@
 	inhand_icon_state = "sawedoff"
 	force = 15
 	fire_delay = 0.5 SECONDS
+	slot_flags = ITEM_SLOT_BELT
 	slowdown = 0.5
 	w_class = WEIGHT_CLASS_NORMAL
 	weapon_weight = WEAPON_MEDIUM
 
 /obj/item/gun/ballistic/revolver/ms13/single
 	name = "single shotgun"
-	desc = "A very cheap and very common shotgun with only a single round, better make it count."
+	desc = "A very cheap and very common lightweight shotgun with only a single round, better make it count."
 	icon_state = "singleshot"
 	inhand_icon_state = "singleshot"
 	force = 20
 	fire_delay = 0.4 SECONDS
+	slot_flags = ITEM_SLOT_BACK | ITEM_SLOT_BELT
 	recoil = 1.5
 	slowdown = 0.75
 	mag_type = /obj/item/ammo_box/magazine/internal/shot/ms13/single
@@ -80,6 +83,7 @@
 	inhand_icon_state = "revrifle"
 	w_class = WEIGHT_CLASS_BULKY
 	weapon_weight = WEAPON_HEAVY
+	slot_flags = ITEM_SLOT_BACK
 	fire_delay = 0.65 SECONDS
 	extra_damage = 45
 	spread = 5

--- a/mojave/items/medical/stack_medical.dm
+++ b/mojave/items/medical/stack_medical.dm
@@ -8,7 +8,7 @@
     icon_state = "suture"
     max_amount = 12
     amount = 12
-    self_delay = 4 SECONDS
+    self_delay = 3.5 SECONDS
     other_delay = 2 SECONDS
     heal_brute = 8
     stop_bleeding = 0.65
@@ -40,7 +40,7 @@
     self_delay = 2.5 SECONDS
     other_delay = 1.5 SECONDS
     heal_burn = 8
-    flesh_regeneration = 3
+    flesh_regeneration = 3.5
     sanitization = 1.25
     gender = NEUTER //So examine text says "This is a bottle of ointment" instead of "These are some bottle of ointment"
     merge_type = /obj/item/stack/medical/ointment/ms13
@@ -58,7 +58,7 @@
     amount = 10
     max_amount = 10
     heal_burn = 4
-    flesh_regeneration = 1.5
+    flesh_regeneration = 2
     sanitization = 0.5
     gender = PLURAL
     merge_type = /obj/item/stack/medical/ointment/ms13/aloe
@@ -69,7 +69,7 @@
     icon_state = "burncream"
     inhand_icon_state = "burncream"
     heal_burn = 6
-    flesh_regeneration = 2
+    flesh_regeneration = 2.75
     sanitization = 0.75
     gender = PLURAL
     merge_type = /obj/item/stack/medical/ointment/ms13/cream
@@ -86,12 +86,12 @@
     righthand_file = 'mojave/icons/mob/inhands/items_righthand.dmi'
     icon_state = "bandage"
     inhand_icon_state = "bandage"
-    self_delay = 3 SECONDS
+    self_delay = 2.5 SECONDS
     other_delay = 1.5 SECONDS
     max_amount = 12
     amount = 12
-    absorption_rate = 0.15
-    absorption_capacity = 4.25
+    absorption_rate = 0.13
+    absorption_capacity = 4.75
     splint_factor = 0.5
     merge_type = /obj/item/stack/medical/gauze/ms13
 
@@ -111,6 +111,6 @@
     icon_state = "bandage_m"
     inhand_icon_state = "bandage_m"
     absorption_rate = 0.2
-    absorption_capacity = 6
-    splint_factor = 0.4 //Lower = better
+    absorption_capacity = 6.5
+    splint_factor = 0.35 //Lower = better
     merge_type = /obj/item/stack/medical/gauze/ms13/military

--- a/mojave/items/medical/stack_medical.dm
+++ b/mojave/items/medical/stack_medical.dm
@@ -91,7 +91,7 @@
     max_amount = 12
     amount = 12
     absorption_rate = 0.13
-    absorption_capacity = 4.75
+    absorption_capacity = 4.25
     splint_factor = 0.5
     merge_type = /obj/item/stack/medical/gauze/ms13
 
@@ -111,6 +111,6 @@
     icon_state = "bandage_m"
     inhand_icon_state = "bandage_m"
     absorption_rate = 0.2
-    absorption_capacity = 6.5
-    splint_factor = 0.35 //Lower = better
+    absorption_capacity = 6
+    splint_factor = 0.4 //Lower = better
     merge_type = /obj/item/stack/medical/gauze/ms13/military

--- a/mojave/items/medical/stimpak.dm
+++ b/mojave/items/medical/stimpak.dm
@@ -23,7 +23,7 @@
 	AddElement(/datum/element/inworld_sprite, 'mojave/icons/objects/medical/medical_inventory.dmi')
 
 /obj/item/reagent_containers/hypospray/medipen/ms13/attack(mob/living/M, mob/user)
-	if(do_after(M, 1 SECONDS))
+	if(do_after(M, 0.75 SECONDS))
 		inject(M, user)
 
 /obj/item/reagent_containers/hypospray/medipen/ms13/inject(mob/living/M, mob/user)
@@ -36,7 +36,7 @@
 		return
 	if(!user.canUseTopic(src, BE_CLOSE, FALSE, NO_TK, FALSE, FLOOR_OKAY))
 		return
-	if(do_after(user, 1 SECONDS))
+	if(do_after(user, 0.75 SECONDS))
 		inject(user)
 		update_icon_state()
 		playsound(src.loc, 'mojave/sound/ms13items/stimpak_inject.ogg', 40, FALSE)

--- a/mojave/items/storage/storage.dm
+++ b/mojave/items/storage/storage.dm
@@ -20,7 +20,7 @@
 
 /obj/item/storage/firstaid/ms13/regular/PopulateContents()
 	new /obj/item/stack/medical/gauze/ms13(src)
-	new /obj/item/stack/medical/suture/ms13/eight(src)
+	new /obj/item/stack/medical/suture/ms13(src)
 	new /obj/item/stack/medical/ointment/ms13/cream(src)
 
 /obj/item/storage/firstaid/ms13/quality


### PR DESCRIPTION
## About The Pull Request

Basically the title. Included is a reduction in PA strip time and an increase in PA equip time, slight bug fixes for weapon storage, some buffs for medical items in the form of self delay slight reductions and flesh regen on burn items, and a wound bonus nerf for lasers since they seemed a bit strong in the tests.

## Why It's Good For The Game

Balance and listening to feedback and making adjustments based on observations is good.