### PR TITLE
Remove the sleep in Destroy() for crosses

### DIFF
--- a/mojave/structures/cross.dm
+++ b/mojave/structures/cross.dm
@@ -81,7 +81,7 @@
 	M.adjustBruteLoss(15)
 	src.visible_message(text("<span class='danger'>[M] falls free of [src]!</span>"))
 	unbuckle_mob(M,force=1)
-	M.emote("collapse")
+	//M.emote("collapse")
 	M.overlays -= image('mojave/icons/structure/cross.dmi', "lashing")
 
 /obj/structure/kitchenspike/ms13/cross/Destroy()

--- a/mojave/structures/cross.dm
+++ b/mojave/structures/cross.dm
@@ -81,7 +81,6 @@
 	M.adjustBruteLoss(15)
 	src.visible_message(text("<span class='danger'>[M] falls free of [src]!</span>"))
 	unbuckle_mob(M,force=1)
-	//M.emote("collapse")
 	M.overlays -= image('mojave/icons/structure/cross.dmi', "lashing")
 
 /obj/structure/kitchenspike/ms13/cross/Destroy()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Due to recent changes in tgstation linting, `sleep` is now checked for in `Destroy()` procs.  In this case, while destroying a cross, a certain emote is called, but apparently emotes have a sleep, so I'll be removing this line for now.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Sleep when creating/destroying objects is bad.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
