### PR TITLE
Changes fertilizer string to typepath

### DIFF
--- a/mojave/flora/wasteflora.dm
+++ b/mojave/flora/wasteflora.dm
@@ -311,10 +311,10 @@
 /obj/structure/reagent_dispensers/compostbin/proc/process_compost()
 	for(var/obj/item/C in contents)
 		if(istype(C, /obj/item/seeds))
-			reagents.add_reagent("fertilizer", seed_value)
+			reagents.add_reagent(/datum/reagent/plantnutriment/ms13/fertilizer, seed_value)
 			qdel(C)
 		else if(istype(C, /obj/item/food))
-			reagents.add_reagent("fertilizer", food_value)
+			reagents.add_reagent(/datum/reagent/plantnutriment/ms13/fertilizer, food_value)
 			qdel(C)
 		else //Not sure how we got here, but there's only one reasonable thing to do.
 			qdel(C)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes with calling `add_reagent` with a string instead of a typepath.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Dynamic typing strikes again.  Since inputs in `add_reagent` are not checked, we can pass a string instead of the intended reagent typepath.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
