### PR TITLE
Fix for water runtime due to null value

### DIFF
--- a/mojave/turfs/plating.dm
+++ b/mojave/turfs/plating.dm
@@ -555,9 +555,9 @@
 	layer = TURF_LAYER_WATER_BASE
 	slowdown = 0.5
 	var/next_splash = 1
-	var/atom/watereffect
-	var/atom/watertop
-	var/depth
+	var/atom/watereffect = /obj/effect/overlay/ms13/water/medium
+	var/atom/watertop = /obj/effect/overlay/ms13/water/top/medium
+	var/depth = 0
 
 /turf/open/ms13/water/deep
 	name = "deep water"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
When setting the water overlays, the base class does not have any values set.  So the proc reads a null value.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It's a base class, but tests that run the initialization of all objects can catch these issues.  While not important for practical purposes, it's best to set some sort of default value.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

