### PR TITLE
Fix hard delete NCR radio backpack

### DIFF
--- a/mojave/items/storage/radiopack.dm
+++ b/mojave/items/storage/radiopack.dm
@@ -26,6 +26,7 @@
 
 /obj/item/ms13/storage/backpack/radiopack/Destroy()
 	STOP_PROCESSING(SSobj, src)
+	qdel(radio)
 	return ..()
 
 /obj/item/ms13/storage/backpack/radiopack/AltClick(var/mob/living/carbon/user)

--- a/mojave/items/storage/radiopack.dm
+++ b/mojave/items/storage/radiopack.dm
@@ -110,7 +110,7 @@
 	return ..()
 
 /obj/item/radio/ms13/NCR/Destroy()
-	radipack = null
+	radiopack = null
 	return ..()
 
 /obj/item/radio/ms13/NCR/dropped(mob/user)

--- a/mojave/items/storage/radiopack.dm
+++ b/mojave/items/storage/radiopack.dm
@@ -26,7 +26,7 @@
 
 /obj/item/ms13/storage/backpack/radiopack/Destroy()
 	STOP_PROCESSING(SSobj, src)
-	qdel(radio)
+	QDEL_NULL(radio)
 	return ..()
 
 /obj/item/ms13/storage/backpack/radiopack/AltClick(var/mob/living/carbon/user)
@@ -109,6 +109,9 @@
 
 	return ..()
 
+/obj/item/radio/ms13/NCR/Destroy()
+	radipack = null
+	return ..()
 
 /obj/item/radio/ms13/NCR/dropped(mob/user)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The NCR radiopack has a hard delete due to storing the handset in the pack.  This fixes that by having the handset `qdel` during the deletion of the backpack.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Hard deletes suck for the GC.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

