### PR TITLE
Remove title screen assertion

### DIFF
--- a/code/controllers/subsystem/title.dm
+++ b/code/controllers/subsystem/title.dm
@@ -33,7 +33,8 @@ SUBSYSTEM_DEF(title)
 	if(!file_path)
 		file_path = "mojave/icons/default_title.dmi" //MOJAVE EDIT CHANGE - file_path = "icons/runtime/default_title.dmi"
 
-	ASSERT(fexists(file_path))
+	// MOJAVE EDIT REMOVE - non-working file assertion
+	// ASSERT(fexists(file_path))
 
 	icon = new(fcopy_rsc(file_path))
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removed an assertion causing integration test failures.  The file clearly exists, and is even loaded properly as an `rsc`, so it's not clear what's causing the issue.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Assertion is claiming something doesn't exist when it works, and I can't see inside `fexists` to see what's happening.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

