### PR TITLE
Chem Reagentening

### DIFF
--- a/mojave/code/modules/reagents/addictions.dm
+++ b/mojave/code/modules/reagents/addictions.dm
@@ -8,7 +8,7 @@
 	///Lower threshold, when you stop being addicted
 	addiction_loss_threshold = 50
 	///Rates at which you lose addiction (in units/second) if you are not on the drug at that time per stage
-	addiction_loss_per_stage = list(0.5, 0.5, 1, 1.5)
+	addiction_loss_per_stage = list(0.5, 0.5, 1, 1)
 
 // Jet //
 
@@ -192,6 +192,10 @@
 		to_chat(M, span_warning("You feel angry, and you don't know why..."))
 	..()
 
+/datum/addiction/ms13/psycho/withdrawal_enters_stage_2(mob/living/carbon/M)
+	. = ..()
+	to_chat(M, span_warning("You feel like something changed- But you can't figure out what. This angers you!"))
+
 /datum/addiction/ms13/psycho/withdrawal_stage_2_process(mob/living/carbon/M, delta_time)
 	. = ..()
 	M.Jitter(10)
@@ -200,26 +204,70 @@
 		to_chat(M, span_warning("[pick("You are filled with anger.", "Is the room spinning...? This is PISSING YOU OFF!", "You REALLY want to PUNCH someone right now.")]"))
 	..()
 
-/datum/addiction/ms13/psycho/withdrawal_enters_stage_2(mob/living/carbon/M)
-	. = ..()
-	to_chat(M, span_warning("You feel like something changed- But you can't figure out what. This angers you!"))
-
 /datum/addiction/ms13/psycho/withdrawal_enters_stage_3(mob/living/carbon/M)
 	. = ..()
 	to_chat(M, span_boldwarning("Everything is just- Wrong! What the HELL IS GOING ON?"))
 
 /datum/addiction/ms13/psycho/withdrawal_stage_3_process(mob/living/carbon/M, delta_time)
 	. = ..()
-	M.adjustOrganLoss(ORGAN_SLOT_BRAIN, 0.5)
+	M.adjustOrganLoss(ORGAN_SLOT_BRAIN, 0.25)
 	M.Jitter(5)
 	M.Dizzy(10)
 	if(prob(20))
 		to_chat(M, span_warning("[pick("Your head burns... Your heart aches... You are FURIOUS!", "You feel a sickening nausea run over you- You're filled with RAGE!", "Why is EVERYONE so adamant on PISSING YOU OFF at a time like this?!")]"))
 	..()
 
-// Smooch //
+// Overdrive //
 
-/datum/addiction/ms13/smooch/withdrawal_stage_1_process(mob/living/carbon/M)
+/datum/addiction/ms13/overdrive
+	name = "overdrive"
+	withdrawal_stage_messages = list("", "", "")
+
+/datum/addiction/ms13/overdrive/withdrawal_enters_stage_1(mob/living/carbon/M)
+	. = ..()
+	to_chat(M, span_warning("Your eye twitches slightly."))
+
+/datum/addiction/ms13/overdrive/withdrawal_stage_1_process(mob/living/carbon/M, delta_time)
+	. = ..()
+	M.Jitter(15)
+	if(prob(20))
+		to_chat(M, span_warning("You begin to shake in fury."))
+	..()
+
+/datum/addiction/ms13/overdrive/withdrawal_enters_stage_2(mob/living/carbon/M)
+	. = ..()
+	to_chat(M, span_warning("You begin to shake with fury."))
+
+/datum/addiction/ms13/overdrive/withdrawal_stage_2_process(mob/living/carbon/M, delta_time)
+	. = ..()
+	M.Jitter(25)
+	M.Dizzy(10)
+	if(prob(20))
+		to_chat(M, span_warning("[pick("You have trouble thinking clearly through your rage", "You're REALLY pissed off right now.")]"))
+	..()
+
+
+/datum/addiction/ms13/overdrive/withdrawal_enters_stage_3(mob/living/carbon/M)
+	. = ..()
+	to_chat(M, span_boldwarning("You're so mad- You could just KILL someone!"))
+
+/datum/addiction/ms13/overdrive/withdrawal_stage_3_process(mob/living/carbon/M, delta_time)
+	. = ..()
+	M.adjustOrganLoss(ORGAN_SLOT_BRAIN, 1)
+	M.Jitter(45)
+	M.Dizzy(10)
+	M.adjustStaminaLoss(2.5)
+	if(prob(20))
+		to_chat(M, span_warning("[pick("You feel so tired- and it's REALLY pissing you off!", "Your arms ache heavily.", "Your whole body throbs with fatigue.")]"))
+	..()
+
+// Day Tripper //
+
+/datum/addiction/ms13/daytripper
+	name = "day tripper"
+	withdrawal_stage_messages = list("", "", "")
+
+/datum/addiction/ms13/daytripper/withdrawal_stage_1_process(mob/living/carbon/M)
 	. = ..()
 	M.hallucination += 20
 	if(!HAS_TRAIT(M, TRAIT_IMMOBILIZED) && !isspaceturf(M.loc) && isturf(M.loc))
@@ -230,7 +278,7 @@
 	if(prob(30))
 		M.emote(pick("twitch","drool","moan"))
 
-/datum/addiction/ms13/smooch/withdrawal_stage_2_process(mob/living/carbon/M)
+/datum/addiction/ms13/daytripper/withdrawal_stage_2_process(mob/living/carbon/M)
 	. = ..()
 	M.hallucination += 30
 	if(!HAS_TRAIT(M, TRAIT_IMMOBILIZED) && !isspaceturf(M.loc) && isturf(M.loc))
@@ -241,7 +289,7 @@
 	if(prob(40))
 		M.emote(pick("twitch","drool","moan"))
 
-/datum/addiction/ms13/smooch/withdrawal_stage_3_process(mob/living/carbon/M)
+/datum/addiction/ms13/daytripper/withdrawal_stage_3_process(mob/living/carbon/M)
 	. = ..()
 	M.hallucination += 30
 	if(!HAS_TRAIT(M, TRAIT_IMMOBILIZED) && !isspaceturf(M.loc) && isturf(M.loc))

--- a/mojave/code/modules/reagents/addictions.dm
+++ b/mojave/code/modules/reagents/addictions.dm
@@ -1,0 +1,232 @@
+/*datum/addiction/opiods
+	name = "opiod"
+	withdrawal_stage_messages = list("I feel aches in my bodies..", "I need some pain relief...", "It aches all over...I need some opiods!")
+
+/datum/addiction/ms13/opiods/withdrawal_stage_1_process(mob/living/carbon/affected_carbon, delta_time)
+	. = ..()
+	if(DT_PROB(10, delta_time))
+		affected_carbon.emote("yawn")
+
+/datum/addiction/ms13/opiods/withdrawal_enters_stage_2(mob/living/carbon/affected_carbon)
+	. = ..()
+	affected_carbon.apply_status_effect(STATUS_EFFECT_HIGHBLOODPRESSURE)
+
+/datum/addiction/ms13/opiods/withdrawal_stage_3_process(mob/living/carbon/affected_carbon, delta_time)
+	. = ..()
+	if(affected_carbon.disgust < DISGUST_LEVEL_DISGUSTED && DT_PROB(7.5, delta_time))
+		affected_carbon.adjust_disgust(12.5 * delta_time)
+
+
+/datum/addiction/ms13/opiods/end_withdrawal(mob/living/carbon/affected_carbon)
+	. = ..()
+	affected_carbon.remove_status_effect(STATUS_EFFECT_HIGHBLOODPRESSURE)
+	affected_carbon.set_disgust(affected_carbon.disgust * 0.5) //half their disgust to help
+*/
+/////=======================/////
+
+// Jet //
+
+/datum/addiction/ms13/jet
+	name = "jet"
+	withdrawal_stage_messages = list("", "", "")
+
+/datum/addiction/jet/withdrawal_enters_stage_1(mob/living/carbon/affected_carbon)
+	. = ..()
+	to_chat(affected_carbon, span_holoparasite("[pick("Need some jet man...", "It's a good time for some jet.")]"))
+
+/datum/addiction/ms13/jet/withdrawal_stage_1_process(mob/living/carbon/affected_carbon, delta_time)
+	. = ..()
+	affected_carbon.Dizzy(5)
+	if(prob(30))
+		affected_carbon.emote(pick("twitch", "groan"))
+
+/datum/addiction/jet/withdrawal_enters_stage_2(mob/living/carbon/affected_carbon)
+	. = ..()
+	to_chat(affected_carbon, span_holoparasite("[pick("Could really use some jet right now.", "Come on... Let's go get some jet.")]"))
+
+/datum/addiction/ms13/jet/withdrawal_stage_2_process(mob/living/carbon/affected_carbon, delta_time)
+	. = ..()
+	affected_carbon.set_disgust(60)
+	affected_carbon.Dizzy(10)
+	if(prob(40))
+		affected_carbon.emote(pick("twitch", "groan", "moan"))
+
+/datum/addiction/jet/withdrawal_enters_stage_3(mob/living/carbon/affected_carbon)
+	. = ..()
+	to_chat(affected_carbon, span_holoparasite("[pick("I really need some jet- NOW!", "I'm FALLING APART!")]"))
+
+/datum/addiction/ms13/jet/withdrawal_stage_3_process(mob/living/carbon/affected_carbon, delta_time)
+	. = ..()
+	if(!HAS_TRAIT(affected_carbon, TRAIT_IMMOBILIZED) && !isspaceturf(affected_carbon.loc) && isturf(affected_carbon.loc))
+		step(affected_carbon, pick(GLOB.cardinals))
+	affected_carbon.adjustToxLoss(1, 0)
+	affected_carbon.set_disgust(100)
+	affected_carbon.Dizzy(15)
+	if(prob(50))
+		affected_carbon.emote(pick("twitch", "drool", "groan"))
+
+// Rocket //
+
+/datum/addiction/ms13/rocket
+	name = "rocket"
+	withdrawal_stage_messages = list("", "", "")
+
+/datum/addiction/rocket/withdrawal_enters_stage_1(mob/living/carbon/affected_carbon)
+	. = ..()
+	to_chat(affected_carbon, span_holoparasite("[pick("Need some rocket man...", "It's a good time for some rocket.")]"))
+
+/datum/addiction/ms13/rocket/withdrawal_stage_1_process(mob/living/carbon/affected_carbon, delta_time)
+	. = ..()
+	affected_carbon.Dizzy(5)
+	if(prob(30))
+		affected_carbon.emote(pick("twitch", "groan"))
+
+/datum/addiction/rocket/withdrawal_enters_stage_2(mob/living/carbon/affected_carbon)
+	. = ..()
+	to_chat(affected_carbon, span_holoparasite("[pick("Could really use some rocket right now.", "Come on... Let's go get some rocket.")]"))
+
+/datum/addiction/ms13/rocket/withdrawal_stage_2_process(mob/living/carbon/affected_carbon, delta_time)
+	. = ..()
+	affected_carbon.set_disgust(60)
+	affected_carbon.Dizzy(10)
+	if(prob(40))
+		affected_carbon.emote(pick("twitch", "groan", "moan"))
+
+/datum/addiction/rocket/withdrawal_enters_stage_3(mob/living/carbon/affected_carbon)
+	. = ..()
+	to_chat(affected_carbon, span_holoparasite("[pick("I really need some rocket- NOW!", "I'm FALLING APART!")]"))
+
+/datum/addiction/ms13/rocket/withdrawal_stage_3_process(mob/living/carbon/affected_carbon, delta_time)
+	. = ..()
+	if(!HAS_TRAIT(affected_carbon, TRAIT_IMMOBILIZED) && !isspaceturf(affected_carbon.loc) && isturf(affected_carbon.loc))
+		step(affected_carbon, pick(GLOB.cardinals))
+	affected_carbon.adjustToxLoss(1, 0)
+	affected_carbon.set_disgust(100)
+	affected_carbon.Dizzy(15)
+	if(prob(50))
+		affected_carbon.emote(pick("twitch", "drool", "groan"))
+
+// Mentats //
+
+/datum/addiction/ms13/mentats
+	name = "mentats"
+	withdrawal_stage_messages = list("", "", "")
+
+/datum/addiction/mentats/withdrawal_enters_stage_1(mob/living/carbon/affected_carbon)
+	. = ..()
+	to_chat(affected_carbon, span_notice("[pick("Your head strains slightly", "You begin to feel unwell.")]"))
+
+/datum/addiction/ms13/mentats/withdrawal_stage_1_process(mob/living/carbon/affected_carbon, delta_time)
+	. = ..()
+	affected_carbon.Jitter(3)
+	affected_carbon.Dizzy(5)
+	if(prob(20))
+		to_chat(affected_carbon, span_warning("[pick("Your head hurts.", "Your head pounds.")]"))
+	..()
+
+/datum/addiction/mentats/withdrawal_enters_stage_2(mob/living/carbon/affected_carbon)
+	. = ..()
+	to_chat(affected_carbon, span_notice("[pick("Your head strains heavily", "You begin to feel very headsick.")]"))
+
+/datum/addiction/ms13/mentats/withdrawal_stage_2_process(mob/living/carbon/affected_carbon, delta_time)
+	. = ..()
+	affected_carbon.Jitter(5)
+	affected_carbon.Dizzy(10)
+	if(prob(20))
+		affected_carbon.adjustStaminaLoss(25)
+		to_chat(affected_carbon, span_warning("[pick("Your head hurts a lot.", "Your head pounds incessantly.")]"))
+	..()
+
+/datum/addiction/mentats/withdrawal_enters_stage_3(mob/living/carbon/affected_carbon)
+	. = ..()
+	to_chat(affected_carbon, span_notice("[pick("Your head pounds in anguish", "You sulk in pain as your head constricts and expands.")]"))
+
+/datum/addiction/ms13/mentats/withdrawal_stage_3_process(mob/living/carbon/affected_carbon, delta_time)
+	. = ..()
+	affected_carbon.adjustOrganLoss(ORGAN_SLOT_BRAIN, rand(1,3))
+	affected_carbon.Jitter(5)
+	affected_carbon.Dizzy(10)
+	if(prob(20))
+		affected_carbon.Stun(35)
+		to_chat(affected_carbon, span_userdanger("[pick("Your head hurts!", "You feel a burning knife inside your brain!", "A wave of pain fills your head!")]"))
+	..()
+
+// Psycho //
+
+/datum/addiction/ms13/psycho
+	name = "psycho"
+	withdrawal_stage_messages = list("Your eye twitches sl ightly.", "You feel like something changed- But you can't figure out what. This angers you!", "Everything is just- Wrong! What the HELL IS GOING ON?")
+
+/datum/addiction/ms13/psycho/withdrawal_enters_stage_1(mob/living/carbon/affected_carbon)
+	. = ..()
+	to_chat(affected_carbon, span_warning("Your eye twitches slightly."))
+
+/datum/addiction/ms13/psycho/withdrawal_stage_1_process(mob/living/carbon/affected_carbon, delta_time)
+	. = ..()
+	affected_carbon.Jitter(5)
+	if(prob(20))
+		to_chat(affected_carbon, span_warning("You feel angry, and you don't know why..."))
+	..()
+
+/datum/addiction/ms13/psycho/withdrawal_stage_2_process(mob/living/carbon/affected_carbon, delta_time)
+	. = ..()
+	affected_carbon.adjustOrganLoss(ORGAN_SLOT_HEART, 0.25)
+	affected_carbon.Jitter(10)
+	affected_carbon.Dizzy(10)
+	if(prob(20))
+		to_chat(affected_carbon, span_warning("[pick("You are filled with anger.", "Is the room spinning...? This is PISSING YOU OFF!", "You REALLY want to PUNCH someone right now.")]"))
+	..()
+
+/datum/addiction/ms13/psycho/withdrawal_enters_stage_2(mob/living/carbon/affected_carbon)
+	. = ..()
+	to_chat(affected_carbon, span_warning("You feel like something changed- But you can't figure out what. This angers you!"))
+
+/datum/addiction/ms13/psycho/withdrawal_enters_stage_3(mob/living/carbon/affected_carbon)
+	. = ..()
+	to_chat(affected_carbon, span_boldwarning("Everything is just- Wrong! What the HELL IS GOING ON?"))
+
+/datum/addiction/ms13/psycho/withdrawal_stage_3_process(mob/living/carbon/affected_carbon, delta_time)
+	. = ..()
+	affected_carbon.adjustOrganLoss(ORGAN_SLOT_HEART, 0.65)
+	affected_carbon.adjustOrganLoss(ORGAN_SLOT_BRAIN, 0.5)
+	affected_carbon.Jitter(5)
+	affected_carbon.Dizzy(10)
+	if(prob(20))
+		to_chat(affected_carbon, span_warning("[pick("Your head burns... Your heart aches... You are FURIOUS!", "You feel a sickening nausea run over you- You're filled with RAGE!", "Why is EVERYONE so adamant on PISSING YOU OFF at a time like this?!")]"))
+	..()
+
+// Smooch //
+
+/datum/addiction/ms13/smooch/withdrawal_stage_1_process(mob/living/carbon/affected_carbon)
+	. = ..()
+	affected_carbon.hallucination += 20
+	if(!HAS_TRAIT(affected_carbon, TRAIT_IMMOBILIZED) && !isspaceturf(affected_carbon.loc) && isturf(affected_carbon.loc))
+		step(affected_carbon, pick(GLOB.cardinals))
+	affected_carbon.Jitter(10)
+	affected_carbon.Dizzy(10)
+	affected_carbon.adjustOrganLoss(ORGAN_SLOT_BRAIN, 10)
+	if(prob(30))
+		affected_carbon.emote(pick("twitch","drool","moan"))
+
+/datum/addiction/ms13/smooch/withdrawal_stage_2_process(mob/living/carbon/affected_carbon)
+	. = ..()
+	affected_carbon.hallucination += 30
+	if(!HAS_TRAIT(affected_carbon, TRAIT_IMMOBILIZED) && !isspaceturf(affected_carbon.loc) && isturf(affected_carbon.loc))
+		step(affected_carbon, pick(GLOB.cardinals))
+	affected_carbon.Jitter(15)
+	affected_carbon.Dizzy(15)
+	affected_carbon.adjustOrganLoss(ORGAN_SLOT_BRAIN, 10)
+	if(prob(40))
+		affected_carbon.emote(pick("twitch","drool","moan"))
+
+/datum/addiction/ms13/smooch/withdrawal_stage_3_process(mob/living/carbon/affected_carbon)
+	. = ..()
+	affected_carbon.hallucination += 30
+	if(!HAS_TRAIT(affected_carbon, TRAIT_IMMOBILIZED) && !isspaceturf(affected_carbon.loc) && isturf(affected_carbon.loc))
+		step(affected_carbon, pick(GLOB.cardinals))
+	affected_carbon.Jitter(50)
+	affected_carbon.Dizzy(50)
+	affected_carbon.adjustToxLoss(5, 0)
+	affected_carbon.adjustOrganLoss(ORGAN_SLOT_BRAIN, 10)
+	if(prob(50))
+		affected_carbon.emote(pick("twitch","drool","moan"))

--- a/mojave/code/modules/reagents/addictions.dm
+++ b/mojave/code/modules/reagents/addictions.dm
@@ -146,7 +146,6 @@
 	M.Dizzy(5)
 	if(prob(20))
 		to_chat(M, span_warning("[pick("Your head hurts.", "Your head pounds.")]"))
-	..()
 
 /datum/addiction/mentats/withdrawal_enters_stage_2(mob/living/carbon/M)
 	. = ..()
@@ -159,7 +158,6 @@
 	if(prob(20))
 		M.adjustStaminaLoss(25)
 		to_chat(M, span_warning("[pick("Your head hurts a lot.", "Your head pounds incessantly.")]"))
-	..()
 
 /datum/addiction/mentats/withdrawal_enters_stage_3(mob/living/carbon/M)
 	. = ..()
@@ -173,7 +171,6 @@
 	if(prob(20))
 		M.Stun(35)
 		to_chat(M, span_userdanger("[pick("Your head hurts!", "You feel a burning knife inside your brain!", "A wave of pain fills your head!")]"))
-	..()
 
 // Psycho //
 
@@ -190,7 +187,6 @@
 	M.Jitter(5)
 	if(prob(20))
 		to_chat(M, span_warning("You feel angry, and you don't know why..."))
-	..()
 
 /datum/addiction/ms13/psycho/withdrawal_enters_stage_2(mob/living/carbon/M)
 	. = ..()
@@ -202,7 +198,6 @@
 	M.Dizzy(10)
 	if(prob(20))
 		to_chat(M, span_warning("[pick("You are filled with anger.", "Is the room spinning...? This is PISSING YOU OFF!", "You REALLY want to PUNCH someone right now.")]"))
-	..()
 
 /datum/addiction/ms13/psycho/withdrawal_enters_stage_3(mob/living/carbon/M)
 	. = ..()
@@ -215,7 +210,6 @@
 	M.Dizzy(10)
 	if(prob(20))
 		to_chat(M, span_warning("[pick("Your head burns... Your heart aches... You are FURIOUS!", "You feel a sickening nausea run over you- You're filled with RAGE!", "Why is EVERYONE so adamant on PISSING YOU OFF at a time like this?!")]"))
-	..()
 
 // Overdrive //
 
@@ -232,7 +226,6 @@
 	M.Jitter(15)
 	if(prob(20))
 		to_chat(M, span_warning("You begin to shake in fury."))
-	..()
 
 /datum/addiction/ms13/overdrive/withdrawal_enters_stage_2(mob/living/carbon/M)
 	. = ..()
@@ -244,7 +237,6 @@
 	M.Dizzy(10)
 	if(prob(20))
 		to_chat(M, span_warning("[pick("You have trouble thinking clearly through your rage", "You're REALLY pissed off right now.")]"))
-	..()
 
 
 /datum/addiction/ms13/overdrive/withdrawal_enters_stage_3(mob/living/carbon/M)
@@ -259,7 +251,6 @@
 	M.adjustStaminaLoss(2.5)
 	if(prob(20))
 		to_chat(M, span_warning("[pick("You feel so tired- and it's REALLY pissing you off!", "Your arms ache heavily.", "Your whole body throbs with fatigue.")]"))
-	..()
 
 // Day Tripper //
 

--- a/mojave/code/modules/reagents/addictions.dm
+++ b/mojave/code/modules/reagents/addictions.dm
@@ -1,28 +1,8 @@
-/*datum/addiction/opiods
-	name = "opiod"
-	withdrawal_stage_messages = list("I feel aches in my bodies..", "I need some pain relief...", "It aches all over...I need some opiods!")
+// Obligatory basetype //
 
-/datum/addiction/ms13/opiods/withdrawal_stage_1_process(mob/living/carbon/affected_carbon, delta_time)
-	. = ..()
-	if(DT_PROB(10, delta_time))
-		affected_carbon.emote("yawn")
-
-/datum/addiction/ms13/opiods/withdrawal_enters_stage_2(mob/living/carbon/affected_carbon)
-	. = ..()
-	affected_carbon.apply_status_effect(STATUS_EFFECT_HIGHBLOODPRESSURE)
-
-/datum/addiction/ms13/opiods/withdrawal_stage_3_process(mob/living/carbon/affected_carbon, delta_time)
-	. = ..()
-	if(affected_carbon.disgust < DISGUST_LEVEL_DISGUSTED && DT_PROB(7.5, delta_time))
-		affected_carbon.adjust_disgust(12.5 * delta_time)
-
-
-/datum/addiction/ms13/opiods/end_withdrawal(mob/living/carbon/affected_carbon)
-	. = ..()
-	affected_carbon.remove_status_effect(STATUS_EFFECT_HIGHBLOODPRESSURE)
-	affected_carbon.set_disgust(affected_carbon.disgust * 0.5) //half their disgust to help
-*/
-/////=======================/////
+/datum/addiction/ms13
+	name = "base type MS13 crack addiction"
+	withdrawal_stage_messages = list("", "", "")
 
 // Jet //
 

--- a/mojave/code/modules/reagents/addictions.dm
+++ b/mojave/code/modules/reagents/addictions.dm
@@ -99,7 +99,8 @@
 /datum/addiction/turbo/withdrawal_enters_stage_1(mob/living/carbon/M)
 	. = ..()
 	to_chat(M, span_red("[pick("Going any faster just seems so impossible...", "I don't think I can maintain speed without turbo...")]"))
-	M.add_movespeed_modifier(/datum/movespeed_modifier/reagent/ms13/turbo_slow) // Don't do drugs, kids. Dependencies are real.
+	if(M.has_movespeed_modifier(/datum/movespeed_modifier/reagent/ms13/turbo_slow)) // Stacking this could break stuff.
+		M.add_movespeed_modifier(/datum/movespeed_modifier/reagent/ms13/turbo_slow) // Don't do drugs, kids. Dependencies are real.
 
 /datum/addiction/ms13/turbo/withdrawal_stage_1_process(mob/living/carbon/M, delta_time)
 	. = ..()

--- a/mojave/code/modules/reagents/addictions.dm
+++ b/mojave/code/modules/reagents/addictions.dm
@@ -3,6 +3,12 @@
 /datum/addiction/ms13
 	name = "base type MS13 crack addiction"
 	withdrawal_stage_messages = list("", "", "")
+	///Higher threshold, when you start being addicted. Should be high so that it's hard to shrug off addictions.
+	addiction_gain_threshold = 950
+	///Lower threshold, when you stop being addicted
+	addiction_loss_threshold = 50
+	///Rates at which you lose addiction (in units/second) if you are not on the drug at that time per stage
+	addiction_loss_per_stage = list(0.5, 0.5, 1, 1.5)
 
 // Jet //
 
@@ -10,40 +16,39 @@
 	name = "jet"
 	withdrawal_stage_messages = list("", "", "")
 
-/datum/addiction/jet/withdrawal_enters_stage_1(mob/living/carbon/affected_carbon)
+/datum/addiction/jet/withdrawal_enters_stage_1(mob/living/carbon/M)
 	. = ..()
-	to_chat(affected_carbon, span_holoparasite("[pick("Need some jet man...", "It's a good time for some jet.")]"))
+	to_chat(M, span_red("[pick("Need some jet man...", "It's a good time for some jet.")]"))
 
-/datum/addiction/ms13/jet/withdrawal_stage_1_process(mob/living/carbon/affected_carbon, delta_time)
+/datum/addiction/ms13/jet/withdrawal_stage_1_process(mob/living/carbon/M, delta_time)
 	. = ..()
-	affected_carbon.Dizzy(5)
-	if(prob(30))
-		affected_carbon.emote(pick("twitch", "groan"))
+	M.Dizzy(5)
+	if(prob(5))
+		M.emote("groan")
 
-/datum/addiction/jet/withdrawal_enters_stage_2(mob/living/carbon/affected_carbon)
+/datum/addiction/jet/withdrawal_enters_stage_2(mob/living/carbon/M)
 	. = ..()
-	to_chat(affected_carbon, span_holoparasite("[pick("Could really use some jet right now.", "Come on... Let's go get some jet.")]"))
+	to_chat(M, span_red("[pick("Could really use some jet right now.", "Come on... Let's go get some jet.")]"))
 
-/datum/addiction/ms13/jet/withdrawal_stage_2_process(mob/living/carbon/affected_carbon, delta_time)
+/datum/addiction/ms13/jet/withdrawal_stage_2_process(mob/living/carbon/M, delta_time)
 	. = ..()
-	affected_carbon.set_disgust(60)
-	affected_carbon.Dizzy(10)
-	if(prob(40))
-		affected_carbon.emote(pick("twitch", "groan", "moan"))
+	M.set_disgust(25)
+	M.Dizzy(10)
+	if(prob(15))
+		M.emote(pick("groan", "moan"))
 
-/datum/addiction/jet/withdrawal_enters_stage_3(mob/living/carbon/affected_carbon)
+/datum/addiction/jet/withdrawal_enters_stage_3(mob/living/carbon/M)
 	. = ..()
-	to_chat(affected_carbon, span_holoparasite("[pick("I really need some jet- NOW!", "I'm FALLING APART!")]"))
+	to_chat(M, span_red("[pick("I really need some jet- NOW!", "I'm FALLING APART!")]"))
 
-/datum/addiction/ms13/jet/withdrawal_stage_3_process(mob/living/carbon/affected_carbon, delta_time)
+/datum/addiction/ms13/jet/withdrawal_stage_3_process(mob/living/carbon/M, delta_time)
 	. = ..()
-	if(!HAS_TRAIT(affected_carbon, TRAIT_IMMOBILIZED) && !isspaceturf(affected_carbon.loc) && isturf(affected_carbon.loc))
-		step(affected_carbon, pick(GLOB.cardinals))
-	affected_carbon.adjustToxLoss(1, 0)
-	affected_carbon.set_disgust(100)
-	affected_carbon.Dizzy(15)
-	if(prob(50))
-		affected_carbon.emote(pick("twitch", "drool", "groan"))
+	if(!HAS_TRAIT(M, TRAIT_IMMOBILIZED) && !isspaceturf(M.loc) && isturf(M.loc))
+		step(M, pick(GLOB.cardinals))
+	M.set_disgust(45)
+	M.Dizzy(15)
+	if(prob(25))
+		M.emote(pick("drool", "groan"))
 
 // Rocket //
 
@@ -51,40 +56,78 @@
 	name = "rocket"
 	withdrawal_stage_messages = list("", "", "")
 
-/datum/addiction/rocket/withdrawal_enters_stage_1(mob/living/carbon/affected_carbon)
+/datum/addiction/rocket/withdrawal_enters_stage_1(mob/living/carbon/M)
 	. = ..()
-	to_chat(affected_carbon, span_holoparasite("[pick("Need some rocket man...", "It's a good time for some rocket.")]"))
+	to_chat(M, span_red("[pick("Need some rocket man...", "It's a good time for some rocket.")]"))
 
-/datum/addiction/ms13/rocket/withdrawal_stage_1_process(mob/living/carbon/affected_carbon, delta_time)
+/datum/addiction/ms13/rocket/withdrawal_stage_1_process(mob/living/carbon/M, delta_time)
 	. = ..()
-	affected_carbon.Dizzy(5)
+	M.set_disgust(25)
+	M.Dizzy(5)
 	if(prob(30))
-		affected_carbon.emote(pick("twitch", "groan"))
+		M.emote("groan")
 
-/datum/addiction/rocket/withdrawal_enters_stage_2(mob/living/carbon/affected_carbon)
+/datum/addiction/rocket/withdrawal_enters_stage_2(mob/living/carbon/M)
 	. = ..()
-	to_chat(affected_carbon, span_holoparasite("[pick("Could really use some rocket right now.", "Come on... Let's go get some rocket.")]"))
+	to_chat(M, span_red("[pick("Could really use some rocket right now.", "Come on... Let's go get some rocket.")]"))
 
-/datum/addiction/ms13/rocket/withdrawal_stage_2_process(mob/living/carbon/affected_carbon, delta_time)
+/datum/addiction/ms13/rocket/withdrawal_stage_2_process(mob/living/carbon/M, delta_time)
 	. = ..()
-	affected_carbon.set_disgust(60)
-	affected_carbon.Dizzy(10)
+	M.set_disgust(60)
+	M.Dizzy(10)
 	if(prob(40))
-		affected_carbon.emote(pick("twitch", "groan", "moan"))
+		M.emote(pick("groan", "moan"))
 
-/datum/addiction/rocket/withdrawal_enters_stage_3(mob/living/carbon/affected_carbon)
+/datum/addiction/rocket/withdrawal_enters_stage_3(mob/living/carbon/M)
 	. = ..()
-	to_chat(affected_carbon, span_holoparasite("[pick("I really need some rocket- NOW!", "I'm FALLING APART!")]"))
+	to_chat(M, span_red("[pick("I really need some rocket- NOW!", "I'm FALLING APART!")]"))
 
-/datum/addiction/ms13/rocket/withdrawal_stage_3_process(mob/living/carbon/affected_carbon, delta_time)
+/datum/addiction/ms13/rocket/withdrawal_stage_3_process(mob/living/carbon/M, delta_time)
 	. = ..()
-	if(!HAS_TRAIT(affected_carbon, TRAIT_IMMOBILIZED) && !isspaceturf(affected_carbon.loc) && isturf(affected_carbon.loc))
-		step(affected_carbon, pick(GLOB.cardinals))
-	affected_carbon.adjustToxLoss(1, 0)
-	affected_carbon.set_disgust(100)
-	affected_carbon.Dizzy(15)
+	if(!HAS_TRAIT(M, TRAIT_IMMOBILIZED) && !isspaceturf(M.loc) && isturf(M.loc))
+		step(M, pick(GLOB.cardinals))
+	M.set_disgust(100)
+	M.Dizzy(25)
 	if(prob(50))
-		affected_carbon.emote(pick("twitch", "drool", "groan"))
+		M.emote(pick("drool", "groan"))
+// Turbo //
+
+/datum/addiction/ms13/turbo
+	name = "turbo"
+	withdrawal_stage_messages = list("", "", "")
+
+/datum/addiction/turbo/withdrawal_enters_stage_1(mob/living/carbon/M)
+	. = ..()
+	to_chat(M, span_red("[pick("Going any faster just seems so impossible...", "I don't think I can maintain speed without turbo...")]"))
+	M.add_movespeed_modifier(/datum/movespeed_modifier/reagent/ms13/turbo_slow) // Don't do drugs, kids. Dependencies are real.
+
+/datum/addiction/ms13/turbo/withdrawal_stage_1_process(mob/living/carbon/M, delta_time)
+	. = ..()
+	M.Dizzy(5)
+	if(prob(5))
+		M.emote("groan")
+
+/datum/addiction/turbo/withdrawal_enters_stage_2(mob/living/carbon/M)
+	. = ..()
+	to_chat(M, span_red("[pick("Really need a speedup right about now.", "I should go get some Turbo. Then I can be fast again.")]"))
+
+/datum/addiction/ms13/jet/withdrawal_stage_2_process(mob/living/carbon/M, delta_time)
+	. = ..()
+	M.Dizzy(10)
+	if(prob(15))
+		M.emote(pick("groan", "moan"))
+
+/datum/addiction/turbo/withdrawal_enters_stage_3(mob/living/carbon/M)
+	. = ..()
+	to_chat(M, span_red("[pick("I really gotta go fast.", "I want to go NOW!")]"))
+
+/datum/addiction/ms13/turbo/withdrawal_stage_3_process(mob/living/carbon/M, delta_time)
+	. = ..()
+	if(!HAS_TRAIT(M, TRAIT_IMMOBILIZED) && !isspaceturf(M.loc) && isturf(M.loc))
+		step(M, pick(GLOB.cardinals))
+	M.Dizzy(15)
+	if(prob(25))
+		M.emote(pick("drool", "groan"))
 
 // Mentats //
 
@@ -92,121 +135,119 @@
 	name = "mentats"
 	withdrawal_stage_messages = list("", "", "")
 
-/datum/addiction/mentats/withdrawal_enters_stage_1(mob/living/carbon/affected_carbon)
+/datum/addiction/mentats/withdrawal_enters_stage_1(mob/living/carbon/M)
 	. = ..()
-	to_chat(affected_carbon, span_notice("[pick("Your head strains slightly", "You begin to feel unwell.")]"))
+	to_chat(M, span_notice("[pick("Your head strains slightly", "You begin to feel unwell.")]"))
 
-/datum/addiction/ms13/mentats/withdrawal_stage_1_process(mob/living/carbon/affected_carbon, delta_time)
+/datum/addiction/ms13/mentats/withdrawal_stage_1_process(mob/living/carbon/M, delta_time)
 	. = ..()
-	affected_carbon.Jitter(3)
-	affected_carbon.Dizzy(5)
+	M.Jitter(3)
+	M.Dizzy(5)
 	if(prob(20))
-		to_chat(affected_carbon, span_warning("[pick("Your head hurts.", "Your head pounds.")]"))
+		to_chat(M, span_warning("[pick("Your head hurts.", "Your head pounds.")]"))
 	..()
 
-/datum/addiction/mentats/withdrawal_enters_stage_2(mob/living/carbon/affected_carbon)
+/datum/addiction/mentats/withdrawal_enters_stage_2(mob/living/carbon/M)
 	. = ..()
-	to_chat(affected_carbon, span_notice("[pick("Your head strains heavily", "You begin to feel very headsick.")]"))
+	to_chat(M, span_notice("[pick("Your head strains heavily", "You begin to feel very headsick.")]"))
 
-/datum/addiction/ms13/mentats/withdrawal_stage_2_process(mob/living/carbon/affected_carbon, delta_time)
+/datum/addiction/ms13/mentats/withdrawal_stage_2_process(mob/living/carbon/M, delta_time)
 	. = ..()
-	affected_carbon.Jitter(5)
-	affected_carbon.Dizzy(10)
+	M.Jitter(5)
+	M.Dizzy(10)
 	if(prob(20))
-		affected_carbon.adjustStaminaLoss(25)
-		to_chat(affected_carbon, span_warning("[pick("Your head hurts a lot.", "Your head pounds incessantly.")]"))
+		M.adjustStaminaLoss(25)
+		to_chat(M, span_warning("[pick("Your head hurts a lot.", "Your head pounds incessantly.")]"))
 	..()
 
-/datum/addiction/mentats/withdrawal_enters_stage_3(mob/living/carbon/affected_carbon)
+/datum/addiction/mentats/withdrawal_enters_stage_3(mob/living/carbon/M)
 	. = ..()
-	to_chat(affected_carbon, span_notice("[pick("Your head pounds in anguish", "You sulk in pain as your head constricts and expands.")]"))
+	to_chat(M, span_notice("[pick("Your head pounds in anguish", "You sulk in pain as your head constricts and expands.")]"))
 
-/datum/addiction/ms13/mentats/withdrawal_stage_3_process(mob/living/carbon/affected_carbon, delta_time)
+/datum/addiction/ms13/mentats/withdrawal_stage_3_process(mob/living/carbon/M, delta_time)
 	. = ..()
-	affected_carbon.adjustOrganLoss(ORGAN_SLOT_BRAIN, rand(1,3))
-	affected_carbon.Jitter(5)
-	affected_carbon.Dizzy(10)
+	M.adjustOrganLoss(ORGAN_SLOT_BRAIN, rand(1,3))
+	M.Jitter(5)
+	M.Dizzy(10)
 	if(prob(20))
-		affected_carbon.Stun(35)
-		to_chat(affected_carbon, span_userdanger("[pick("Your head hurts!", "You feel a burning knife inside your brain!", "A wave of pain fills your head!")]"))
+		M.Stun(35)
+		to_chat(M, span_userdanger("[pick("Your head hurts!", "You feel a burning knife inside your brain!", "A wave of pain fills your head!")]"))
 	..()
 
 // Psycho //
 
 /datum/addiction/ms13/psycho
 	name = "psycho"
-	withdrawal_stage_messages = list("Your eye twitches sl ightly.", "You feel like something changed- But you can't figure out what. This angers you!", "Everything is just- Wrong! What the HELL IS GOING ON?")
+	withdrawal_stage_messages = list("", "", "")
 
-/datum/addiction/ms13/psycho/withdrawal_enters_stage_1(mob/living/carbon/affected_carbon)
+/datum/addiction/ms13/psycho/withdrawal_enters_stage_1(mob/living/carbon/M)
 	. = ..()
-	to_chat(affected_carbon, span_warning("Your eye twitches slightly."))
+	to_chat(M, span_warning("Your eye twitches slightly."))
 
-/datum/addiction/ms13/psycho/withdrawal_stage_1_process(mob/living/carbon/affected_carbon, delta_time)
+/datum/addiction/ms13/psycho/withdrawal_stage_1_process(mob/living/carbon/M, delta_time)
 	. = ..()
-	affected_carbon.Jitter(5)
+	M.Jitter(5)
 	if(prob(20))
-		to_chat(affected_carbon, span_warning("You feel angry, and you don't know why..."))
+		to_chat(M, span_warning("You feel angry, and you don't know why..."))
 	..()
 
-/datum/addiction/ms13/psycho/withdrawal_stage_2_process(mob/living/carbon/affected_carbon, delta_time)
+/datum/addiction/ms13/psycho/withdrawal_stage_2_process(mob/living/carbon/M, delta_time)
 	. = ..()
-	affected_carbon.adjustOrganLoss(ORGAN_SLOT_HEART, 0.25)
-	affected_carbon.Jitter(10)
-	affected_carbon.Dizzy(10)
+	M.Jitter(10)
+	M.Dizzy(10)
 	if(prob(20))
-		to_chat(affected_carbon, span_warning("[pick("You are filled with anger.", "Is the room spinning...? This is PISSING YOU OFF!", "You REALLY want to PUNCH someone right now.")]"))
+		to_chat(M, span_warning("[pick("You are filled with anger.", "Is the room spinning...? This is PISSING YOU OFF!", "You REALLY want to PUNCH someone right now.")]"))
 	..()
 
-/datum/addiction/ms13/psycho/withdrawal_enters_stage_2(mob/living/carbon/affected_carbon)
+/datum/addiction/ms13/psycho/withdrawal_enters_stage_2(mob/living/carbon/M)
 	. = ..()
-	to_chat(affected_carbon, span_warning("You feel like something changed- But you can't figure out what. This angers you!"))
+	to_chat(M, span_warning("You feel like something changed- But you can't figure out what. This angers you!"))
 
-/datum/addiction/ms13/psycho/withdrawal_enters_stage_3(mob/living/carbon/affected_carbon)
+/datum/addiction/ms13/psycho/withdrawal_enters_stage_3(mob/living/carbon/M)
 	. = ..()
-	to_chat(affected_carbon, span_boldwarning("Everything is just- Wrong! What the HELL IS GOING ON?"))
+	to_chat(M, span_boldwarning("Everything is just- Wrong! What the HELL IS GOING ON?"))
 
-/datum/addiction/ms13/psycho/withdrawal_stage_3_process(mob/living/carbon/affected_carbon, delta_time)
+/datum/addiction/ms13/psycho/withdrawal_stage_3_process(mob/living/carbon/M, delta_time)
 	. = ..()
-	affected_carbon.adjustOrganLoss(ORGAN_SLOT_HEART, 0.65)
-	affected_carbon.adjustOrganLoss(ORGAN_SLOT_BRAIN, 0.5)
-	affected_carbon.Jitter(5)
-	affected_carbon.Dizzy(10)
+	M.adjustOrganLoss(ORGAN_SLOT_BRAIN, 0.5)
+	M.Jitter(5)
+	M.Dizzy(10)
 	if(prob(20))
-		to_chat(affected_carbon, span_warning("[pick("Your head burns... Your heart aches... You are FURIOUS!", "You feel a sickening nausea run over you- You're filled with RAGE!", "Why is EVERYONE so adamant on PISSING YOU OFF at a time like this?!")]"))
+		to_chat(M, span_warning("[pick("Your head burns... Your heart aches... You are FURIOUS!", "You feel a sickening nausea run over you- You're filled with RAGE!", "Why is EVERYONE so adamant on PISSING YOU OFF at a time like this?!")]"))
 	..()
 
 // Smooch //
 
-/datum/addiction/ms13/smooch/withdrawal_stage_1_process(mob/living/carbon/affected_carbon)
+/datum/addiction/ms13/smooch/withdrawal_stage_1_process(mob/living/carbon/M)
 	. = ..()
-	affected_carbon.hallucination += 20
-	if(!HAS_TRAIT(affected_carbon, TRAIT_IMMOBILIZED) && !isspaceturf(affected_carbon.loc) && isturf(affected_carbon.loc))
-		step(affected_carbon, pick(GLOB.cardinals))
-	affected_carbon.Jitter(10)
-	affected_carbon.Dizzy(10)
-	affected_carbon.adjustOrganLoss(ORGAN_SLOT_BRAIN, 10)
+	M.hallucination += 20
+	if(!HAS_TRAIT(M, TRAIT_IMMOBILIZED) && !isspaceturf(M.loc) && isturf(M.loc))
+		step(M, pick(GLOB.cardinals))
+	M.Jitter(10)
+	M.Dizzy(10)
+	M.adjustOrganLoss(ORGAN_SLOT_BRAIN, 10)
 	if(prob(30))
-		affected_carbon.emote(pick("twitch","drool","moan"))
+		M.emote(pick("twitch","drool","moan"))
 
-/datum/addiction/ms13/smooch/withdrawal_stage_2_process(mob/living/carbon/affected_carbon)
+/datum/addiction/ms13/smooch/withdrawal_stage_2_process(mob/living/carbon/M)
 	. = ..()
-	affected_carbon.hallucination += 30
-	if(!HAS_TRAIT(affected_carbon, TRAIT_IMMOBILIZED) && !isspaceturf(affected_carbon.loc) && isturf(affected_carbon.loc))
-		step(affected_carbon, pick(GLOB.cardinals))
-	affected_carbon.Jitter(15)
-	affected_carbon.Dizzy(15)
-	affected_carbon.adjustOrganLoss(ORGAN_SLOT_BRAIN, 10)
+	M.hallucination += 30
+	if(!HAS_TRAIT(M, TRAIT_IMMOBILIZED) && !isspaceturf(M.loc) && isturf(M.loc))
+		step(M, pick(GLOB.cardinals))
+	M.Jitter(15)
+	M.Dizzy(15)
+	M.adjustOrganLoss(ORGAN_SLOT_BRAIN, 10)
 	if(prob(40))
-		affected_carbon.emote(pick("twitch","drool","moan"))
+		M.emote(pick("twitch","drool","moan"))
 
-/datum/addiction/ms13/smooch/withdrawal_stage_3_process(mob/living/carbon/affected_carbon)
+/datum/addiction/ms13/smooch/withdrawal_stage_3_process(mob/living/carbon/M)
 	. = ..()
-	affected_carbon.hallucination += 30
-	if(!HAS_TRAIT(affected_carbon, TRAIT_IMMOBILIZED) && !isspaceturf(affected_carbon.loc) && isturf(affected_carbon.loc))
-		step(affected_carbon, pick(GLOB.cardinals))
-	affected_carbon.Jitter(50)
-	affected_carbon.Dizzy(50)
-	affected_carbon.adjustToxLoss(5, 0)
-	affected_carbon.adjustOrganLoss(ORGAN_SLOT_BRAIN, 10)
+	M.hallucination += 30
+	if(!HAS_TRAIT(M, TRAIT_IMMOBILIZED) && !isspaceturf(M.loc) && isturf(M.loc))
+		step(M, pick(GLOB.cardinals))
+	M.Jitter(50)
+	M.Dizzy(50)
+	M.adjustToxLoss(5, 0)
+	M.adjustOrganLoss(ORGAN_SLOT_BRAIN, 10)
 	if(prob(50))
-		affected_carbon.emote(pick("twitch","drool","moan"))
+		M.emote(pick("twitch","drool","moan"))

--- a/mojave/code/modules/reagents/consumables/alcohols.dm
+++ b/mojave/code/modules/reagents/consumables/alcohols.dm
@@ -222,7 +222,7 @@
 	glass_name = "glass of dark red liquid"
 	glass_desc = "A dark red liquid with particles floating around in it. Intense alcoholic aroma."
 
-/*/datum/reagent/consumable/ethanol/ms13/necromancer/on_mob_life(mob/living/carbon/M)
+/*/datum/reagent/consumable/ethanol/ms13/necromancer/on_mob_life(mob/living/carbon/M, delta_time, times_fired)
 	M.drowsyness = max(0,M.drowsyness-3)
 	..()
 	. = 1 */
@@ -426,7 +426,7 @@
 	glass_name = "glass of pale yellow-ish liquid"
 	glass_desc = "A faint pale yellow liquid with a familiar distant agave smell to it. Smells pretty alcoholic."
 
-/datum/reagent/consumable/ethanol/ms13/waster_tequila/on_mob_life(mob/living/carbon/M)
+/datum/reagent/consumable/ethanol/ms13/waster_tequila/on_mob_life(mob/living/carbon/M, delta_time, times_fired)
 	if(M.getToxLoss() && prob(20))
 		M.adjustToxLoss(-1*REM, 0)
 		. = 1
@@ -461,7 +461,7 @@
 	glass_name = "glass of murky brown liquid"
 	glass_desc = "A murky brown liquid with a gross smell to it. You can ALMOST pick up the faint smell of alcohol."
 
-/datum/reagent/consumable/ethanol/ms13/brew_sludge/on_mob_life(mob/living/carbon/M)
+/datum/reagent/consumable/ethanol/ms13/brew_sludge/on_mob_life(mob/living/carbon/M, delta_time, times_fired)
 	M.adjustOrganLoss(ORGAN_SLOT_STOMACH, rand(1,2))
 	M.adjust_disgust(15)
 	..()
@@ -496,7 +496,7 @@
 	glass_name = "glass of pale orange liquid"
 	glass_desc = "A pale orange liquid. It reeks of fungus and has hints of tato."
 
-/datum/reagent/consumable/ethanol/ms13/swift_recovery/on_mob_life(mob/living/carbon/M)
+/datum/reagent/consumable/ethanol/ms13/swift_recovery/on_mob_life(mob/living/carbon/M, delta_time, times_fired)
 	M.adjustOrganLoss(ORGAN_SLOT_BRAIN, rand(-5,-1))
 	if(M.getToxLoss() && prob(20))
 		M.adjustToxLoss(1*REM, 0)
@@ -513,7 +513,7 @@
 	glass_name = "glass of deep red liquid"
 	glass_desc = "A deep red liquid with a spiced aroma. Smelling it brings a comforting aura."
 
-/datum/reagent/consumable/ethanol/ms13/fire_wine/on_mob_life(mob/living/carbon/M)
+/datum/reagent/consumable/ethanol/ms13/fire_wine/on_mob_life(mob/living/carbon/M, delta_time, times_fired)
 	M.adjust_bodytemperature(25 * TEMPERATURE_DAMAGE_COEFFICIENT, 0, M.get_body_temp_normal())
 	..()
 	. = 1
@@ -538,7 +538,7 @@
 	glass_name = "glass of a reddish-purple liquid"
 	glass_desc = "A reddish-purple liquid with a distant fruit aroma to it, occasional black flakes can be seen floating around. Alcohol is present in it, albeit not too strong."
 
-/datum/reagent/consumable/ethanol/ms13/lead_champagne/on_mob_life(mob/living/carbon/M)
+/datum/reagent/consumable/ethanol/ms13/lead_champagne/on_mob_life(mob/living/carbon/M, delta_time, times_fired)
 	if(prob(20))
 		M.radiation -= min(4, M.radiation)
 		M.adjustOrganLoss(ORGAN_SLOT_BRAIN, rand(1,5))
@@ -564,7 +564,7 @@
 	to_chat(L, (span_swarmer("Against it all odds, it looks like the pain faded...")))
 	..()
 
-/datum/reagent/consumable/ethanol/ms13/nukashine/on_mob_life(mob/living/carbon/M)
+/datum/reagent/consumable/ethanol/ms13/nukashine/on_mob_life(mob/living/carbon/M, delta_time, times_fired)
 	M.AdjustStun(-20, FALSE)
 	M.AdjustKnockdown(-20, FALSE)
 	M.adjustStaminaLoss(-5, 0)

--- a/mojave/code/modules/reagents/consumables/drinks.dm
+++ b/mojave/code/modules/reagents/consumables/drinks.dm
@@ -25,14 +25,14 @@
 	glass_name = "glass of murky liquid"
 	glass_desc = "A murky green liquid with a pungeant vile smell. Not so sure about this one."
 
-/datum/reagent/consumable/ms13/dirty_water/on_mob_life(mob/living/carbon/M)
+/datum/reagent/consumable/ms13/dirty_water/on_mob_life(mob/living/carbon/M, delta_time, times_fired)
 	M.adjust_disgust(10)
 	if(prob(50))
 		M.adjustToxLoss(5)
 
 	if(prob(10))
 		M.vomit(lost_nutrition = 25, distance = 1, purge_ratio = 0.2)
-	..()
+	return ..()
 
 //// E for Everyone drinks - Soda/Beverages ////
 
@@ -54,7 +54,7 @@
 	glass_name = "glass of dark fizzy liquid"
 	glass_desc = "A dark fizzy liquid with a slighty off sweet smell. Bubbles form on the side."
 
-/datum/reagent/consumable/ms13/nuka_diet/on_mob_life(mob/living/carbon/M)
+/datum/reagent/consumable/ms13/nuka_diet/on_mob_life(mob/living/carbon/M, delta_time, times_fired)
 	if(prob(5))
 		M.adjustBruteLoss(0.5) //aspartame is bad for your bones. Shoulda just drank water.
 
@@ -157,14 +157,14 @@
 	glass_name = "glass of brown-ish fizzy liquid"
 	glass_desc = "A dark brown-ish fizzy liquid with a slighty sweet smell. Bubbles form on the side."
 
-/datum/reagent/consumable/ms13/nuka_vaccinated/on_mob_life(mob/living/carbon/M)
+/datum/reagent/consumable/ms13/nuka_vaccinated/on_mob_life(mob/living/carbon/M, delta_time, times_fired)
 	M.adjustToxLoss(-0.2, 0, TRUE)
 	for(var/thing in M.diseases)
 		var/datum/disease/D = thing
 		if(D.severity == DISEASE_SEVERITY_POSITIVE)
 			continue
 		D.cure()
-	..()
+	return ..()
 
 /datum/reagent/consumable/ms13/nuka_fusion
 	name = "Nuka-Fusion"
@@ -267,11 +267,11 @@
 	glass_name = "glass of murky dark green liquid"
 	glass_desc = "A murky dark green liquid with bits of plant matter floating at the top. Has a vile smell to it."
 
-/datum/reagent/consumable/ms13/gagquik/on_mob_life(mob/living/carbon/M) // This definitely won't be slipped into drinks
+/datum/reagent/consumable/ms13/gagquik/on_mob_life(mob/living/carbon/M, delta_time, times_fired) // This definitely won't be slipped into drinks
 	if(prob(25))
 		M.vomit(lost_nutrition = 25, distance = 1, purge_ratio = 0.5)
 	M.adjust_disgust(10)
-	..()
+	return ..()
 
 /datum/reagent/consumable/ms13/redheave //Geigpunga wine, Toxic soot extract, Gagquik, CHEMICALS?
 	name = "red heave"
@@ -282,13 +282,13 @@
 	glass_name = "glass of murky pale green liquid"
 	glass_desc = "A murky pale green liquid. It occasionally frothes a bit and has a vile smell to it."
 
-/datum/reagent/consumable/ms13/redheave/on_mob_life(mob/living/carbon/M)
+/datum/reagent/consumable/ms13/redheave/on_mob_life(mob/living/carbon/M, delta_time, times_fired)
 	M.adjustOrganLoss(ORGAN_SLOT_STOMACH, rand(1,10))
 	to_chat(M, (span_cultboldtalic("It BURNS!")))
 	if(prob(25))
 		M.vomit(lost_nutrition = 10, distance = 2, purge_ratio = 0, blood = TRUE, harm = TRUE)
 	M.adjust_disgust(5)
-	..()
+	return ..()
 
 //// POWER GAMER brews- allegedly. ////
 
@@ -315,7 +315,7 @@
 	glass_name = "glass of pale-ish green liquid"
 	glass_desc = "A faint pale-ish green liquid with a bitter earthy smell."
 
-/datum/reagent/consumable/ms13/herb_brew/on_mob_life(mob/living/carbon/M)
+/datum/reagent/consumable/ms13/herb_brew/on_mob_life(mob/living/carbon/M, delta_time, times_fired)
 	M.adjustBruteLoss(-1)
 	M.AdjustAllImmobility(5)
 	..()

--- a/mojave/code/modules/reagents/consumables/drinks.dm
+++ b/mojave/code/modules/reagents/consumables/drinks.dm
@@ -1,11 +1,38 @@
-/datum/reagent/consumable/ms13
-	name = "Generic MS13 yummy liquid"
-	description = "Yeah probably skip out on this one chief."
-	color = "#7c7b7a"
-	quality = DRINK_NICE
-	glass_name = "glass of liquid" // Keep these generic for flavour!
-	glass_desc = "A pale coloured liquid. It screams 'PAIN'." // Same with this. Keep people guessin'. Make em know the drink via flavour and look for immersion.
-	glass_icon_state = null // None of this dumb nonsense. Glasses don't just morph based on liquid!
+// When You Code It //
+
+/datum/reagent/consumable/ms13/water // When you code it
+	name = "water"
+	description = "Water. The base of all life. Don't run out."
+	color = "#f1eeeca1"
+	quality = DRINK_VERYGOOD
+	taste_description = "water"
+	glass_name = "glass of clear liquid"
+	glass_desc = "A clear liquid with no smell. Nothing out of the ordinary."
+
+/datum/reagent/consumable/ms13/unfiltered_water
+	name = "Unfiltered Water"
+	description = "Water... Questionable water. Should run it through some filtering or something."
+	color = "#d8d3cfa1"
+	taste_description = "water with an off taste"
+	glass_name = "glass of clear liquid"
+	glass_desc = "A clear liquid with some stray particles seen floating around peacefully inside."
+
+/datum/reagent/consumable/ms13/dirty_water
+	name = "Dirty Water"
+	description = "An ubiquitous chemical substance that is composed of hydrogen and oxygen, this one is impure and toxic to drink."
+	color = "#4439288c"
+	taste_description = "vile water"
+	glass_name = "glass of murky liquid"
+	glass_desc = "A murky green liquid with a pungeant vile smell. Not so sure about this one."
+
+/datum/reagent/consumable/ms13/dirty_water/on_mob_life(mob/living/carbon/M)
+	M.adjust_disgust(10)
+	if(prob(50))
+		M.adjustToxLoss(5)
+
+	if(prob(10))
+		M.vomit(lost_nutrition = 25, distance = 1, purge_ratio = 0.2)
+	..()
 
 //// E for Everyone drinks - Soda/Beverages ////
 

--- a/mojave/code/modules/reagents/drugs.dm
+++ b/mojave/code/modules/reagents/drugs.dm
@@ -9,12 +9,12 @@
 /datum/reagent/ms13/buffout/on_mob_metabolize(mob/living/M)
 	M.maxHealth += 30 // These probably shouldn't ever be too high for the sake of balance. You're only human anyways afterall.
 	M.health += 30
-	..()
+	return ..()
 
 /datum/reagent/ms13/buffout/on_mob_delete(mob/living/M)
 	M.maxHealth -= 30
 	M.health -= 30
-	..()
+	return ..()
 
 /datum/reagent/ms13/buffout/overdose_start(mob/living/M)
 	. = ..()
@@ -32,7 +32,7 @@
 
 	M.drowsyness += 1
 	M.emote(pick("groan"))
-	..()
+	return ..()
 
 // Calmex //
 
@@ -42,10 +42,10 @@
 	color = "#BC13FE"
 	overdose_threshold = 30
 
-/datum/reagent/ms13/calmex/on_mob_life(mob/living/carbon/M)
+/datum/reagent/ms13/calmex/on_mob_life(mob/living/carbon/M, delta_time, times_fired)
 	if(current_cycle >= 5)
 		SEND_SIGNAL(M, COMSIG_ADD_MOOD_EVENT, "numb", /datum/mood_event/narcotic_medium, name)
-	..()
+	return ..()
 
 /datum/reagent/ms13/calmex/overdose_process(mob/living/M)
 	switch(current_cycle)
@@ -55,7 +55,7 @@
 			M.drowsyness += 1
 		if(24 to INFINITY)
 			M.Sleeping(40, 0)
-			..()
+			return ..()
 
 // Day Tripper //
 
@@ -67,24 +67,24 @@
 	addiction_types = list(/datum/addiction/ms13/daytripper = 25)
 
 /datum/reagent/ms13/day_tripper/on_mob_metabolize(mob/living/L)
-	..()
+	. = ..()
 	SEND_SIGNAL(L, COMSIG_ADD_MOOD_EVENT, "daytripper_drug", /datum/mood_event/happiness_drug)
 
 /datum/reagent/ms13/day_tripper/on_mob_delete(mob/living/L)
 	SEND_SIGNAL(L, COMSIG_CLEAR_MOOD_EVENT, "daytripper_drug")
-	..()
+	return ..()
 
-/datum/reagent/ms13/day_tripper/on_mob_life(mob/living/carbon/M)
+/datum/reagent/ms13/day_tripper/on_mob_life(mob/living/carbon/M, delta_time, times_fired)
 	M.set_drugginess(15)
 	M.jitteriness = 0
 	if(prob(7))
 		M.emote(pick("twitch","drool","moan","giggle"))
-	..()
+	return ..()
 
 /datum/reagent/ms13/day_tripper/overdose_process(mob/living/M)
 	M.adjust_disgust(2)
 	M.adjustOrganLoss(ORGAN_SLOT_BRAIN, 0.2)
-	..()
+	return ..()
 
 // Steady //
 
@@ -112,9 +112,9 @@
 
 /datum/reagent/ms13/hydra/on_mob_add(mob/living/M, amount)
 	to_chat(M, span_notice("Your insides start tingling slightly. You can feel things shifting."))
-	..()
+	return ..()
 
-/datum/reagent/ms13/hydra/on_mob_life(mob/living/carbon/M) // This needs to be unscuffed before we can use it. It WORKS. Just too well. Instant healing of wounds for as long as it's in your blood. I'm not qualified for this! help!
+/datum/reagent/ms13/hydra/on_mob_life(mob/living/carbon/M, delta_time, times_fired) // This needs to be unscuffed before we can use it. It WORKS. Just too well. Instant healing of wounds for as long as it's in your blood. I'm not qualified for this! help!
 	if(!isliving(M))
 		return
 
@@ -123,10 +123,9 @@
 		W.remove_wound()
 
 /datum/reagent/ms13/hydra/on_mob_delete(mob/living/carbon/human/M)
-	..()
+	. = ..()
 	if(isliving(M))
 		to_chat(M, span_notice("Everything seems back to normal now."))
-	..()
 
 // Jet //
 
@@ -148,7 +147,7 @@
 	M.add_movespeed_modifier(/datum/movespeed_modifier/reagent/ms13/jet)
 	if(isliving(M))
 		to_chat(M, span_userdanger("You feel an incredible pulsating high! You just absolutely love life in this moment!"))
-	..()
+	return ..()
 
 /datum/reagent/ms13/jet/on_mob_delete(mob/living/carbon/human/M)
 	if(!M.hud_used)
@@ -158,14 +157,14 @@
 	M.remove_movespeed_modifier(/datum/movespeed_modifier/reagent/ms13/jet)
 	if(isliving(M))
 		to_chat(M, span_userdanger("You come down from your high. Maybe you should go get some more?"))
-	..()
+	return ..()
 
-/datum/reagent/ms13/jet/on_mob_life(mob/living/carbon/M)
+/datum/reagent/ms13/jet/on_mob_life(mob/living/carbon/M, delta_time, times_fired)
 	M.adjustStaminaLoss(-2.5, 0)
 	M.setOrganLoss(ORGAN_SLOT_LUNGS, rand(0.25, 2))
 	if(prob(12))
 		M.emote(pick("drool", "moan", "chuckle"))
-	..()
+	return ..()
 
 /datum/reagent/ms13/jet/overdose_start(mob/living/M)
 	to_chat(M, span_userdanger("You start tripping hard!"))
@@ -174,7 +173,7 @@
 /datum/reagent/ms13/jet/overdose_process(mob/living/M)
 	M.hallucination += 10
 	M.adjustOrganLoss(ORGAN_SLOT_LUNGS, rand(0.25,5))
-	..()
+	return ..()
 
 // Rocket //
 
@@ -196,7 +195,7 @@
 	M.add_movespeed_modifier(/datum/movespeed_modifier/reagent/ms13/rocket)
 	if(isliving(M))
 		to_chat(M, span_userdanger("You feel an incredible high! But feel very focused..."))
-	..()
+	return ..()
 
 /datum/reagent/ms13/rocket/on_mob_delete(mob/living/carbon/human/M)
 	if(!M.hud_used)
@@ -207,9 +206,9 @@
 
 	if(isliving(M))
 		to_chat(M, span_userdanger("You come down from your high. Everything seems back to normal."))
-	..()
+	return ..()
 
-/datum/reagent/ms13/rocket/on_mob_life(mob/living/carbon/M)
+/datum/reagent/ms13/rocket/on_mob_life(mob/living/carbon/M, delta_time, times_fired)
 	M.adjustStaminaLoss(-5, 0)
 	M.setOrganLoss(ORGAN_SLOT_LUNGS, rand(0.25, 1))
 	if(prob(12))
@@ -222,7 +221,7 @@
 /datum/reagent/ms13/rocket/overdose_process(mob/living/M)
 	M.hallucination += 10
 	M.adjustOrganLoss(ORGAN_SLOT_LUNGS, rand(2,8))
-	..()
+	return ..()
 
 // Turbo //
 
@@ -244,7 +243,7 @@
 	M.sound_environment_override = SOUND_ENVIRONMENT_DRUGGED
 	if(isliving(M))
 		to_chat(M, span_notice("The world around you begins to slow down."))
-	..()
+	return ..()
 
 /datum/reagent/ms13/turbo/on_mob_delete(mob/living/carbon/human/M)
 	if(!M.hud_used)
@@ -255,23 +254,23 @@
 	M.sound_environment_override = NONE
 	if(isliving(M))
 		to_chat(M, span_notice("The world around you starts speeding up again."))
-	..()
+	return ..()
 
-/datum/reagent/ms13/turbo/on_mob_life(mob/living/carbon/M)
+/datum/reagent/ms13/turbo/on_mob_life(mob/living/carbon/M, delta_time, times_fired)
 	M.setOrganLoss(ORGAN_SLOT_LUNGS, rand(0.25, 2))
 	if(prob(12))
 		M.emote(pick("stare", "glare"))
-	..()
+	return ..()
 
 /datum/reagent/ms13/turbo/overdose_start(mob/living/M)
 	to_chat(M, span_userdanger("You start tripping hard!"))
 	SEND_SIGNAL(M, COMSIG_ADD_MOOD_EVENT, "[type]_overdose", /datum/mood_event/overdose, name)
-	..()
+	return ..()
 
 /datum/reagent/ms13/turbo/overdose_process(mob/living/M)
 	M.hallucination += 10
 	M.adjustOrganLoss(ORGAN_SLOT_LUNGS, rand(0.25,5))
-	..()
+	return ..()
 
 // Mentats //
 
@@ -286,7 +285,7 @@
 	C.adjustOrganLoss(ORGAN_SLOT_BRAIN, -2*REM)
 	if(prob(15))
 		C.cure_trauma_type(resilience = TRAUMA_RESILIENCE_BASIC)
-	..()
+	return ..()
 
 /datum/reagent/ms13/mentats/overdose_process(mob/living/carbon/M)
 	M.Jitter(3)
@@ -300,7 +299,7 @@
 	if(prob(1))
 		to_chat(M, span_userdanger("You feel something within your head snap."))
 		M.gain_trauma_type(BRAIN_TRAUMA_MILD, TRAUMA_RESILIENCE_ABSOLUTE)
-	..()
+	return ..()
 
 // Psycho //
 
@@ -324,7 +323,7 @@
 	if(prob(25))
 		M.adjustOrganLoss(ORGAN_SLOT_HEART, )
 	M.visible_message(span_danger("[M]'s eyes go empty, with their face quickly shifting to a scorn"), span_narsiesmall("Your mind suddenly begins to drift- you begin to feel ANGRY."))
-	..()
+	return ..()
 
 /datum/reagent/ms13/psycho/on_mob_end_metabolize(mob/living/M)
 	REMOVE_TRAIT(M, TRAIT_STUNIMMUNE, type)
@@ -333,11 +332,11 @@
 	if(rage)
 		QDEL_NULL(rage)
 	M.clear_fullscreen("psycho")
-	..()
+	return ..()
 
 /datum/reagent/ms13/psycho/overdose_start(mob/living/M)
 	to_chat(M, span_narsiesmall("YOU FEEL AN INSATIABLE BLOODLUST!"))
-	..()
+	return ..()
 
 /datum/reagent/ms13/psycho/overdose_process(mob/living/M)
 	M.Jitter(10)
@@ -346,13 +345,13 @@
 		M.emote(pick("twitch", "shiver"))
 	if(prob(15))
 		M.adjustToxLoss(2, 0)
-	..()
+	return ..()
 
 /datum/reagent/ms13/psycho/on_mob_life(mob/living/M)
 	SEND_SIGNAL(M, COMSIG_ADD_MOOD_EVENT, "gone_psycho", /datum/mood_event/stimulant_heavy, name)
 	M.adjustOrganLoss(ORGAN_SLOT_HEART, 0.25)
 	M.hallucination += 5
-	..()
+	return ..()
 
 // Rebound //
 
@@ -372,7 +371,7 @@
 	var/datum/brain_trauma/special/psychotic_brawling/bath_salts/rage
 
 /datum/reagent/ms13/overdrive/on_mob_metabolize(mob/living/M)
-	..()
+	. = ..()
 	ADD_TRAIT(M, TRAIT_STUNIMMUNE, type)
 	ADD_TRAIT(M, TRAIT_SLEEPIMMUNE, type)
 	ADD_TRAIT(M, TRAIT_NOSOFTCRIT, TRAUMA_TRAIT)
@@ -393,7 +392,7 @@
 	if(rage)
 		QDEL_NULL(rage)
 	M.clear_fullscreen("overdrive")
-	..()
+	return ..()
 
 /datum/reagent/ms13/overdrive/overdose_start(mob/living/M)
 	M.emote("scream")
@@ -402,7 +401,7 @@
 	REMOVE_TRAIT(M, TRAIT_STUNIMMUNE, type)
 	REMOVE_TRAIT(M, TRAIT_SLEEPIMMUNE, type)
 	M.Stun(25)
-	..()
+	return ..()
 
 /datum/reagent/ms13/overdrive/overdose_process(mob/living/carbon/M)
 	if(prob(35)) // panic
@@ -413,7 +412,7 @@
 	M.emote(pick("twitch", "shiver"))
 	M.adjustOrganLoss(ORGAN_SLOT_BRAIN, rand(1, 5))
 	addtimer(CALLBACK(src, .proc/heartsplosion, M), rand(1, 5) SECONDS) // We want to delay the actual removal of the heart a tiny bit so people can get out a "Oh damn" or something. You go ZZZzzz mode the second you don't have one.
-	..()
+	return ..()
 
 /datum/reagent/ms13/overdrive/proc/heartsplosion(mob/living/carbon/M)
 	var/obj/item/organ/heart/our_heart = M.getorganslot(ORGAN_SLOT_HEART)
@@ -425,7 +424,7 @@
 	if(prob(25))
 		M.adjustOrganLoss(ORGAN_SLOT_BRAIN, rand(1, 5))
 	M.hallucination += 10
-	..()
+	return ..()
 
 // Addictol //
 
@@ -436,7 +435,7 @@
 	overdose_threshold = 10
 
 /datum/reagent/ms13/addictol/on_mob_metabolize(mob/living/carbon/M)
-	..()
+	. = ..()
 	if(M.mind)
 		for(var/addiction_type in subtypesof(/datum/addiction))
 			M.mind.remove_addiction_points(addiction_type, MAX_ADDICTION_POINTS) //Remove addictions
@@ -450,11 +449,11 @@
 */
 /datum/reagent/ms13/addictol/overdose_process(mob/living/carbon/M)
 	M.adjustToxLoss(5, 0)
-	..()
+	return ..()
 
 /datum/reagent/ms13/addictol/on_mob_life(mob/living/M)
 	M.adjustToxLoss(2, 0)
-	..()
+	return ..()
 
 /////// Movespeed Modifiers ///////
 

--- a/mojave/code/modules/reagents/drugs.dm
+++ b/mojave/code/modules/reagents/drugs.dm
@@ -1,9 +1,10 @@
-//UNCRAFTABLE (MUST BE SCAVENGED)
+// Buffout //
+
 /datum/reagent/ms13/buffout
 	name = "Buffout"
 	description = "A highly potent anabolic steroid popular before the war with athletes. Causes mild liver and heart damage."
 	color = "#60A584" // rgb: 96, 165, 132
-	overdose_threshold = 1
+	overdose_threshold = 25
 
 /datum/reagent/ms13/buffout/on_mob_metabolize(mob/living/M)
 	M.maxHealth += 30
@@ -65,36 +66,25 @@
 	color = "#60A584" // rgb: 96, 165, 132
 	overdose_threshold = 30
 
-// Smooch //
-
-/datum/reagent/ms13/smooch
-	name = "Smooch"
-	description = "A novel smokable from Northern Nevada. Tastes terrible, but causes mellowness and ecstacy. Prolonged use causes extreme brain damage."
-	color = "#65FF00"
-	overdose_threshold = 20
-	taste_description = "putrid death"
-
-/datum/reagent/ms13/smooch/on_mob_metabolize(mob/living/L)
+/datum/reagent/ms13/day_tripper/on_mob_metabolize(mob/living/L)
 	..()
 	SEND_SIGNAL(L, COMSIG_ADD_MOOD_EVENT, "smooch_drug", /datum/mood_event/happiness_drug)
 
-/datum/reagent/ms13/smooch/on_mob_delete(mob/living/L)
+/datum/reagent/ms13/day_tripper/on_mob_delete(mob/living/L)
 	SEND_SIGNAL(L, COMSIG_CLEAR_MOOD_EVENT, "smooch_drug")
 	..()
 
-/datum/reagent/ms13/smooch/on_mob_life(mob/living/carbon/M)
+/datum/reagent/ms13/day_tripper/on_mob_life(mob/living/carbon/M)
 	M.set_drugginess(15)
 	M.jitteriness = 0
-	M.adjustOrganLoss(ORGAN_SLOT_BRAIN, 0.2)
 	if(prob(7))
 		M.emote(pick("twitch","drool","moan","giggle"))
 	..()
 	. = 1
 
-/datum/reagent/ms13/smooch/overdose_process(mob/living/M)
-	M.adjustOrganLoss(ORGAN_SLOT_BRAIN, 0.5)
-	M.adjustToxLoss(0.5, 0)
+/datum/reagent/ms13/day_tripper/overdose_process(mob/living/M)
 	M.adjust_disgust(2)
+	M.adjustOrganLoss(ORGAN_SLOT_BRAIN, 0.2)
 	..()
 	. = 1
 
@@ -139,16 +129,16 @@
 /datum/reagent/ms13/hydra/on_mob_delete(mob/living/carbon/human/M)
 	..()
 	if(isliving(M))
-		to_chat(M, span_notice("Your insides halt to a stop. Everything seems back to normal now."))
+		to_chat(M, span_notice("Everything seems back to normal now."))
 
 // Jet //
 
 /datum/reagent/ms13/jet
 	name = "Jet"
 	description = "A highly addictive substance. Causes lung damage and addiction."
-	color = "#60A584" // rgb: 96, 165, 132
-	overdose_threshold = 30
-	addiction_types = list(/datum/addiction/ms13/jet = 35)
+	color = "#ca4f4f"
+	overdose_threshold = 45
+	addiction_types = list(/datum/addiction/ms13/jet = 65)
 
 /datum/reagent/ms13/jet/on_mob_add(mob/living/carbon/human/M)
 	..()
@@ -167,14 +157,14 @@
 	var/atom/movable/plane_master_controller/game_plane_master_controller = M.hud_used.plane_master_controllers[PLANE_MASTERS_GAME]
 	game_plane_master_controller.remove_filter("jet_blur")
 	M.remove_movespeed_modifier(/datum/movespeed_modifier/reagent/ms13/jet)
-
 	if(isliving(M))
 		to_chat(M, span_userdanger("You come down from your high. Maybe you should go get some more?"))
 
 /datum/reagent/ms13/jet/on_mob_life(mob/living/carbon/M)
+	M.adjustStaminaLoss(-2.5, 0)
 	M.setOrganLoss(ORGAN_SLOT_LUNGS, rand(0.25, 2))
 	if(prob(12))
-		M.emote(pick("twitch", "drool", "moan", "giggle"))
+		M.emote(pick("drool", "moan", "chuckle"))
 	..()
 
 /datum/reagent/ms13/jet/overdose_start(mob/living/M)
@@ -191,9 +181,9 @@
 /datum/reagent/ms13/rocket
 	name = "Rocket"
 	description = "A variant of jet. Has more potent combat properties, but carries a higher risk of addiction."
-	color = "#60A584" // rgb: 96, 165, 132
+	color = "#a35353"
 	overdose_threshold = 30
-	addiction_types = list(/datum/addiction/ms13/rocket = 45)
+	addiction_types = list(/datum/addiction/ms13/rocket = 75)
 
 /datum/reagent/ms13/rocket/on_mob_add(mob/living/carbon/human/M)
 	..()
@@ -217,8 +207,7 @@
 		to_chat(M, span_userdanger("You come down from your high. Everything seems back to normal."))
 
 /datum/reagent/ms13/rocket/on_mob_life(mob/living/carbon/M)
-	M.adjustStaminaLoss(-20, 0)
-	M.AdjustAllImmobility(-5)
+	M.adjustStaminaLoss(-5, 0)
 	M.setOrganLoss(ORGAN_SLOT_LUNGS, rand(0.25, 1))
 	if(prob(12))
 		M.emote(pick("twitch","drool","moan"))
@@ -232,6 +221,50 @@
 	M.adjustOrganLoss(ORGAN_SLOT_LUNGS, rand(2,8))
 	..()
 
+// Turbo //
+
+/datum/reagent/ms13/turbo
+	name = "Turbo"
+	description = "Jet mixed with cazador poison and hairspray. Results in extremely strong Jet effects."
+	color = "#be8585"
+	overdose_threshold = 30
+	addiction_types = list(/datum/addiction/ms13/turbo = 65)
+
+/datum/reagent/ms13/turbo/on_mob_add(mob/living/carbon/human/M)
+	..()
+	var/rotation = min(round(current_cycle/20), 89) // wiggle wiggle. Don't even mention where you've seen this before.
+	var/atom/movable/plane_master_controller/game_plane_master_controller = M.hud_used.plane_master_controllers[PLANE_MASTERS_GAME]
+	game_plane_master_controller.add_filter("turbo_wave", 1, list("type" = "wave", "x" = 32, "y" = 32))
+	for(var/filter in game_plane_master_controller.get_filters("turbo_wave"))
+		animate(filter = matrix(-rotation, MATRIX_ROTATE), time = 5, easing = QUAD_EASING)
+		animate(filter, time = 32 SECONDS, loop = -1, easing = LINEAR_EASING, offset = 32, flags = ANIMATION_PARALLEL)
+	M.add_movespeed_modifier(/datum/movespeed_modifier/reagent/ms13/turbo)
+	M.sound_environment_override = SOUND_ENVIRONMENT_DRUGGED
+	if(isliving(M))
+		to_chat(M, span_notice("The world around you begins to slow down."))
+
+/datum/reagent/ms13/turbo/on_mob_delete(mob/living/carbon/human/M)
+	..()
+	var/atom/movable/plane_master_controller/game_plane_master_controller = M.hud_used.plane_master_controllers[PLANE_MASTERS_GAME]
+	game_plane_master_controller.remove_filter("turbo_wave")
+	M.remove_movespeed_modifier(/datum/movespeed_modifier/reagent/ms13/turbo)
+	M.sound_environment_override = NONE
+	if(isliving(M))
+		to_chat(M, span_notice("The world around you starts speeding up again."))
+
+/datum/reagent/ms13/turbo/on_mob_life(mob/living/carbon/M)
+	M.setOrganLoss(ORGAN_SLOT_LUNGS, rand(0.25, 2))
+	if(prob(12))
+		M.emote(pick("stare", "glare"))
+	..()
+
+/datum/reagent/ms13/turbo/overdose_start(mob/living/M)
+	to_chat(M, span_userdanger("You start tripping hard!"))
+	SEND_SIGNAL(M, COMSIG_ADD_MOOD_EVENT, "[type]_overdose", /datum/mood_event/overdose, name)
+
+/datum/reagent/ms13/turbo/overdose_process(mob/living/M)
+	M.hallucination += 10
+	M.adjustOrganLoss(ORGAN_SLOT_LUNGS, rand(0.25,5))
 	..()
 
 // Mentats //
@@ -268,9 +301,9 @@
 /datum/reagent/ms13/psycho //military grade bath salts? SIGN ME AND THE REST OF AMERICA THE FUCK UP!
 	name = "Psycho"
 	description = "A military grade amphetamine. Causes increased strength and endurance, but induces a powerful psychosis."
-	color = "#60A584" // rgb: 96, 165, 132
+	color = "#cf6060"
 	overdose_threshold = 20
-	addiction_types = list(/datum/addiction/ms13/psycho = 25)
+	addiction_types = list(/datum/addiction/ms13/psycho = 75)
 	var/datum/brain_trauma/special/psychotic_brawling/bath_salts/rage
 
 /datum/reagent/ms13/psycho/on_mob_metabolize(mob/living/M)
@@ -278,8 +311,6 @@
 	ADD_TRAIT(M, TRAIT_STUNIMMUNE, type)
 	ADD_TRAIT(M, TRAIT_SLEEPIMMUNE, type)
 	M.apply_status_effect(STATUS_EFFECT_SPASMS)
-	M.maxHealth += 25
-	M.health += 25
 	if(iscarbon(M))
 		var/mob/living/carbon/C = M
 		rage = new()
@@ -287,13 +318,12 @@
 	M.overlay_fullscreen("psycho", /atom/movable/screen/fullscreen/color_vision/red)
 	if(prob(25))
 		M.adjustOrganLoss(ORGAN_SLOT_HEART, )
+	M.visible_message(span_danger("[M]'s eyes go empty, with their face quickly shifting to a scorn"), span_narsiesmall("Your mind suddenly begins to drift- you begin to feel ANGRY."))
 
 /datum/reagent/ms13/psycho/on_mob_end_metabolize(mob/living/M)
 	REMOVE_TRAIT(M, TRAIT_STUNIMMUNE, type)
 	REMOVE_TRAIT(M, TRAIT_SLEEPIMMUNE, type)
 	M.remove_status_effect(STATUS_EFFECT_SPASMS)
-	M.maxHealth -= 25
-	M.health -= 25
 	if(rage)
 		QDEL_NULL(rage)
 	M.clear_fullscreen("psycho")
@@ -305,51 +335,24 @@
 /datum/reagent/ms13/psycho/overdose_process(mob/living/M)
 	M.Jitter(10)
 	M.adjustOrganLoss(ORGAN_SLOT_HEART, 0.5)
-	if(prob(5))
-		M.drop_all_held_items()
 	if(prob(15))
-		M.emote(pick("scream","twitch"))
+		M.emote(pick("twitch", "shiver"))
 	if(prob(15))
-		M.adjustToxLoss(3, 0)
+		M.adjustToxLoss(2, 0)
 	..()
 
 /datum/reagent/ms13/psycho/on_mob_life(mob/living/M)
 	SEND_SIGNAL(M, COMSIG_ADD_MOOD_EVENT, "gone_psycho", /datum/mood_event/stimulant_heavy, name)
-	M.adjustOrganLoss(ORGAN_SLOT_HEART, 1)
+	M.adjustOrganLoss(ORGAN_SLOT_HEART, 0.25)
 	M.hallucination += 5
 	..()
 	. = 1
-
 
 // Rebound //
 
 /datum/reagent/ms13/rebound
 	name = "Rebound"
 	description = "A powerful mix of adrenaline and liquid Jet. Makes the user faster, but causes considerable heart damage."
-	color = "#60A584" // rgb: 96, 165, 132
-	overdose_threshold = 30
-
-// Turbo //
-
-/datum/reagent/ms13/turbo
-	name = "Turbo"
-	description = "Jet mixed with cazador poison and hairspray. Results in extremely strong Jet effects."
-	color = "#60A584" // rgb: 96, 165, 132
-	overdose_threshold = 30
-
-// Voodoo //
-
-/datum/reagent/ms13/voodoo
-	name = "Voodoo"
-	description = "A potent mix of animal venoms and alcohol. Results in numbness that reduces damage."
-	color = "#60A584" // rgb: 96, 165, 132
-	overdose_threshold = 30
-
-// Mutie //
-
-/datum/reagent/ms13/mutie
-	name = "Mutie"
-	description = "A potent mutagenic serum that causes random mutations."
 	color = "#60A584" // rgb: 96, 165, 132
 	overdose_threshold = 30
 
@@ -360,16 +363,76 @@
 	description = "A modified version of Psycho, designed to produce a stronger effect. Extremely dangerous."
 	color = "#60A584" // rgb: 96, 165, 132
 	overdose_threshold = 30
+	var/datum/brain_trauma/special/psychotic_brawling/bath_salts/rage
+
+/datum/reagent/ms13/overdrive/on_mob_metabolize(mob/living/M)
+	..()
+	ADD_TRAIT(M, TRAIT_STUNIMMUNE, type)
+	ADD_TRAIT(M, TRAIT_SLEEPIMMUNE, type)
+	ADD_TRAIT(M, TRAIT_NOSOFTCRIT, TRAUMA_TRAIT)
+	ADD_TRAIT(M, TRAIT_NOHARDCRIT, TRAUMA_TRAIT)
+	M.apply_status_effect(STATUS_EFFECT_SPASMS)
+	if(iscarbon(M))
+		var/mob/living/carbon/C = M
+		rage = new()
+		C.gain_trauma(rage, TRAUMA_RESILIENCE_ABSOLUTE)
+	M.overlay_fullscreen("overdrive", /atom/movable/screen/fullscreen/color_vision/red)
+
+/datum/reagent/ms13/overdrive/on_mob_end_metabolize(mob/living/M)
+	REMOVE_TRAIT(M, TRAIT_STUNIMMUNE, type)
+	REMOVE_TRAIT(M, TRAIT_SLEEPIMMUNE, type)
+	REMOVE_TRAIT(M, TRAIT_NOSOFTCRIT, TRAUMA_TRAIT)
+	REMOVE_TRAIT(M, TRAIT_NOHARDCRIT, TRAUMA_TRAIT)
+	M.remove_status_effect(STATUS_EFFECT_SPASMS)
+	if(rage)
+		QDEL_NULL(rage)
+	M.clear_fullscreen("overdrive")
+	..()
+
+/datum/reagent/ms13/overdrive/overdose_start(mob/living/M)
+	M.emote("scream")
+	M.drop_all_held_items()
+	M.visible_message(span_userdanger("[M]'s chest produces an audible pop. They look visibly stunned and in pain."), span_userdanger("A pop is heard coming from your chest and sudden pain appears- It's INTOLERABLE! What happened?"), span_hear("You hear a pop."))
+	REMOVE_TRAIT(M, TRAIT_STUNIMMUNE, type)
+	REMOVE_TRAIT(M, TRAIT_SLEEPIMMUNE, type)
+	M.Stun(25)
+
+/datum/reagent/ms13/overdrive/overdose_process(mob/living/carbon/M)
+	if(prob(35)) // panic
+		to_chat(M, span_userdanger("[pick("OH SHIT!", "THE PAIN!", "AGHHHH!", "OH GOD IT HURTS!")]"))
+	if(prob(10))
+		M.vomit(25, TRUE ,TRUE)
+	M.Jitter(20)
+	M.emote(pick("twitch", "shiver"))
+	M.adjustOrganLoss(ORGAN_SLOT_BRAIN, rand(1, 5))
+	addtimer(CALLBACK(src, .proc/heartsplosion, M), rand(1, 5) SECONDS) // We want to delay the actual removal of the heart a tiny bit so people can get out a "Oh damn" or something. You go ZZZzzz mode the second you don't have one.
+	..()
+
+/datum/reagent/ms13/overdrive/proc/heartsplosion(mob/living/carbon/M)
+	var/obj/item/organ/heart/our_heart = M.getorganslot(ORGAN_SLOT_HEART)
+	qdel(our_heart)
+	M.visible_message(span_notice("[M] looks faint and begins to close their eyes."), span_alert("This doesn't feel good at all..."))
+
+/datum/reagent/ms13/overdrive/on_mob_life(mob/living/M)
+	SEND_SIGNAL(M, COMSIG_ADD_MOOD_EVENT, "gone_OVERDRIVE", /datum/mood_event/stimulant_heavy, name)
+	if(prob(25))
+		M.adjustOrganLoss(ORGAN_SLOT_BRAIN, rand(1, 5))
+	M.hallucination += 10
+	..()
+	. = 1
 
 /////// Movespeed Modifiers ///////
 
 /datum/movespeed_modifier/reagent/ms13
 
 /datum/movespeed_modifier/reagent/ms13/jet
-	multiplicative_slowdown = -0.10
+	multiplicative_slowdown = -0.1
 
 /datum/movespeed_modifier/reagent/ms13/rocket
-	multiplicative_slowdown = -0.15
+	multiplicative_slowdown = -0.2
 
 /datum/movespeed_modifier/reagent/ms13/turbo
-	multiplicative_slowdown = -0.25
+	multiplicative_slowdown = -0.35
+
+/datum/movespeed_modifier/reagent/ms13/turbo_slow
+	multiplicative_slowdown = 0.35

--- a/mojave/code/modules/reagents/drugs.dm
+++ b/mojave/code/modules/reagents/drugs.dm
@@ -3,7 +3,7 @@
 /datum/reagent/ms13/buffout
 	name = "Buffout"
 	description = "A highly potent anabolic steroid popular before the war with athletes. Causes mild liver and heart damage."
-	color = "#60A584" // rgb: 96, 165, 132
+	color = "#a19f7c"
 	overdose_threshold = 25
 
 /datum/reagent/ms13/buffout/on_mob_metabolize(mob/living/M)
@@ -39,7 +39,7 @@
 /datum/reagent/ms13/calmex //useful for surgery allegedly
 	name = "Calmex"
 	description = "A light anaesthetic. Reduces inhibitions and dulls the senses."
-	color = "#BC13FE" // rgb: 96, 165, 132
+	color = "#BC13FE"
 	overdose_threshold = 30
 
 /datum/reagent/ms13/calmex/on_mob_life(mob/living/carbon/M)
@@ -55,16 +55,16 @@
 			M.drowsyness += 1
 		if(24 to INFINITY)
 			M.Sleeping(40, 0)
-			. = 1
-	..()
+			..()
 
 // Day Tripper //
 
 /datum/reagent/ms13/day_tripper
 	name = "Day Tripper"
 	description = "A mild hallucinogen. Helps take the edge off, but weakens muscles."
-	color = "#60A584" // rgb: 96, 165, 132
+	color = "#94b8cc"
 	overdose_threshold = 30
+	addiction_types = list(/datum/addiction/ms13/daytripper = 25)
 
 /datum/reagent/ms13/day_tripper/on_mob_metabolize(mob/living/L)
 	..()
@@ -80,20 +80,18 @@
 	if(prob(7))
 		M.emote(pick("twitch","drool","moan","giggle"))
 	..()
-	. = 1
 
 /datum/reagent/ms13/day_tripper/overdose_process(mob/living/M)
 	M.adjust_disgust(2)
 	M.adjustOrganLoss(ORGAN_SLOT_BRAIN, 0.2)
 	..()
-	. = 1
 
 // Steady //
 
 /datum/reagent/ms13/steady
 	name = "Steady"
 	description = "A military grade relaxant. Reduces weapon sway and increases effective accuracy, but carries a severe risk of addiction."
-	color = "#60A584" // rgb: 96, 165, 132
+	color = "#665355"
 	overdose_threshold = 30
 
 // X-Cell //
@@ -101,7 +99,7 @@
 /datum/reagent/ms13/x_cell
 	name = "X-Cell"
 	description = "A general purpose performance enhancer. Gives a general boost to all SPECIAL stats, but with a high risk of addiction."
-	color = "#60A584" // rgb: 96, 165, 132
+	color = "#766494"
 	overdose_threshold = 30
 
 // Hydra //
@@ -109,16 +107,14 @@
 /datum/reagent/ms13/hydra
 	name = "Hydra"
 	description = "A curative agent that anaesthetises and restores crippled limbs. Causes heart damage."
-	color = "#60A584" // rgb: 96, 165, 132
+	color = "#60A584"
 	overdose_threshold = 30
 
 /datum/reagent/ms13/hydra/on_mob_add(mob/living/M, amount)
-	. = ..()
 	to_chat(M, span_notice("Your insides start tingling slightly. You can feel things shifting."))
+	..()
 
 /datum/reagent/ms13/hydra/on_mob_life(mob/living/carbon/M) // This needs to be unscuffed before we can use it. It WORKS. Just too well. Instant healing of wounds for as long as it's in your blood. I'm not qualified for this! help!
-	. = ..()
-	..()
 	if(!isliving(M))
 		return
 
@@ -130,6 +126,7 @@
 	..()
 	if(isliving(M))
 		to_chat(M, span_notice("Everything seems back to normal now."))
+	..()
 
 // Jet //
 
@@ -138,10 +135,9 @@
 	description = "A highly addictive substance. Causes lung damage and addiction."
 	color = "#ca4f4f"
 	overdose_threshold = 45
-	addiction_types = list(/datum/addiction/ms13/jet = 65)
+	addiction_types = list(/datum/addiction/ms13/jet = 45)
 
 /datum/reagent/ms13/jet/on_mob_add(mob/living/carbon/human/M)
-	..()
 	var/atom/movable/plane_master_controller/game_plane_master_controller = M.hud_used.plane_master_controllers[PLANE_MASTERS_GAME]
 	game_plane_master_controller.add_filter("jet_blur", 1, list("type" = "radial_blur", "size" = 0))
 	M.add_movespeed_modifier(/datum/movespeed_modifier/reagent/ms13/jet)
@@ -151,14 +147,15 @@
 		animate(size = 0, time = 6 SECONDS, easing = CIRCULAR_EASING|EASE_IN)
 	if(isliving(M))
 		to_chat(M, span_userdanger("You feel an incredible pulsating high! You just absolutely love life in this moment!"))
+	..()
 
 /datum/reagent/ms13/jet/on_mob_delete(mob/living/carbon/human/M)
-	..()
 	var/atom/movable/plane_master_controller/game_plane_master_controller = M.hud_used.plane_master_controllers[PLANE_MASTERS_GAME]
 	game_plane_master_controller.remove_filter("jet_blur")
 	M.remove_movespeed_modifier(/datum/movespeed_modifier/reagent/ms13/jet)
 	if(isliving(M))
 		to_chat(M, span_userdanger("You come down from your high. Maybe you should go get some more?"))
+	..()
 
 /datum/reagent/ms13/jet/on_mob_life(mob/living/carbon/M)
 	M.adjustStaminaLoss(-2.5, 0)
@@ -183,10 +180,9 @@
 	description = "A variant of jet. Has more potent combat properties, but carries a higher risk of addiction."
 	color = "#a35353"
 	overdose_threshold = 30
-	addiction_types = list(/datum/addiction/ms13/rocket = 75)
+	addiction_types = list(/datum/addiction/ms13/rocket = 40)
 
 /datum/reagent/ms13/rocket/on_mob_add(mob/living/carbon/human/M)
-	..()
 	var/atom/movable/plane_master_controller/game_plane_master_controller = M.hud_used.plane_master_controllers[PLANE_MASTERS_GAME]
 	game_plane_master_controller.add_filter("rocket_blur", 1, list("type" = "radial_blur", "size" = 0))
 	M.add_movespeed_modifier(/datum/movespeed_modifier/reagent/ms13/rocket)
@@ -196,15 +192,16 @@
 		animate(size = 0, time = 6 SECONDS, easing = JUMP_EASING|EASE_IN)
 	if(isliving(M))
 		to_chat(M, span_userdanger("You feel an incredible high! But feel very focused..."))
+	..()
 
 /datum/reagent/ms13/rocket/on_mob_delete(mob/living/carbon/human/M)
-	..()
 	var/atom/movable/plane_master_controller/game_plane_master_controller = M.hud_used.plane_master_controllers[PLANE_MASTERS_GAME]
 	game_plane_master_controller.remove_filter("rocket_blur")
 	M.remove_movespeed_modifier(/datum/movespeed_modifier/reagent/ms13/jet)
 
 	if(isliving(M))
 		to_chat(M, span_userdanger("You come down from your high. Everything seems back to normal."))
+	..()
 
 /datum/reagent/ms13/rocket/on_mob_life(mob/living/carbon/M)
 	M.adjustStaminaLoss(-5, 0)
@@ -228,10 +225,9 @@
 	description = "Jet mixed with cazador poison and hairspray. Results in extremely strong Jet effects."
 	color = "#be8585"
 	overdose_threshold = 30
-	addiction_types = list(/datum/addiction/ms13/turbo = 65)
+	addiction_types = list(/datum/addiction/ms13/turbo = 35)
 
 /datum/reagent/ms13/turbo/on_mob_add(mob/living/carbon/human/M)
-	..()
 	var/atom/movable/plane_master_controller/game_plane_master_controller = M.hud_used.plane_master_controllers[PLANE_MASTERS_GAME]
 	game_plane_master_controller.add_filter("turbo_wave", 1, list("type" = "wave", "x" = 32, "y" = 32))
 	for(var/filter in game_plane_master_controller.get_filters("turbo_wave"))
@@ -240,15 +236,16 @@
 	M.sound_environment_override = SOUND_ENVIRONMENT_DRUGGED
 	if(isliving(M))
 		to_chat(M, span_notice("The world around you begins to slow down."))
+	..()
 
 /datum/reagent/ms13/turbo/on_mob_delete(mob/living/carbon/human/M)
-	..()
 	var/atom/movable/plane_master_controller/game_plane_master_controller = M.hud_used.plane_master_controllers[PLANE_MASTERS_GAME]
 	game_plane_master_controller.remove_filter("turbo_wave")
 	M.remove_movespeed_modifier(/datum/movespeed_modifier/reagent/ms13/turbo)
 	M.sound_environment_override = NONE
 	if(isliving(M))
 		to_chat(M, span_notice("The world around you starts speeding up again."))
+	..()
 
 /datum/reagent/ms13/turbo/on_mob_life(mob/living/carbon/M)
 	M.setOrganLoss(ORGAN_SLOT_LUNGS, rand(0.25, 2))
@@ -259,6 +256,7 @@
 /datum/reagent/ms13/turbo/overdose_start(mob/living/M)
 	to_chat(M, span_userdanger("You start tripping hard!"))
 	SEND_SIGNAL(M, COMSIG_ADD_MOOD_EVENT, "[type]_overdose", /datum/mood_event/overdose, name)
+	..()
 
 /datum/reagent/ms13/turbo/overdose_process(mob/living/M)
 	M.hallucination += 10
@@ -270,7 +268,7 @@
 /datum/reagent/ms13/mentats
 	name = "Mentat powder"
 	description = "A powerful nootropic that increases mental faculties and cures brain damage, but increases thirst."
-	color = "#60A584" // rgb: 96, 165, 132
+	color = "#a0dfe7"
 	overdose_threshold = 30
 	addiction_types = list(/datum/addiction/ms13/mentats = 25)
 
@@ -301,11 +299,10 @@
 	description = "A military grade amphetamine. Causes increased strength and endurance, but induces a powerful psychosis."
 	color = "#cf6060"
 	overdose_threshold = 20
-	addiction_types = list(/datum/addiction/ms13/psycho = 75)
+	addiction_types = list(/datum/addiction/ms13/psycho = 35)
 	var/datum/brain_trauma/special/psychotic_brawling/bath_salts/rage
 
 /datum/reagent/ms13/psycho/on_mob_metabolize(mob/living/M)
-	..()
 	ADD_TRAIT(M, TRAIT_STUNIMMUNE, type)
 	ADD_TRAIT(M, TRAIT_SLEEPIMMUNE, type)
 	M.apply_status_effect(STATUS_EFFECT_SPASMS)
@@ -317,6 +314,7 @@
 	if(prob(25))
 		M.adjustOrganLoss(ORGAN_SLOT_HEART, )
 	M.visible_message(span_danger("[M]'s eyes go empty, with their face quickly shifting to a scorn"), span_narsiesmall("Your mind suddenly begins to drift- you begin to feel ANGRY."))
+	..()
 
 /datum/reagent/ms13/psycho/on_mob_end_metabolize(mob/living/M)
 	REMOVE_TRAIT(M, TRAIT_STUNIMMUNE, type)
@@ -329,6 +327,7 @@
 
 /datum/reagent/ms13/psycho/overdose_start(mob/living/M)
 	to_chat(M, span_narsiesmall("YOU FEEL AN INSATIABLE BLOODLUST!"))
+	..()
 
 /datum/reagent/ms13/psycho/overdose_process(mob/living/M)
 	M.Jitter(10)
@@ -344,14 +343,13 @@
 	M.adjustOrganLoss(ORGAN_SLOT_HEART, 0.25)
 	M.hallucination += 5
 	..()
-	. = 1
 
 // Rebound //
 
 /datum/reagent/ms13/rebound
 	name = "Rebound"
 	description = "A powerful mix of adrenaline and liquid Jet. Makes the user faster, but causes considerable heart damage."
-	color = "#60A584" // rgb: 96, 165, 132
+	color = "#ddab69"
 	overdose_threshold = 30
 
 // OVERDRIVE //
@@ -359,7 +357,7 @@
 /datum/reagent/ms13/overdrive
 	name = "Overdrive"
 	description = "A modified version of Psycho, designed to produce a stronger effect. Extremely dangerous."
-	color = "#60A584" // rgb: 96, 165, 132
+	color = "#ac4b4b"
 	overdose_threshold = 30
 	var/datum/brain_trauma/special/psychotic_brawling/bath_salts/rage
 
@@ -394,6 +392,7 @@
 	REMOVE_TRAIT(M, TRAIT_STUNIMMUNE, type)
 	REMOVE_TRAIT(M, TRAIT_SLEEPIMMUNE, type)
 	M.Stun(25)
+	..()
 
 /datum/reagent/ms13/overdrive/overdose_process(mob/living/carbon/M)
 	if(prob(35)) // panic
@@ -417,7 +416,35 @@
 		M.adjustOrganLoss(ORGAN_SLOT_BRAIN, rand(1, 5))
 	M.hallucination += 10
 	..()
-	. = 1
+
+// Addictol //
+
+/datum/reagent/ms13/addictol
+	name = "Addictol"
+	description = "An effective pre-War medicine that works both physically and psychologically to remove both the symptoms of drug abuse and the craving."
+	color = "#8da070"
+	overdose_threshold = 10
+
+/datum/reagent/ms13/addictol/on_mob_metabolize(mob/living/carbon/M)
+	..()
+	if(M.mind)
+		for(var/addiction_type in subtypesof(/datum/addiction))
+			M.mind.remove_addiction_points(addiction_type, MAX_ADDICTION_POINTS) //Remove addictions
+	to_chat(M, span_green("Your head feels a lot more clear now!"))
+
+/*/datum/reagent/ms13/addictol/overdose_start(mob/living/carbon/M) This is busted, probably. Let's not for now.
+	..()
+	if(M.mind)
+		for(var/addiction_type in subtypesof(/datum/addiction/ms13))
+			M.mind.add_addiction_points(addiction_type, MAX_ADDICTION_POINTS) //KILL.
+*/
+/datum/reagent/ms13/addictol/overdose_process(mob/living/carbon/M)
+	M.adjustToxLoss(5, 0)
+	..()
+
+/datum/reagent/ms13/addictol/on_mob_life(mob/living/M)
+	M.adjustToxLoss(2, 0)
+	..()
 
 /////// Movespeed Modifiers ///////
 

--- a/mojave/code/modules/reagents/drugs.dm
+++ b/mojave/code/modules/reagents/drugs.dm
@@ -1,0 +1,327 @@
+//UNCRAFTABLE (MUST BE SCAVENGED)
+/datum/reagent/ms13/buffout
+	name = "Buffout"
+	description = "A highly potent anabolic steroid popular before the war with athletes. Causes mild liver and heart damage."
+	color = "#60A584" // rgb: 96, 165, 132
+	overdose_threshold = 20
+
+// Calmex //
+
+/datum/reagent/ms13/calmex //useful for surgery
+	name = "Calmex"
+	description = "A light anaesthetic. Reduces inhibitions and dulls the senses."
+	color = "#BC13FE" // rgb: 96, 165, 132
+	overdose_threshold = 30
+
+/datum/reagent/ms13/calmex/on_mob_life(mob/living/carbon/M)
+	if(current_cycle >= 5)
+		SEND_SIGNAL(M, COMSIG_ADD_MOOD_EVENT, "numb", /datum/mood_event/narcotic_medium, name)
+	..()
+
+/datum/reagent/ms13/calmex/overdose_process(mob/living/M)
+	switch(current_cycle)
+		if(11)
+			to_chat(M, span_warning("You start to feel tired..." ))
+		if(12 to 24)
+			M.drowsyness += 1
+		if(24 to INFINITY)
+			M.Sleeping(40, 0)
+			. = 1
+	..()
+
+// Day Tripper //
+
+/datum/reagent/ms13/day_tripper
+	name = "Day Tripper"
+	description = "A mild hallucinogen. Helps take the edge off, but weakens muscles."
+	color = "#60A584" // rgb: 96, 165, 132
+	overdose_threshold = 30
+
+// Smooch //
+
+/datum/reagent/ms13/smooch
+	name = "Smooch"
+	description = "A novel smokable from Northern Nevada. Tastes terrible, but causes mellowness and ecstacy. Prolonged use causes extreme brain damage."
+	color = "#65FF00"
+	overdose_threshold = 20
+	taste_description = "putrid death"
+
+/datum/reagent/ms13/smooch/on_mob_metabolize(mob/living/L)
+	..()
+	SEND_SIGNAL(L, COMSIG_ADD_MOOD_EVENT, "smooch_drug", /datum/mood_event/happiness_drug)
+
+/datum/reagent/ms13/smooch/on_mob_delete(mob/living/L)
+	SEND_SIGNAL(L, COMSIG_CLEAR_MOOD_EVENT, "smooch_drug")
+	..()
+
+/datum/reagent/ms13/smooch/on_mob_life(mob/living/carbon/M)
+	M.set_drugginess(15)
+	M.jitteriness = 0
+	M.adjustOrganLoss(ORGAN_SLOT_BRAIN, 0.2)
+	if(prob(7))
+		M.emote(pick("twitch","drool","moan","giggle"))
+	..()
+	. = 1
+
+/datum/reagent/ms13/smooch/overdose_process(mob/living/M)
+	M.adjustOrganLoss(ORGAN_SLOT_BRAIN, 0.5)
+	M.adjustToxLoss(0.5, 0)
+	M.adjust_disgust(2)
+	..()
+	. = 1
+
+// Steady //
+
+/datum/reagent/ms13/steady
+	name = "Steady"
+	description = "A military grade relaxant. Reduces weapon sway and increases effective accuracy, but carries a severe risk of addiction."
+	color = "#60A584" // rgb: 96, 165, 132
+	overdose_threshold = 30
+
+// X-Cell //
+
+/datum/reagent/ms13/x_cell
+	name = "X-Cell"
+	description = "A general purpose performance enhancer. Gives a general boost to all SPECIAL stats, but with a high risk of addiction."
+	color = "#60A584" // rgb: 96, 165, 132
+	overdose_threshold = 30
+
+// Hydra //
+
+/datum/reagent/ms13/hydra
+	name = "Hydra"
+	description = "A curative agent that anaesthetises and restores crippled limbs. Causes heart damage."
+	color = "#60A584" // rgb: 96, 165, 132
+	overdose_threshold = 30
+
+/datum/reagent/ms13/hydra/on_mob_add(mob/living/M, amount)
+	. = ..()
+	to_chat(M, span_notice("Your insides start tingling slightly. You can feel things shifting."))
+
+/datum/reagent/ms13/hydra/on_mob_life(mob/living/carbon/M) // This needs to be unscuffed before we can use it. It WORKS. Just too well. Instant healing of wounds for as long as it's in your blood. I'm not qualified for this! help!
+	. = ..()
+	..()
+	if(!isliving(M))
+		return
+
+	for(var/thing in M.all_wounds)
+		var/datum/wound/blunt/severe/W = thing
+		W.remove_wound()
+
+/datum/reagent/ms13/hydra/on_mob_delete(mob/living/carbon/human/M)
+	..()
+	if(isliving(M))
+		to_chat(M, span_notice("Your insides halt to a stop. Everything seems back to normal now."))
+
+// Jet //
+
+/datum/reagent/ms13/jet
+	name = "Jet"
+	description = "A highly addictive substance. Causes lung damage and addiction."
+	color = "#60A584" // rgb: 96, 165, 132
+	overdose_threshold = 30
+	addiction_types = list(/datum/addiction/ms13/jet = 35)
+
+/datum/reagent/ms13/jet/on_mob_add(mob/living/carbon/human/M)
+	..()
+	var/atom/movable/plane_master_controller/game_plane_master_controller = M.hud_used.plane_master_controllers[PLANE_MASTERS_GAME]
+	game_plane_master_controller.add_filter("jet_blur", 1, list("type" = "radial_blur", "size" = 0))
+	M.add_movespeed_modifier(/datum/movespeed_modifier/reagent/ms13/jet)
+
+	for(var/filter in game_plane_master_controller.get_filters("jet_blur"))
+		animate(filter, loop = -1, size = 0.04, time = 2 SECONDS, easing = ELASTIC_EASING|EASE_OUT, flags = ANIMATION_PARALLEL)
+		animate(size = 0, time = 6 SECONDS, easing = CIRCULAR_EASING|EASE_IN)
+	if(isliving(M))
+		to_chat(M, span_userdanger("You feel an incredible pulsating high! You just absolutely love life in this moment!"))
+
+/datum/reagent/ms13/jet/on_mob_delete(mob/living/carbon/human/M)
+	..()
+	var/atom/movable/plane_master_controller/game_plane_master_controller = M.hud_used.plane_master_controllers[PLANE_MASTERS_GAME]
+	game_plane_master_controller.remove_filter("jet_blur")
+	M.remove_movespeed_modifier(/datum/movespeed_modifier/reagent/ms13/jet)
+
+	if(isliving(M))
+		to_chat(M, span_userdanger("You come down from your high. Maybe you should go get some more?"))
+
+/datum/reagent/ms13/jet/on_mob_life(mob/living/carbon/M)
+	M.setOrganLoss(ORGAN_SLOT_LUNGS, rand(0.25, 2))
+	if(prob(12))
+		M.emote(pick("twitch", "drool", "moan", "giggle"))
+	..()
+
+/datum/reagent/ms13/jet/overdose_start(mob/living/M)
+	to_chat(M, span_userdanger("You start tripping hard!"))
+	SEND_SIGNAL(M, COMSIG_ADD_MOOD_EVENT, "[type]_overdose", /datum/mood_event/overdose, name)
+
+/datum/reagent/ms13/jet/overdose_process(mob/living/M)
+	M.hallucination += 10
+	M.adjustOrganLoss(ORGAN_SLOT_LUNGS, rand(0.25,5))
+	..()
+
+// Rocket //
+
+/datum/reagent/ms13/rocket
+	name = "Rocket"
+	description = "A variant of jet. Has more potent combat properties, but carries a higher risk of addiction."
+	color = "#60A584" // rgb: 96, 165, 132
+	overdose_threshold = 30
+	addiction_types = list(/datum/addiction/ms13/rocket = 45)
+
+/datum/reagent/ms13/rocket/on_mob_add(mob/living/carbon/human/M)
+	..()
+	if(isliving(M))
+		to_chat(M, span_userdanger("You feel an incredible high! But feel very focused..."))
+
+/datum/reagent/ms13/rocket/on_mob_delete(mob/living/carbon/human/M)
+	..()
+	if(isliving(M))
+		to_chat(M, span_userdanger("You come down from your high. Everything seems back to normal."))
+
+/datum/reagent/ms13/rocket/on_mob_life(mob/living/carbon/M)
+	M.adjustStaminaLoss(-20, 0)
+	M.AdjustAllImmobility(-5)
+	M.set_drugginess(10)
+	M.setOrganLoss(ORGAN_SLOT_LUNGS, rand(0.25, 1))
+	if(prob(12))
+		M.emote(pick("twitch","drool","moan"))
+	..()
+
+// Mentats //
+
+/datum/reagent/ms13/mentats
+	name = "Mentat powder"
+	description = "A powerful nootropic that increases mental faculties and cures brain damage, but increases thirst."
+	color = "#60A584" // rgb: 96, 165, 132
+	overdose_threshold = 30
+	addiction_types = list(/datum/addiction/ms13/mentats = 25)
+
+/datum/reagent/ms13/mentats/on_mob_life(mob/living/carbon/C)
+	C.adjustOrganLoss(ORGAN_SLOT_BRAIN, -2*REM)
+	if(prob(15))
+		C.cure_trauma_type(resilience = TRAUMA_RESILIENCE_BASIC)
+	..()
+
+/datum/reagent/ms13/mentats/overdose_process(mob/living/carbon/M)
+	M.Jitter(3)
+	M.adjustToxLoss(0.5, 1)
+	M.adjustOrganLoss(ORGAN_SLOT_BRAIN, -5*REM)
+	if(prob(50))
+		to_chat(M, span_warning("<[pick("Your head hurts a lot.", "Your head pounds incessantly.")]"))
+	else if(prob(33))
+		to_chat(M, span_userdanger("[pick("Your head hurts!", "You feel a burning knife inside your brain!", "A wave of pain fills your head!")]"))
+		M.Stun(35)
+	if(prob(1))
+		to_chat(M, span_userdanger("You feel something within your head snap."))
+		M.gain_trauma_type(BRAIN_TRAUMA_MILD, TRAUMA_RESILIENCE_ABSOLUTE)
+	..()
+
+// Psycho //
+
+/datum/reagent/ms13/psycho //military grade bath salts? SIGN ME AND THE REST OF AMERICA THE FUCK UP!
+	name = "Psycho"
+	description = "A military grade amphetamine. Causes increased strength and endurance, but induces a powerful psychosis."
+	color = "#60A584" // rgb: 96, 165, 132
+	overdose_threshold = 20
+	addiction_types = list(/datum/addiction/ms13/psycho = 25)
+	var/datum/brain_trauma/special/psychotic_brawling/bath_salts/rage
+
+/datum/reagent/ms13/psycho/on_mob_metabolize(mob/living/M)
+	..()
+	ADD_TRAIT(M, TRAIT_STUNIMMUNE, type)
+	ADD_TRAIT(M, TRAIT_SLEEPIMMUNE, type)
+	M.apply_status_effect(STATUS_EFFECT_SPASMS)
+	M.maxHealth += 25
+	M.health += 25
+	if(iscarbon(M))
+		var/mob/living/carbon/C = M
+		rage = new()
+		C.gain_trauma(rage, TRAUMA_RESILIENCE_ABSOLUTE)
+	M.overlay_fullscreen("psycho", /atom/movable/screen/fullscreen/color_vision/red)
+	if(prob(25))
+		M.adjustOrganLoss(ORGAN_SLOT_HEART, )
+
+/datum/reagent/ms13/psycho/on_mob_end_metabolize(mob/living/M)
+	REMOVE_TRAIT(M, TRAIT_STUNIMMUNE, type)
+	REMOVE_TRAIT(M, TRAIT_SLEEPIMMUNE, type)
+	M.remove_status_effect(STATUS_EFFECT_SPASMS)
+	M.maxHealth -= 25
+	M.health -= 25
+	if(rage)
+		QDEL_NULL(rage)
+	M.clear_fullscreen("psycho")
+	..()
+
+/datum/reagent/ms13/psycho/overdose_start(mob/living/M)
+	to_chat(M, span_narsiesmall("YOU FEEL AN INSATIABLE BLOODLUST!"))
+
+/datum/reagent/ms13/psycho/overdose_process(mob/living/M)
+	M.Jitter(10)
+	M.adjustOrganLoss(ORGAN_SLOT_HEART, 0.5)
+	if(prob(5))
+		M.drop_all_held_items()
+	if(prob(15))
+		M.emote(pick("scream","twitch"))
+	if(prob(15))
+		M.adjustToxLoss(3, 0)
+	..()
+
+/datum/reagent/ms13/psycho/on_mob_life(mob/living/M)
+	SEND_SIGNAL(M, COMSIG_ADD_MOOD_EVENT, "gone_psycho", /datum/mood_event/stimulant_heavy, name)
+	M.adjustOrganLoss(ORGAN_SLOT_HEART, 1)
+	M.hallucination += 5
+	..()
+	. = 1
+
+
+// Rebound //
+
+/datum/reagent/ms13/rebound
+	name = "Rebound"
+	description = "A powerful mix of adrenaline and liquid Jet. Makes the user faster, but causes considerable heart damage."
+	color = "#60A584" // rgb: 96, 165, 132
+	overdose_threshold = 30
+
+// Turbo //
+
+/datum/reagent/ms13/turbo
+	name = "Turbo"
+	description = "Jet mixed with cazador poison and hairspray. Results in extremely strong Jet effects."
+	color = "#60A584" // rgb: 96, 165, 132
+	overdose_threshold = 30
+
+// Voodoo //
+
+/datum/reagent/ms13/voodoo
+	name = "Voodoo"
+	description = "A potent mix of animal venoms and alcohol. Results in numbness that reduces damage."
+	color = "#60A584" // rgb: 96, 165, 132
+	overdose_threshold = 30
+
+// Mutie //
+
+/datum/reagent/ms13/mutie
+	name = "Mutie"
+	description = "A potent mutagenic serum that causes random mutations."
+	color = "#60A584" // rgb: 96, 165, 132
+	overdose_threshold = 30
+
+// OVERDRIVE //
+
+/datum/reagent/ms13/overdrive
+	name = "Overdrive"
+	description = "A modified version of Psycho, designed to produce a stronger effect. Extremely dangerous."
+	color = "#60A584" // rgb: 96, 165, 132
+	overdose_threshold = 30
+
+/////// Movespeed Modifiers ///////
+
+/datum/movespeed_modifier/reagent/ms13
+
+/datum/movespeed_modifier/reagent/ms13/jet
+	multiplicative_slowdown = -0.10
+
+/datum/movespeed_modifier/reagent/ms13/rocket
+	multiplicative_slowdown = -0.15
+
+/datum/movespeed_modifier/reagent/ms13/turbo
+	multiplicative_slowdown = -0.25

--- a/mojave/code/modules/reagents/drugs.dm
+++ b/mojave/code/modules/reagents/drugs.dm
@@ -139,11 +139,12 @@
 
 /datum/reagent/ms13/jet/on_mob_add(mob/living/carbon/human/M)
 	if(!M.hud_used)
-		var/atom/movable/plane_master_controller/game_plane_master_controller = M.hud_used.plane_master_controllers[PLANE_MASTERS_GAME]
-		game_plane_master_controller.add_filter("jet_blur", 1, list("type" = "radial_blur", "size" = 0))
-		for(var/filter in game_plane_master_controller.get_filters("jet_blur"))
-			animate(filter, loop = -1, size = 0.04, time = 2 SECONDS, easing = ELASTIC_EASING|EASE_OUT, flags = ANIMATION_PARALLEL)
-			animate(size = 0, time = 6 SECONDS, easing = CIRCULAR_EASING|EASE_IN)
+		return
+	var/atom/movable/plane_master_controller/game_plane_master_controller = M.hud_used.plane_master_controllers[PLANE_MASTERS_GAME]
+	game_plane_master_controller.add_filter("jet_blur", 1, list("type" = "radial_blur", "size" = 0))
+	for(var/filter in game_plane_master_controller.get_filters("jet_blur"))
+		animate(filter, loop = -1, size = 0.04, time = 2 SECONDS, easing = ELASTIC_EASING|EASE_OUT, flags = ANIMATION_PARALLEL)
+		animate(size = 0, time = 6 SECONDS, easing = CIRCULAR_EASING|EASE_IN)
 	M.add_movespeed_modifier(/datum/movespeed_modifier/reagent/ms13/jet)
 	if(isliving(M))
 		to_chat(M, span_userdanger("You feel an incredible pulsating high! You just absolutely love life in this moment!"))
@@ -151,8 +152,9 @@
 
 /datum/reagent/ms13/jet/on_mob_delete(mob/living/carbon/human/M)
 	if(!M.hud_used)
-		var/atom/movable/plane_master_controller/game_plane_master_controller = M.hud_used.plane_master_controllers[PLANE_MASTERS_GAME]
-		game_plane_master_controller.remove_filter("jet_blur")
+		return
+	var/atom/movable/plane_master_controller/game_plane_master_controller = M.hud_used.plane_master_controllers[PLANE_MASTERS_GAME]
+	game_plane_master_controller.remove_filter("jet_blur")
 	M.remove_movespeed_modifier(/datum/movespeed_modifier/reagent/ms13/jet)
 	if(isliving(M))
 		to_chat(M, span_userdanger("You come down from your high. Maybe you should go get some more?"))
@@ -185,11 +187,12 @@
 
 /datum/reagent/ms13/rocket/on_mob_add(mob/living/carbon/human/M)
 	if(!M.hud_used)
-		var/atom/movable/plane_master_controller/game_plane_master_controller = M.hud_used.plane_master_controllers[PLANE_MASTERS_GAME]
-		game_plane_master_controller.add_filter("rocket_blur", 1, list("type" = "radial_blur", "size" = 0))
-		for(var/filter in game_plane_master_controller.get_filters("rocket_blur"))
-			animate(filter, loop = -1, size = 0.02, time = 2 SECONDS, easing = JUMP_EASING|EASE_OUT, flags = ANIMATION_PARALLEL)
-			animate(size = 0, time = 6 SECONDS, easing = JUMP_EASING|EASE_IN)
+		return
+	var/atom/movable/plane_master_controller/game_plane_master_controller = M.hud_used.plane_master_controllers[PLANE_MASTERS_GAME]
+	game_plane_master_controller.add_filter("rocket_blur", 1, list("type" = "radial_blur", "size" = 0))
+	for(var/filter in game_plane_master_controller.get_filters("rocket_blur"))
+		animate(filter, loop = -1, size = 0.02, time = 2 SECONDS, easing = JUMP_EASING|EASE_OUT, flags = ANIMATION_PARALLEL)
+		animate(size = 0, time = 6 SECONDS, easing = JUMP_EASING|EASE_IN)
 	M.add_movespeed_modifier(/datum/movespeed_modifier/reagent/ms13/rocket)
 	if(isliving(M))
 		to_chat(M, span_userdanger("You feel an incredible high! But feel very focused..."))
@@ -197,8 +200,9 @@
 
 /datum/reagent/ms13/rocket/on_mob_delete(mob/living/carbon/human/M)
 	if(!M.hud_used)
-		var/atom/movable/plane_master_controller/game_plane_master_controller = M.hud_used.plane_master_controllers[PLANE_MASTERS_GAME]
-		game_plane_master_controller.remove_filter("rocket_blur")
+		return
+	var/atom/movable/plane_master_controller/game_plane_master_controller = M.hud_used.plane_master_controllers[PLANE_MASTERS_GAME]
+	game_plane_master_controller.remove_filter("rocket_blur")
 	M.remove_movespeed_modifier(/datum/movespeed_modifier/reagent/ms13/jet)
 
 	if(isliving(M))
@@ -231,10 +235,11 @@
 
 /datum/reagent/ms13/turbo/on_mob_add(mob/living/carbon/human/M)
 	if(!M.hud_used)
-		var/atom/movable/plane_master_controller/game_plane_master_controller = M.hud_used.plane_master_controllers[PLANE_MASTERS_GAME]
-		game_plane_master_controller.add_filter("turbo_wave", 1, list("type" = "wave", "x" = 32, "y" = 32))
-		for(var/filter in game_plane_master_controller.get_filters("turbo_wave"))
-			animate(filter, time = 32 SECONDS, loop = -1, easing = LINEAR_EASING, offset = 32, flags = ANIMATION_PARALLEL)
+		return
+	var/atom/movable/plane_master_controller/game_plane_master_controller = M.hud_used.plane_master_controllers[PLANE_MASTERS_GAME]
+	game_plane_master_controller.add_filter("turbo_wave", 1, list("type" = "wave", "x" = 32, "y" = 32))
+	for(var/filter in game_plane_master_controller.get_filters("turbo_wave"))
+		animate(filter, time = 32 SECONDS, loop = -1, easing = LINEAR_EASING, offset = 32, flags = ANIMATION_PARALLEL)
 	M.add_movespeed_modifier(/datum/movespeed_modifier/reagent/ms13/turbo)
 	M.sound_environment_override = SOUND_ENVIRONMENT_DRUGGED
 	if(isliving(M))
@@ -243,8 +248,9 @@
 
 /datum/reagent/ms13/turbo/on_mob_delete(mob/living/carbon/human/M)
 	if(!M.hud_used)
-		var/atom/movable/plane_master_controller/game_plane_master_controller = M.hud_used.plane_master_controllers[PLANE_MASTERS_GAME]
-		game_plane_master_controller.remove_filter("turbo_wave")
+		return
+	var/atom/movable/plane_master_controller/game_plane_master_controller = M.hud_used.plane_master_controllers[PLANE_MASTERS_GAME]
+	game_plane_master_controller.remove_filter("turbo_wave")
 	M.remove_movespeed_modifier(/datum/movespeed_modifier/reagent/ms13/turbo)
 	M.sound_environment_override = NONE
 	if(isliving(M))

--- a/mojave/code/modules/reagents/drugs.dm
+++ b/mojave/code/modules/reagents/drugs.dm
@@ -7,7 +7,7 @@
 	overdose_threshold = 25
 
 /datum/reagent/ms13/buffout/on_mob_metabolize(mob/living/M)
-	M.maxHealth += 30
+	M.maxHealth += 30 // These probably shouldn't ever be too high for the sake of balance. You're only human anyways afterall.
 	M.health += 30
 	..()
 
@@ -68,10 +68,10 @@
 
 /datum/reagent/ms13/day_tripper/on_mob_metabolize(mob/living/L)
 	..()
-	SEND_SIGNAL(L, COMSIG_ADD_MOOD_EVENT, "smooch_drug", /datum/mood_event/happiness_drug)
+	SEND_SIGNAL(L, COMSIG_ADD_MOOD_EVENT, "daytripper_drug", /datum/mood_event/happiness_drug)
 
 /datum/reagent/ms13/day_tripper/on_mob_delete(mob/living/L)
-	SEND_SIGNAL(L, COMSIG_CLEAR_MOOD_EVENT, "smooch_drug")
+	SEND_SIGNAL(L, COMSIG_CLEAR_MOOD_EVENT, "daytripper_drug")
 	..()
 
 /datum/reagent/ms13/day_tripper/on_mob_life(mob/living/carbon/M)
@@ -232,11 +232,9 @@
 
 /datum/reagent/ms13/turbo/on_mob_add(mob/living/carbon/human/M)
 	..()
-	var/rotation = min(round(current_cycle/20), 89) // wiggle wiggle. Don't even mention where you've seen this before.
 	var/atom/movable/plane_master_controller/game_plane_master_controller = M.hud_used.plane_master_controllers[PLANE_MASTERS_GAME]
 	game_plane_master_controller.add_filter("turbo_wave", 1, list("type" = "wave", "x" = 32, "y" = 32))
 	for(var/filter in game_plane_master_controller.get_filters("turbo_wave"))
-		animate(filter = matrix(-rotation, MATRIX_ROTATE), time = 5, easing = QUAD_EASING)
 		animate(filter, time = 32 SECONDS, loop = -1, easing = LINEAR_EASING, offset = 32, flags = ANIMATION_PARALLEL)
 	M.add_movespeed_modifier(/datum/movespeed_modifier/reagent/ms13/turbo)
 	M.sound_environment_override = SOUND_ENVIRONMENT_DRUGGED

--- a/mojave/code/modules/reagents/drugs.dm
+++ b/mojave/code/modules/reagents/drugs.dm
@@ -138,20 +138,21 @@
 	addiction_types = list(/datum/addiction/ms13/jet = 45)
 
 /datum/reagent/ms13/jet/on_mob_add(mob/living/carbon/human/M)
-	var/atom/movable/plane_master_controller/game_plane_master_controller = M.hud_used.plane_master_controllers[PLANE_MASTERS_GAME]
-	game_plane_master_controller.add_filter("jet_blur", 1, list("type" = "radial_blur", "size" = 0))
+	if(!M.hud_used)
+		var/atom/movable/plane_master_controller/game_plane_master_controller = M.hud_used.plane_master_controllers[PLANE_MASTERS_GAME]
+		game_plane_master_controller.add_filter("jet_blur", 1, list("type" = "radial_blur", "size" = 0))
+		for(var/filter in game_plane_master_controller.get_filters("jet_blur"))
+			animate(filter, loop = -1, size = 0.04, time = 2 SECONDS, easing = ELASTIC_EASING|EASE_OUT, flags = ANIMATION_PARALLEL)
+			animate(size = 0, time = 6 SECONDS, easing = CIRCULAR_EASING|EASE_IN)
 	M.add_movespeed_modifier(/datum/movespeed_modifier/reagent/ms13/jet)
-
-	for(var/filter in game_plane_master_controller.get_filters("jet_blur"))
-		animate(filter, loop = -1, size = 0.04, time = 2 SECONDS, easing = ELASTIC_EASING|EASE_OUT, flags = ANIMATION_PARALLEL)
-		animate(size = 0, time = 6 SECONDS, easing = CIRCULAR_EASING|EASE_IN)
 	if(isliving(M))
 		to_chat(M, span_userdanger("You feel an incredible pulsating high! You just absolutely love life in this moment!"))
 	..()
 
 /datum/reagent/ms13/jet/on_mob_delete(mob/living/carbon/human/M)
-	var/atom/movable/plane_master_controller/game_plane_master_controller = M.hud_used.plane_master_controllers[PLANE_MASTERS_GAME]
-	game_plane_master_controller.remove_filter("jet_blur")
+	if(!M.hud_used)
+		var/atom/movable/plane_master_controller/game_plane_master_controller = M.hud_used.plane_master_controllers[PLANE_MASTERS_GAME]
+		game_plane_master_controller.remove_filter("jet_blur")
 	M.remove_movespeed_modifier(/datum/movespeed_modifier/reagent/ms13/jet)
 	if(isliving(M))
 		to_chat(M, span_userdanger("You come down from your high. Maybe you should go get some more?"))
@@ -183,20 +184,21 @@
 	addiction_types = list(/datum/addiction/ms13/rocket = 40)
 
 /datum/reagent/ms13/rocket/on_mob_add(mob/living/carbon/human/M)
-	var/atom/movable/plane_master_controller/game_plane_master_controller = M.hud_used.plane_master_controllers[PLANE_MASTERS_GAME]
-	game_plane_master_controller.add_filter("rocket_blur", 1, list("type" = "radial_blur", "size" = 0))
+	if(!M.hud_used)
+		var/atom/movable/plane_master_controller/game_plane_master_controller = M.hud_used.plane_master_controllers[PLANE_MASTERS_GAME]
+		game_plane_master_controller.add_filter("rocket_blur", 1, list("type" = "radial_blur", "size" = 0))
+		for(var/filter in game_plane_master_controller.get_filters("rocket_blur"))
+			animate(filter, loop = -1, size = 0.02, time = 2 SECONDS, easing = JUMP_EASING|EASE_OUT, flags = ANIMATION_PARALLEL)
+			animate(size = 0, time = 6 SECONDS, easing = JUMP_EASING|EASE_IN)
 	M.add_movespeed_modifier(/datum/movespeed_modifier/reagent/ms13/rocket)
-
-	for(var/filter in game_plane_master_controller.get_filters("rocket_blur"))
-		animate(filter, loop = -1, size = 0.02, time = 2 SECONDS, easing = JUMP_EASING|EASE_OUT, flags = ANIMATION_PARALLEL)
-		animate(size = 0, time = 6 SECONDS, easing = JUMP_EASING|EASE_IN)
 	if(isliving(M))
 		to_chat(M, span_userdanger("You feel an incredible high! But feel very focused..."))
 	..()
 
 /datum/reagent/ms13/rocket/on_mob_delete(mob/living/carbon/human/M)
-	var/atom/movable/plane_master_controller/game_plane_master_controller = M.hud_used.plane_master_controllers[PLANE_MASTERS_GAME]
-	game_plane_master_controller.remove_filter("rocket_blur")
+	if(!M.hud_used)
+		var/atom/movable/plane_master_controller/game_plane_master_controller = M.hud_used.plane_master_controllers[PLANE_MASTERS_GAME]
+		game_plane_master_controller.remove_filter("rocket_blur")
 	M.remove_movespeed_modifier(/datum/movespeed_modifier/reagent/ms13/jet)
 
 	if(isliving(M))
@@ -228,10 +230,11 @@
 	addiction_types = list(/datum/addiction/ms13/turbo = 35)
 
 /datum/reagent/ms13/turbo/on_mob_add(mob/living/carbon/human/M)
-	var/atom/movable/plane_master_controller/game_plane_master_controller = M.hud_used.plane_master_controllers[PLANE_MASTERS_GAME]
-	game_plane_master_controller.add_filter("turbo_wave", 1, list("type" = "wave", "x" = 32, "y" = 32))
-	for(var/filter in game_plane_master_controller.get_filters("turbo_wave"))
-		animate(filter, time = 32 SECONDS, loop = -1, easing = LINEAR_EASING, offset = 32, flags = ANIMATION_PARALLEL)
+	if(!M.hud_used)
+		var/atom/movable/plane_master_controller/game_plane_master_controller = M.hud_used.plane_master_controllers[PLANE_MASTERS_GAME]
+		game_plane_master_controller.add_filter("turbo_wave", 1, list("type" = "wave", "x" = 32, "y" = 32))
+		for(var/filter in game_plane_master_controller.get_filters("turbo_wave"))
+			animate(filter, time = 32 SECONDS, loop = -1, easing = LINEAR_EASING, offset = 32, flags = ANIMATION_PARALLEL)
 	M.add_movespeed_modifier(/datum/movespeed_modifier/reagent/ms13/turbo)
 	M.sound_environment_override = SOUND_ENVIRONMENT_DRUGGED
 	if(isliving(M))
@@ -239,8 +242,9 @@
 	..()
 
 /datum/reagent/ms13/turbo/on_mob_delete(mob/living/carbon/human/M)
-	var/atom/movable/plane_master_controller/game_plane_master_controller = M.hud_used.plane_master_controllers[PLANE_MASTERS_GAME]
-	game_plane_master_controller.remove_filter("turbo_wave")
+	if(!M.hud_used)
+		var/atom/movable/plane_master_controller/game_plane_master_controller = M.hud_used.plane_master_controllers[PLANE_MASTERS_GAME]
+		game_plane_master_controller.remove_filter("turbo_wave")
 	M.remove_movespeed_modifier(/datum/movespeed_modifier/reagent/ms13/turbo)
 	M.sound_environment_override = NONE
 	if(isliving(M))

--- a/mojave/code/modules/reagents/mojave_chems.dm
+++ b/mojave/code/modules/reagents/mojave_chems.dm
@@ -7,36 +7,11 @@
 	taste_description = "burning chemical taste"
 	overdose_threshold = 1
 
-/datum/reagent/consumable/ms13/water // When you code it
-	name = "water"
-	description = "Water. The base of all life. Don't run out."
-	color = "#f1eeeca1"
-	quality = DRINK_VERYGOOD
-	taste_description = "water"
-	glass_name = "glass of clear liquid"
-	glass_desc = "A clear liquid with no smell. Nothing out of the ordinary."
-
-/datum/reagent/consumable/ms13/unfiltered_water
-	name = "Unfiltered Water"
-	description = "Water... Questionable water. Should run it through some filtering or something."
-	color = "#d8d3cfa1"
-	taste_description = "water with an off taste"
-	glass_name = "glass of clear liquid"
-	glass_desc = "A clear liquid with some stray particles seen floating around peacefully inside."
-
-/datum/reagent/consumable/ms13/dirty_water
-	name = "Dirty Water"
-	description = "An ubiquitous chemical substance that is composed of hydrogen and oxygen, this one is impure and toxic to drink."
-	color = "#4439288c"
-	taste_description = "vile water"
-	glass_name = "glass of murky liquid"
-	glass_desc = "A murky green liquid with a pungeant vile smell. Not so sure about this one."
-
-/datum/reagent/consumable/ms13/dirty_water/on_mob_life(mob/living/carbon/M)
-	M.adjust_disgust(10)
-	if(prob(50))
-		M.adjustToxLoss(5)
-
-	if(prob(10))
-		M.vomit(lost_nutrition = 25, distance = 1, purge_ratio = 0.2)
-	..()
+/datum/reagent/consumable/ms13
+	name = "Generic MS13 yummy liquid"
+	description = "Yeah probably skip out on this one chief."
+	color = "#7c7b7a"
+	quality = DRINK_NICE
+	glass_name = "glass of liquid" // Keep these generic for flavour!
+	glass_desc = "A pale coloured liquid. It screams 'PAIN'." // Same with this. Keep people guessin'. Make em know the drink via flavour and look for immersion.
+	glass_icon_state = null // None of this dumb nonsense. Glasses don't just morph based on liquid!

--- a/mojave/code/modules/reagents/mojave_chems.dm
+++ b/mojave/code/modules/reagents/mojave_chems.dm
@@ -1,5 +1,12 @@
 ///MOJAVE SUN CHEM BASE FILE/TEMP STORAGE///
 
+/datum/reagent/ms13
+	name = "generic MS13 chem"
+	description = "Don't breathe this in."
+	color = "#42330a"
+	taste_description = "burning chemical taste"
+	overdose_threshold = 1
+
 /datum/reagent/consumable/ms13/water // When you code it
 	name = "water"
 	description = "Water. The base of all life. Don't run out."

--- a/mojave/flora/wasteflora.dm
+++ b/mojave/flora/wasteflora.dm
@@ -139,7 +139,7 @@
 	color = "#44341F"
 	taste_description = "rot"
 
-/datum/reagent/plantnutriment/ms13/fertilizer/on_mob_life(mob/living/carbon/M)
+/datum/reagent/plantnutriment/ms13/fertilizer/on_mob_life(mob/living/carbon/M, delta_time, times_fired)
 	M.adjustToxLoss(0.5*REM, 0)
 	. = 1
 	..()

--- a/mojave/items/medical/IV_bags.dm
+++ b/mojave/items/medical/IV_bags.dm
@@ -40,7 +40,7 @@
 	color = "#ff7200"
 	metabolization_rate = 2 * REAGENTS_METABOLISM
 
-/datum/reagent/ms13/medicine/radaway/on_mob_life(mob/living/carbon/M)
+/datum/reagent/ms13/medicine/radaway/on_mob_life(mob/living/carbon/M, delta_time, times_fired)
 	M.adjustToxLoss(-3*REM)
 	M.radiation -= min(M.radiation, 16)
 	. = 1

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4006,6 +4006,8 @@
 #include "mojave\code\modules\mob\robots\handies.dm"
 #include "mojave\code\modules\mob\robots\protectrons.dm"
 #include "mojave\code\modules\mob\robots\robobrains.dm"
+#include "mojave\code\modules\reagents\addictions.dm"
+#include "mojave\code\modules\reagents\drugs.dm"
 #include "mojave\code\modules\reagents\mojave_chems.dm"
 #include "mojave\code\modules\reagents\consumables\alcohols.dm"
 #include "mojave\code\modules\reagents\consumables\drinks.dm"


### PR DESCRIPTION
## About The Pull Request

This PR adds in various chem reagents to start us off with. It doesn't apply them to anything yet. I don't have to drive to do it RIGHT THIS SECOND so it can remain as this for now- it's not hard to apply later on.

Mentats, Day Tripper, Psycho, Overdrive, Jet, Rocket, Turbo, Calmex, Buffout, Hydra, Addictol.

Some of these have some cool visual effects. I tried to make them quirky.

Jet/Rocket/Turbo apply speed buffs with some misc harm potential. 

Psycho/Overdrive give the classic psychotic brawling, and make you a tweaker in general.

Buffout adds 30 health to the user

Hydra heals bone breaks

Day tripper is basically BD jet

Addictol clears all addictions

Addictions for a couple of these- it's another can of worms to open. A lot of them are pretty lethal. The addiction gain rates will need to be tweaked when I have more time to do it, as they're pretty sparadic. Withdrawal stages need to be lengthened at some point, as you essentially reach the last stage in five minutes tops and ride out the worst effects for however long you have according to addiction points.

## Why It's Good For The Game

I think we need these
