### PR TITLE
Fix full auto

### DIFF
--- a/code/datums/components/fullauto.dm
+++ b/code/datums/components/fullauto.dm
@@ -117,7 +117,7 @@
 	if(get_dist(source.mob, _target) < 2) //Adjacent clicking.
 		return
 
-	if(isnull(location)) //Clicking on a screen object.
+	if(isnull(location) || control == ("mapwindow.hud")) //MOJAVE EDIT Clicking on a screen object.
 		if(_target.plane != CLICKCATCHER_PLANE) //The clickcatcher is a special case. We want the click to trigger then, under it.
 			return //If we click and drag on our worn backpack, for example, we want it to open instead.
 		_target = params_to_turf(modifiers["screen-loc"], get_turf(source.eye), source)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Full auto was having an issue where clicking on off-screen (secondary map controls) HUD would cause a runtime.  This made it impossible to put full auto weapons back into suit or belt slots.

This just adds a small check for if we're clicking on off-screen HUD.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Full auto less broken.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

