### PR TITLE
Replaces TG trash bin with Infras trash cans + Bloodbag spawners

### DIFF
--- a/_maps/map_files/Mammoth/Mammoth.dmm
+++ b/_maps/map_files/Mammoth/Mammoth.dmm
@@ -3719,6 +3719,10 @@
 /obj/item/ammo_casing/ms13/c10mm/junk,
 /turf/open/floor/wood/ms13/carpet,
 /area/ms13/town)
+"cyZ" = (
+/obj/structure/table/ms13/metal/alt,
+/turf/open/floor/wood/ms13/carpet/green,
+/area/ms13/town)
 "cza" = (
 /obj/machinery/light/ms13/bulb{
 	dir = 1
@@ -5819,6 +5823,7 @@
 /obj/structure/closet/crate/ms13/footlocker{
 	dir = 4
 	},
+/obj/effect/spawner/random/ms13/medical/lowrandom,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/tribal_abandoned)
 "eeB" = (
@@ -14762,7 +14767,7 @@
 	},
 /obj/structure/table/ms13/metal/alt,
 /obj/effect/spawner/random/ms13/melee/lowrandom,
-/turf/open/floor/wood/ms13/common,
+/turf/open/floor/wood/ms13/carpet/green,
 /area/ms13/town)
 "jCV" = (
 /obj/effect/decal/cleanable/glass,
@@ -14777,7 +14782,7 @@
 	pixel_x = -8;
 	pixel_y = 5
 	},
-/turf/open/floor/wood/ms13/common,
+/turf/open/floor/wood/ms13/carpet/green,
 /area/ms13/town)
 "jDc" = (
 /obj/effect/decal/cleanable/blood/old{
@@ -14889,9 +14894,8 @@
 /turf/open/openspace/ms13,
 /area/ms13/underground/vault_atrium_middle)
 "jGc" = (
-/obj/structure/chair/comfy/ms13/ergo{
-	dir = 1
-	},
+/obj/structure/table/ms13/no_smooth/counter/wood,
+/obj/effect/spawner/random/ms13/medical/lowrandom,
 /turf/open/floor/wood/ms13/common,
 /area/ms13/town)
 "jGh" = (
@@ -15008,13 +15012,13 @@
 /obj/structure/filingcabinet/ms13{
 	dir = 1
 	},
-/turf/open/floor/wood/ms13/common,
+/turf/open/floor/wood/ms13/carpet/green,
 /area/ms13/town)
 "jIm" = (
 /obj/item/paper_bin,
 /obj/item/pen,
 /obj/structure/table/ms13/metal/alt,
-/turf/open/floor/wood/ms13/common,
+/turf/open/floor/wood/ms13/carpet/green,
 /area/ms13/town)
 "jIM" = (
 /obj/machinery/light/ms13/bulb,
@@ -15783,6 +15787,8 @@
 /obj/effect/spawner/random/ms13/ammo/highrandom,
 /obj/effect/spawner/random/ms13/ammo/highrandom,
 /obj/effect/spawner/random/ms13/drink/alcohol_beer,
+/obj/effect/spawner/random/ms13/medical/lowrandom,
+/obj/effect/spawner/random/ms13/medical/lowrandom,
 /turf/open/floor/wood/ms13/carpet,
 /area/ms13/town)
 "kja" = (
@@ -17466,6 +17472,12 @@
 /obj/structure/table/ms13/metal/grate,
 /turf/open/floor/ms13/tile/large/white,
 /area/ms13/supermarket)
+"lke" = (
+/obj/machinery/light/ms13/bulb/broken{
+	dir = 4
+	},
+/turf/open/floor/wood/ms13/carpet/green,
+/area/ms13/town)
 "lkT" = (
 /obj/structure/table/ms13/metal/grate,
 /obj/item/hatchet/ms13,
@@ -22105,6 +22117,12 @@
 /obj/structure/fence/fencenormal,
 /turf/open/floor/wood/ms13/common,
 /area/ms13/ncr)
+"omB" = (
+/obj/structure/ms13/storage/bookshelf{
+	dir = 1
+	},
+/turf/open/floor/wood/ms13/carpet/green,
+/area/ms13/town)
 "omE" = (
 /obj/structure/table/ms13/wood,
 /turf/open/floor/wood/ms13/carpet/shaggy/green,
@@ -23569,6 +23587,13 @@
 /obj/structure/fence/fencecorner,
 /turf/open/floor/plating/ms13/ground/sidewalk,
 /area/ms13)
+"qLd" = (
+/obj/structure/table/ms13/no_smooth/counter/metal{
+	dir = 1
+	},
+/obj/effect/spawner/random/ms13/medical/lowrandom,
+/turf/open/floor/ms13/tile,
+/area/ms13/town)
 "qLH" = (
 /obj/structure/table/ms13/no_smooth/large/wood/square,
 /obj/structure/ms13/tv{
@@ -24561,6 +24586,11 @@
 	},
 /turf/open/floor/ms13/metal,
 /area/ms13/underground/vault_atrium_middle)
+"tCr" = (
+/obj/structure/table/ms13/wood,
+/obj/effect/spawner/random/ms13/medical/lowrandom,
+/turf/open/floor/wood/ms13/carpet/shaggy/green,
+/area/ms13/tribal_abandoned)
 "tCN" = (
 /obj/structure/table/ms13/metal,
 /turf/open/floor/ms13/tile/large/cafeteria,
@@ -25097,9 +25127,8 @@
 	},
 /area/ms13/town)
 "vzs" = (
-/obj/effect/decal/cleanable/glass,
-/obj/effect/spawner/random/ms13/melee/tier1,
-/turf/open/floor/wood/ms13/common,
+/obj/structure/chair/comfy/ms13/armchair,
+/turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "vzz" = (
 /obj/item/ammo_casing/ms13/c10mm/junk,
@@ -50364,7 +50393,7 @@ jIO
 jIO
 jIO
 jIO
-gjv
+ett
 jIO
 jIO
 jIO
@@ -50666,11 +50695,11 @@ ylG
 ylG
 ylG
 jIO
-wSc
-aPV
-anG
-eQw
-wSc
+axO
+bCT
+aDi
+cyZ
+upG
 jIf
 jIO
 xZD
@@ -50968,11 +50997,11 @@ ylG
 ylG
 ylG
 jIO
-bdT
-wSc
-bGe
+awZ
+axO
+vzs
 jCG
-jGc
+eRx
 jIm
 eiu
 xZD
@@ -51270,12 +51299,12 @@ ylG
 ylG
 ylG
 jIO
-bdT
-wSc
-vzs
+awZ
+axO
+fdw
 jCV
-bGm
-bKR
+lke
+omB
 jIO
 xZD
 ykT
@@ -56726,7 +56755,7 @@ vqX
 scA
 dFe
 scA
-cYp
+qLd
 jIO
 xZD
 xZD
@@ -65765,7 +65794,7 @@ xZD
 xZD
 xZD
 dGK
-ids
+jGc
 xGW
 lhk
 ibI
@@ -89128,7 +89157,7 @@ xlF
 omM
 wRd
 omE
-omE
+tCr
 aQU
 omM
 nKM

--- a/_maps/map_files/Mammoth/Mammoth.dmm
+++ b/_maps/map_files/Mammoth/Mammoth.dmm
@@ -23265,11 +23265,6 @@
 /obj/structure/table/ms13/wood/bar,
 /turf/open/floor/ms13/tile/large/cafeteria,
 /area/ms13/underground/vault_atrium_middle)
-"pGK" = (
-/obj/structure/table/ms13/wood,
-/obj/item/instrument/piano_synth/headphones,
-/turf/open/floor/wood/ms13/carpet,
-/area/ms13/town)
 "pHX" = (
 /turf/open/floor/ms13/concrete/bricks,
 /area/ms13/underground/bos)
@@ -23974,6 +23969,10 @@
 /obj/structure/table/ms13/low_wall/reinforced/bunker,
 /turf/open/floor/ms13/metal/grate/border,
 /area/ms13/underground/bos)
+"rMg" = (
+/obj/machinery/iv_drip/ms13,
+/turf/open/floor/ms13/tile,
+/area/ms13/ncr)
 "rMq" = (
 /obj/machinery/door/unpowered/ms13/seethrough/bar{
 	dir = 4
@@ -39913,7 +39912,7 @@ ylG
 ylG
 ylG
 nKL
-mTS
+rMg
 mTS
 mTS
 mTS
@@ -72800,9 +72799,9 @@ xZD
 jIO
 lYG
 jIO
-pGK
 smU
-pGK
+smU
+smU
 wSc
 jfc
 wSc

--- a/_maps/map_files/Mammoth/Mammoth.dmm
+++ b/_maps/map_files/Mammoth/Mammoth.dmm
@@ -438,11 +438,6 @@
 	},
 /turf/open/floor/wood/ms13/common,
 /area/ms13/town)
-"anA" = (
-/obj/effect/decal/cleanable/glass,
-/obj/structure/ms13/storage/bookshelf,
-/turf/open/floor/wood/ms13/mosaic,
-/area/ms13/town)
 "anG" = (
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/wood/ms13/common,
@@ -914,6 +909,7 @@
 /obj/structure/ms13/storage/shelf/rust{
 	dir = 1
 	},
+/obj/effect/spawner/random/ms13/tools/hardware,
 /turf/open/floor/ms13/concrete,
 /area/ms13/town)
 "aFo" = (
@@ -993,13 +989,6 @@
 	},
 /obj/effect/spawner/random/ms13/gun/tier1,
 /turf/open/floor/ms13/tile/long,
-/area/ms13/town)
-"aIC" = (
-/obj/item/trash/can/food/beans,
-/obj/structure/ms13/storage/large/shelf/rust{
-	dir = 1
-	},
-/turf/open/floor/wood/ms13/common,
 /area/ms13/town)
 "aID" = (
 /obj/effect/turf_decal/ms13/road/horizontalline,
@@ -1395,7 +1384,7 @@
 	dir = 4
 	},
 /obj/structure/table/ms13/no_smooth/wood,
-/turf/open/floor/wood/ms13/mosaic,
+/turf/open/floor/wood/ms13/carpet/shaggy,
 /area/ms13/town)
 "aWm" = (
 /obj/structure/chair/ms13/wood{
@@ -1525,13 +1514,6 @@
 	dir = 1
 	},
 /turf/open/floor/wood/ms13/common,
-/area/ms13/town)
-"aZQ" = (
-/obj/item/trash/can/food/beans,
-/obj/structure/ms13/storage/store{
-	dir = 4
-	},
-/turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "bas" = (
 /obj/item/trash/energybar,
@@ -2934,6 +2916,10 @@
 "bXh" = (
 /obj/machinery/oven,
 /turf/open/floor/ms13/tile,
+/area/ms13/town)
+"bXx" = (
+/obj/machinery/door/unpowered/ms13/wood,
+/turf/open/floor/wood/ms13/carpet/shaggy,
 /area/ms13/town)
 "bYv" = (
 /obj/effect/decal/cleanable/generic,
@@ -4391,6 +4377,11 @@
 /obj/item/clothing/suit/apron/chef,
 /turf/open/floor/ms13/tile/long,
 /area/ms13/town)
+"ddR" = (
+/obj/effect/decal/cleanable/glass,
+/obj/structure/table/ms13/low_wall/wood,
+/turf/open/floor/wood/ms13/carpet/shaggy,
+/area/ms13/town)
 "ddS" = (
 /obj/structure/barricade/wooden/snowed,
 /obj/structure/barricade/wooden/crude/snow,
@@ -4591,6 +4582,10 @@
 "dkk" = (
 /turf/closed/wall/ms13/brick/gray,
 /area/ms13/town)
+"dky" = (
+/obj/structure/ms13/storage/bookshelf,
+/turf/open/floor/wood/ms13/carpet/shaggy,
+/area/ms13/town)
 "dkF" = (
 /obj/structure/table/ms13/metal,
 /obj/effect/decal/cleanable/blood/old,
@@ -4601,6 +4596,10 @@
 /obj/item/secateurs/ms13/shears,
 /turf/open/floor/ms13/tile,
 /area/ms13/town)
+"dlb" = (
+/obj/machinery/light/ms13,
+/turf/open/floor/ms13/tile/large/white,
+/area/ms13/underground/vault_atrium_middle)
 "dlh" = (
 /obj/structure/chair/office/ms13/red,
 /turf/open/floor/wood/ms13/common,
@@ -5709,7 +5708,7 @@
 /area/ms13/town)
 "eaF" = (
 /obj/structure/closet/cabinet,
-/turf/open/floor/wood/ms13/mosaic,
+/turf/open/floor/wood/ms13/carpet/shaggy,
 /area/ms13/town)
 "eaJ" = (
 /obj/structure/table/ms13/metal,
@@ -7311,6 +7310,9 @@
 "fcY" = (
 /obj/structure/table/ms13/metal,
 /obj/effect/spawner/random/ms13/medical/lowrandom,
+/obj/machinery/light/ms13{
+	dir = 1
+	},
 /turf/open/floor/ms13/tile/large/white,
 /area/ms13/underground/vault_atrium_middle)
 "fdh" = (
@@ -7641,9 +7643,6 @@
 "fnP" = (
 /obj/structure/table/ms13/metal,
 /obj/item/storage/firstaid/ms13/quality,
-/obj/machinery/light/ms13{
-	dir = 4
-	},
 /turf/open/floor/ms13/tile/large/white,
 /area/ms13/underground/vault_atrium_middle)
 "fnQ" = (
@@ -8795,6 +8794,11 @@
 	},
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
+"fXX" = (
+/obj/structure/window/fulltile/ms13/glass,
+/obj/structure/table/ms13/low_wall/wood,
+/turf/open/floor/wood/ms13/carpet/shaggy,
+/area/ms13/town)
 "fYe" = (
 /obj/machinery/light/ms13{
 	dir = 8
@@ -9730,9 +9734,6 @@
 /area/ms13/underground/vault_atrium_middle)
 "gAZ" = (
 /obj/machinery/iv_drip/ms13,
-/obj/machinery/light/ms13{
-	dir = 8
-	},
 /turf/open/floor/ms13/tile/large/white,
 /area/ms13/underground/vault_atrium_middle)
 "gBf" = (
@@ -11207,6 +11208,14 @@
 /obj/structure/table/ms13/low_wall/brick/alt,
 /turf/open/floor/ms13/tile/full/navy,
 /area/ms13/town)
+"hDb" = (
+/obj/structure/table/ms13/metal/alt,
+/obj/effect/spawner/random/ms13/medical/lowrandom,
+/obj/machinery/light/ms13/bulb{
+	dir = 1
+	},
+/turf/open/floor/ms13/tile/blue,
+/area/ms13/town)
 "hDD" = (
 /obj/structure/chair/sofa/corp/left{
 	dir = 4
@@ -11243,10 +11252,6 @@
 	pixel_y = 8
 	},
 /turf/open/floor/ms13/tile/brown,
-/area/ms13/town)
-"hFs" = (
-/obj/structure/bed/ms13/bedframe/wood,
-/turf/open/floor/wood/ms13/mosaic,
 /area/ms13/town)
 "hFw" = (
 /obj/item/ms13_small_flag/usa{
@@ -12160,7 +12165,7 @@
 /obj/structure/table/ms13/no_smooth/large/metal/desk{
 	dir = 1
 	},
-/turf/open/floor/wood/ms13/mosaic,
+/turf/open/floor/wood/ms13/carpet/shaggy,
 /area/ms13/town)
 "iii" = (
 /obj/effect/decal/cleanable/oil,
@@ -13523,10 +13528,6 @@
 	},
 /turf/open/floor/ms13/tile,
 /area/ms13/town)
-"iUN" = (
-/obj/structure/closet,
-/turf/open/floor/ms13/concrete,
-/area/ms13/town)
 "iUT" = (
 /obj/machinery/vending/snack,
 /turf/open/floor/ms13/tile/blue/long,
@@ -14721,11 +14722,6 @@
 	},
 /turf/open/floor/ms13/tile,
 /area/ms13/town)
-"jBZ" = (
-/obj/machinery/light/ms13/bulb/broken,
-/obj/structure/bed/ms13/medical,
-/turf/open/floor/ms13/tile/blue,
-/area/ms13/town)
 "jCj" = (
 /obj/structure/table/ms13/wood,
 /obj/machinery/ms13/terminal{
@@ -14875,9 +14871,9 @@
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "jFx" = (
-/obj/machinery/light/ms13/bulb,
 /obj/structure/table/ms13/metal/alt,
 /obj/effect/spawner/random/ms13/medical/highrandom,
+/obj/machinery/light/ms13/bulb,
 /turf/open/floor/ms13/tile/blue,
 /area/ms13/town)
 "jFK" = (
@@ -16803,22 +16799,6 @@
 /obj/effect/mob_spawn/human/corpse/ms13/wastelander,
 /turf/open/floor/ms13/tile/large/white,
 /area/ms13/supermarket)
-"kRe" = (
-/obj/machinery/light/ms13{
-	dir = 1
-	},
-/obj/structure/railing/ms13/solo{
-	dir = 4
-	},
-/obj/effect/spawner/random/ms13/drink/soda,
-/obj/structure/ms13/storage/shelf{
-	dir = 4
-	},
-/obj/structure/ms13/storage/shelf{
-	dir = 8
-	},
-/turf/open/floor/ms13/tile/large/white,
-/area/ms13/supermarket)
 "kRl" = (
 /obj/effect/decal/cleanable/blood/footprints,
 /turf/open/floor/ms13/tile/large/white,
@@ -17874,27 +17854,7 @@
 /obj/structure/ms13/storage/shelf/rust{
 	dir = 1
 	},
-/obj/item/shovel/ms13/rake,
-/turf/open/floor/ms13/tile/large/white,
-/area/ms13/supermarket)
-"lvp" = (
-/obj/structure/ms13/storage/shelf/rust{
-	dir = 1
-	},
-/turf/open/floor/ms13/tile/large/white,
-/area/ms13/supermarket)
-"lvu" = (
-/obj/item/shovel/ms13,
-/obj/structure/ms13/storage/shelf/rust{
-	dir = 1
-	},
-/turf/open/floor/ms13/tile/large/white,
-/area/ms13/supermarket)
-"lvv" = (
-/obj/structure/ms13/storage/shelf/rust{
-	dir = 1
-	},
-/obj/item/shovel/ms13/spade,
+/obj/effect/spawner/random/ms13/tools/hardware,
 /turf/open/floor/ms13/tile/large/white,
 /area/ms13/supermarket)
 "lvz" = (
@@ -18438,6 +18398,12 @@
 	dir = 10
 	},
 /turf/open/floor/wood/ms13/common,
+/area/ms13/town)
+"lLw" = (
+/obj/structure/table/ms13/metal/alt,
+/obj/effect/spawner/random/ms13/medical/lowrandom,
+/obj/machinery/light/ms13/bulb,
+/turf/open/floor/ms13/tile/blue,
 /area/ms13/town)
 "lLx" = (
 /obj/machinery/light/ms13/broken,
@@ -19896,13 +19862,6 @@
 /obj/effect/spawner/random/ms13/tools/hardware,
 /turf/open/floor/plating/ms13/ground/sidewalk,
 /area/ms13/town)
-"mOc" = (
-/obj/structure/closet,
-/obj/machinery/light/ms13{
-	dir = 8
-	},
-/turf/open/floor/ms13/concrete,
-/area/ms13/town)
 "mOm" = (
 /obj/structure/bed/ms13/mattress/filthy,
 /turf/open/floor/plating/ms13/ground/mountain,
@@ -20110,6 +20069,7 @@
 	dir = 1
 	},
 /obj/structure/ms13/storage/shelf/rust,
+/obj/effect/spawner/random/ms13/tools/hardware,
 /turf/open/floor/ms13/concrete,
 /area/ms13/town)
 "mUG" = (
@@ -20747,6 +20707,14 @@
 /obj/structure/table/ms13/metal,
 /obj/effect/spawner/random/ms13/ammo/lowrandom,
 /turf/open/floor/ms13/tile/full/navy,
+/area/ms13/town)
+"nrs" = (
+/obj/structure/table/ms13/metal/alt,
+/obj/effect/spawner/random/ms13/medical/highrandom,
+/obj/machinery/light/ms13/bulb{
+	dir = 1
+	},
+/turf/open/floor/ms13/tile/blue,
 /area/ms13/town)
 "nrv" = (
 /obj/item/ammo_casing/ms13/c10mm/junk,
@@ -21607,6 +21575,10 @@
 	dir = 1
 	},
 /turf/open/floor/wood/ms13/wide,
+/area/ms13/town)
+"nUs" = (
+/obj/structure/bed/ms13/bedframe/wood,
+/turf/open/floor/wood/ms13/carpet/shaggy,
 /area/ms13/town)
 "nUx" = (
 /obj/machinery/light/ms13/bulb/broken,
@@ -22785,6 +22757,12 @@
 /obj/item/ms13/brick,
 /turf/open/floor/plating/ms13/ground/mountain,
 /area/ms13/town)
+"oOs" = (
+/obj/machinery/door/unpowered/ms13/wood{
+	dir = 8
+	},
+/turf/open/floor/wood/ms13/carpet/shaggy,
+/area/ms13/town)
 "oOv" = (
 /obj/structure/ms13/storage/large/shelf/rust{
 	dir = 1
@@ -23382,6 +23360,13 @@
 	},
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
+"qfT" = (
+/obj/item/clothing/head/cone,
+/obj/machinery/light/ms13{
+	dir = 4
+	},
+/turf/open/floor/ms13/tile/large/white,
+/area/ms13/supermarket)
 "qgR" = (
 /turf/open/floor/ms13/concrete/industrial/alt,
 /area/ms13/town)
@@ -24461,6 +24446,11 @@
 	},
 /turf/open/floor/ms13/concrete/industrial/alt,
 /area/ms13/town)
+"tkH" = (
+/obj/structure/table/ms13/metal/alt,
+/obj/effect/spawner/random/ms13/tools/hardware,
+/turf/open/floor/wood/ms13/common,
+/area/ms13/town)
 "tkS" = (
 /obj/machinery/power/port_gen/pacman{
 	name = "pretend this is a part of generator"
@@ -24938,6 +24928,10 @@
 /obj/item/ammo_casing/spent,
 /turf/open/floor/ms13/tile/large/white,
 /area/ms13/supermarket)
+"uTd" = (
+/obj/structure/chair/ms13/metal,
+/turf/open/floor/wood/ms13/carpet/shaggy,
+/area/ms13/town)
 "uXf" = (
 /obj/structure/closet/crate/ms13/footlocker{
 	dir = 4
@@ -25635,7 +25629,7 @@
 /area/ms13/town)
 "xiV" = (
 /obj/structure/dresser/ms13/orange,
-/turf/open/floor/wood/ms13/mosaic,
+/turf/open/floor/wood/ms13/carpet/shaggy,
 /area/ms13/town)
 "xjj" = (
 /turf/open/floor/ms13/metal,
@@ -25684,6 +25678,12 @@
 "xpj" = (
 /obj/structure/closet/crate/ms13/woodcrate,
 /turf/open/floor/ms13/tile/brown,
+/area/ms13/town)
+"xpk" = (
+/obj/machinery/light/ms13/bulb{
+	dir = 8
+	},
+/turf/open/floor/wood/ms13/carpet/shaggy,
 /area/ms13/town)
 "xpt" = (
 /obj/structure/table/ms13/no_smooth/large/wood/square,
@@ -26010,7 +26010,7 @@
 "yju" = (
 /obj/structure/bed/ms13/bedframe/cot,
 /obj/structure/bed/ms13/mattress/yellowed,
-/turf/open/floor/wood/ms13/mosaic,
+/turf/open/floor/wood/ms13/carpet/shaggy,
 /area/ms13/town)
 "ykd" = (
 /mob/living/basic/ms13/hostile_animal/hellpig,
@@ -35113,7 +35113,7 @@ khQ
 khQ
 ylG
 ylG
-ykZ
+ehh
 ykZ
 ykZ
 ykZ
@@ -35415,12 +35415,12 @@ khQ
 khQ
 ylG
 ylG
+ehh
 ykZ
-anA
-xih
-xih
-xih
-aOe
+dky
+xpk
+aKu
+bXx
 xih
 xih
 xih
@@ -35717,10 +35717,10 @@ khQ
 khQ
 khQ
 ylG
-aka
-ecs
-xih
-xih
+ehh
+ddR
+aKs
+aKu
 ihZ
 ykZ
 uAa
@@ -36019,11 +36019,11 @@ khQ
 khQ
 khQ
 ylG
+ehh
 ykZ
-hFs
-xih
-ixX
-xih
+nUs
+uTd
+aKu
 ykZ
 uAa
 xih
@@ -36321,7 +36321,7 @@ khQ
 khQ
 khQ
 ylG
-ykZ
+ehh
 ykZ
 ykZ
 ykZ
@@ -36932,7 +36932,7 @@ ykZ
 ykZ
 ykZ
 ykZ
-ixJ
+oOs
 ykZ
 ykZ
 ykZ
@@ -37233,8 +37233,8 @@ ykZ
 apm
 scA
 dLI
-xih
-xih
+aKu
+aKu
 eaF
 ykZ
 ylG
@@ -37535,10 +37535,10 @@ ykZ
 ayi
 aEU
 ykZ
-xih
-xih
-xih
-dTF
+aKu
+aKu
+aKu
+fXX
 ylG
 ylG
 ylG
@@ -37840,7 +37840,7 @@ ykZ
 xiV
 aWf
 yju
-dTF
+fXX
 ylG
 ylG
 ylG
@@ -38824,7 +38824,7 @@ fcY
 mLr
 fmd
 fmd
-fmd
+dlb
 ylm
 cOO
 cOO
@@ -45408,7 +45408,7 @@ cfi
 wSc
 wSc
 wSc
-aIC
+vBJ
 jIO
 aqJ
 scA
@@ -47970,7 +47970,7 @@ axO
 jIO
 sIA
 fiE
-jBZ
+jej
 jIO
 kAW
 xZD
@@ -48263,7 +48263,7 @@ ylG
 ylG
 ylG
 jIO
-jeR
+nrs
 fiE
 sIA
 jjF
@@ -48272,7 +48272,7 @@ axO
 jxu
 sIA
 fiE
-jeX
+lLw
 jIO
 yic
 xZD
@@ -49471,7 +49471,7 @@ ylG
 ylG
 ylG
 jIO
-jeX
+hDb
 fiE
 sIA
 jjF
@@ -54371,8 +54371,8 @@ mMQ
 dss
 tmH
 jIO
-iUN
-mOc
+cbe
+qdD
 mBi
 mBi
 mBi
@@ -57378,7 +57378,7 @@ xZD
 xZD
 jIO
 jIO
-eQw
+tkH
 jIO
 mjr
 wSc
@@ -70756,7 +70756,7 @@ khQ
 khQ
 khQ
 pwP
-aZQ
+gZW
 gZW
 cjk
 bzf
@@ -81221,7 +81221,7 @@ vSh
 lkT
 sQr
 sQr
-lvp
+lvf
 vSh
 qeJ
 tod
@@ -81523,7 +81523,7 @@ vSh
 sQr
 sQr
 sQr
-lvu
+lvf
 vSh
 tod
 tod
@@ -81825,7 +81825,7 @@ vSh
 sQr
 sQr
 sQr
-lvv
+lvf
 vSh
 lCm
 tod
@@ -84233,7 +84233,7 @@ vSh
 sQr
 sQr
 vSh
-kyX
+sQr
 sQr
 sQr
 sQr
@@ -85138,7 +85138,7 @@ sQr
 vSh
 sQr
 sQr
-kOx
+qfT
 sQr
 kOx
 sQr
@@ -85441,7 +85441,7 @@ vSh
 sQr
 sQr
 vSh
-kRe
+kUY
 kUY
 sQr
 sQr
@@ -86649,7 +86649,7 @@ sTz
 kIQ
 hAQ
 vSh
-kRe
+kUY
 kUY
 sQr
 sQr
@@ -86950,7 +86950,7 @@ pid
 sQr
 hAQ
 sQr
-sQr
+lox
 sQr
 sQr
 kYG
@@ -87857,7 +87857,7 @@ vSh
 kJf
 kJf
 vSh
-kzy
+isB
 kVn
 isB
 vSh

--- a/_maps/map_files/Mammoth/Mammoth.dmm
+++ b/_maps/map_files/Mammoth/Mammoth.dmm
@@ -21876,10 +21876,12 @@
 /turf/open/floor/wood/ms13/common,
 /area/ms13/town)
 "odJ" = (
-/obj/structure/flora/rock/jungle,
-/obj/structure/flora/rock/pile,
-/turf/open/floor/plating/ms13/ground/mountain,
-/area/ms13/underground/mountain)
+/obj/structure/sink{
+	pixel_y = 24
+	},
+/obj/effect/landmark/start/ms13/wastelander,
+/turf/open/floor/ms13/tile,
+/area/ms13/town)
 "oef" = (
 /obj/effect/spawner/random/ms13/armor/headgear,
 /turf/open/floor/plating/ms13/ground/mountain,
@@ -21956,9 +21958,11 @@
 /turf/open/floor/plating/ms13/ground/mountain,
 /area/ms13/underground/mountain)
 "ogP" = (
-/obj/structure/flora/rock/pile,
-/turf/open/floor/plating/ms13/ground/mountain,
-/area/ms13/underground/mountain)
+/mob/living/simple_animal/hostile/retaliate/ms13/slepnir{
+	dir = 8
+	},
+/turf/open/floor/plating/ms13/ground/snow,
+/area/ms13/snow/deepforest)
 "ogZ" = (
 /obj/structure/fence/fencedoorside{
 	pixel_x = -2
@@ -22101,15 +22105,6 @@
 	},
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
-"olH" = (
-/obj/structure/flora/rock/pile,
-/turf/closed/indestructible/rock/ms13/mammoth,
-/area/ms13/underground/mountain)
-"olL" = (
-/obj/structure/flora/rock/pile,
-/obj/structure/flora/rock/pile,
-/turf/closed/indestructible/rock/ms13/mammoth,
-/area/ms13/underground/mountain)
 "olQ" = (
 /obj/structure/stairs/north,
 /obj/structure/railing/ms13/solo{
@@ -28555,7 +28550,7 @@ xsE
 xsE
 xsE
 ykZ
-ats
+odJ
 cjH
 wSc
 wSc
@@ -29668,7 +29663,7 @@ ylG
 ylG
 mXV
 oct
-odJ
+jTH
 xmo
 xmo
 khQ
@@ -29985,7 +29980,7 @@ kCC
 kCC
 xmo
 xmo
-ogP
+xmo
 xmo
 khQ
 khQ
@@ -31481,7 +31476,7 @@ khQ
 khQ
 nSG
 nNn
-ogP
+xmo
 khQ
 khQ
 khQ
@@ -32387,7 +32382,7 @@ khQ
 khQ
 khQ
 xmo
-ogP
+xmo
 xmo
 xmo
 khQ
@@ -32692,7 +32687,7 @@ khQ
 xmo
 oiB
 xmo
-ogP
+xmo
 khQ
 khQ
 khQ
@@ -33093,7 +33088,7 @@ ylG
 ylG
 ylG
 ylG
-sCy
+ylG
 nfu
 nfu
 yib
@@ -33597,7 +33592,7 @@ xmo
 pyY
 khQ
 khQ
-olH
+khQ
 xmo
 nNn
 xmo
@@ -33899,12 +33894,12 @@ xmo
 khQ
 khQ
 khQ
-olL
+khQ
 khQ
 xmo
 nOV
 xmo
-ogP
+xmo
 xmo
 khQ
 khQ
@@ -36719,7 +36714,7 @@ xsE
 ylG
 xsE
 ybZ
-ybZ
+ogP
 khQ
 khQ
 khQ

--- a/_maps/map_files/Mammoth/Mammoth.dmm
+++ b/_maps/map_files/Mammoth/Mammoth.dmm
@@ -106,7 +106,7 @@
 /obj/structure/table/ms13/metal,
 /obj/item/wrench/ms13,
 /obj/effect/spawner/random/ms13/tools/hardware,
-/turf/open/floor/wood/ms13/common,
+/turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "adk" = (
 /obj/effect/turf_decal/ms13/road/verticalline,
@@ -116,14 +116,21 @@
 "adl" = (
 /obj/structure/table/ms13/metal,
 /obj/effect/spawner/random/ms13/tools/lights,
-/turf/open/floor/wood/ms13/common,
+/turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "adm" = (
 /obj/structure/table/ms13/metal,
-/obj/item/storage/firstaid/ms13/bag/filled{
-	pixel_y = 6
+/obj/item/retractor{
+	pixel_x = 4;
+	pixel_y = 2
 	},
-/turf/open/floor/ms13/tile,
+/obj/item/hemostat{
+	pixel_x = -5
+	},
+/obj/item/scalpel{
+	pixel_y = 16
+	},
+/turf/open/floor/ms13/tile/navy,
 /area/ms13/town)
 "adp" = (
 /obj/structure/chair/ms13/metal/unfinished{
@@ -145,8 +152,14 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/blood/old,
-/obj/structure/bed/ms13/bedframe/metal,
-/turf/open/floor/ms13/tile,
+/obj/effect/decal/cleanable/blood/old{
+	pixel_x = -7
+	},
+/obj/effect/decal/cleanable/blood/old{
+	pixel_x = -9
+	},
+/obj/structure/bed/ms13/medical/surgery,
+/turf/open/floor/ms13/tile/navy,
 /area/ms13/town)
 "adF" = (
 /turf/open/floor/ms13/concrete/industrial/alt,
@@ -156,7 +169,10 @@
 /obj/effect/decal/cleanable/blood/gibs/core,
 /obj/effect/spawner/random/ms13/medical/lowrandom,
 /obj/effect/spawner/random/ms13/medical/highrandom,
-/turf/open/floor/ms13/tile,
+/obj/item/storage/firstaid/ms13/bag/filled{
+	pixel_y = 6
+	},
+/turf/open/floor/ms13/tile/navy,
 /area/ms13/town)
 "adP" = (
 /obj/structure/table/ms13/no_smooth/large/metal/desk{
@@ -197,7 +213,7 @@
 /obj/structure/railing{
 	dir = 8
 	},
-/turf/open/floor/wood/ms13/common,
+/turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "aeP" = (
 /obj/structure/sink/kitchen{
@@ -210,11 +226,14 @@
 /obj/machinery/light/ms13/bulb{
 	dir = 1
 	},
-/obj/structure/closet/crate/bin{
-	pixel_x = -4;
-	pixel_y = 16
-	},
+/obj/structure/ms13/storage/trashcan,
 /turf/open/floor/wood/ms13/common,
+/area/ms13/town)
+"aff" = (
+/obj/machinery/light/ms13/bulb/broken{
+	dir = 8
+	},
+/turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "afu" = (
 /obj/structure/closet/cabinet,
@@ -275,7 +294,7 @@
 /obj/structure/ms13/storage/shelf{
 	dir = 8
 	},
-/turf/open/floor/wood/ms13/common,
+/turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "ahy" = (
 /obj/structure/closet/crate/ms13/footlocker,
@@ -283,11 +302,10 @@
 	dir = 1
 	},
 /obj/effect/spawner/random/ms13/armor/headgear,
-/turf/open/floor/wood/ms13/common,
+/turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "ahE" = (
-/obj/structure/curtain/cloth,
-/turf/open/floor/ms13/tile,
+/turf/open/floor/ms13/tile/navy,
 /area/ms13/town)
 "ahM" = (
 /obj/structure/fluff/ms13/mammoth_sign,
@@ -299,7 +317,10 @@
 /area/ms13/town)
 "aim" = (
 /obj/structure/ms13/storage/shelf/rust,
-/turf/open/floor/wood/ms13/common,
+/obj/structure/ms13/foundation/common/variantfour{
+	dir = 6
+	},
+/turf/open/floor/plating/ms13/ground/mountain,
 /area/ms13/town)
 "aiu" = (
 /obj/structure/chair/ms13/wood,
@@ -429,7 +450,7 @@
 "anA" = (
 /obj/effect/decal/cleanable/glass,
 /obj/structure/ms13/storage/bookshelf,
-/turf/open/floor/wood/ms13/common,
+/turf/open/floor/wood/ms13/mosaic,
 /area/ms13/town)
 "anG" = (
 /obj/effect/decal/cleanable/glass,
@@ -492,6 +513,7 @@
 /obj/structure/ms13/storage/shelf/rust{
 	dir = 8
 	},
+/obj/effect/spawner/random/ms13/medical/lowrandom,
 /turf/open/floor/wood/ms13/common,
 /area/ms13/town)
 "aqq" = (
@@ -525,6 +547,7 @@
 /obj/structure/toilet{
 	pixel_y = 13
 	},
+/obj/effect/spawner/random/ms13/medical/tier1,
 /obj/effect/spawner/random/ms13/medical/tier1,
 /turf/open/floor/ms13/tile,
 /area/ms13/town)
@@ -631,7 +654,8 @@
 /obj/effect/spawner/random/ms13/drink/alcohol_beer,
 /obj/effect/spawner/random/ms13/drink/alcohol_beer,
 /obj/effect/spawner/random/ms13/food/produce_random,
-/turf/open/floor/ms13/tile,
+/obj/item/food/canned/beans,
+/turf/open/floor/ms13/tile/navy,
 /area/ms13/town)
 "auO" = (
 /obj/structure/toilet{
@@ -688,7 +712,7 @@
 	dir = 1
 	},
 /obj/effect/spawner/random/ms13/clothing/mask,
-/turf/open/floor/wood/ms13/common,
+/turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "awN" = (
 /obj/structure/chair/office/ms13/blue{
@@ -735,6 +759,9 @@
 /obj/structure/toilet,
 /turf/open/floor/ms13/tile,
 /area/ms13/town)
+"ayn" = (
+/turf/open/floor/iron/stairs/left,
+/area/ms13)
 "ays" = (
 /obj/effect/decal/cleanable/generic,
 /turf/open/floor/ms13/tile,
@@ -742,7 +769,7 @@
 "azd" = (
 /obj/effect/spawner/random/ms13/gun/tier1,
 /obj/structure/ms13/storage/shelf,
-/turf/open/floor/wood/ms13/common,
+/turf/open/floor/ms13/metal,
 /area/ms13/town)
 "azf" = (
 /obj/effect/decal/cleanable/generic,
@@ -767,7 +794,7 @@
 "azp" = (
 /obj/effect/spawner/random/ms13/medical/tier1,
 /obj/structure/ms13/storage/shelf/rust,
-/turf/open/floor/wood/ms13/common,
+/turf/open/floor/ms13/metal,
 /area/ms13/town)
 "azL" = (
 /obj/effect/decal/cleanable/ash,
@@ -871,11 +898,11 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/glass,
-/turf/open/floor/wood/ms13/common,
+/turf/open/floor/wood/ms13/mosaic,
 /area/ms13/town)
 "aEt" = (
 /obj/item/chair/ms13/wood,
-/turf/open/floor/wood/ms13/common,
+/turf/open/floor/wood/ms13/mosaic,
 /area/ms13/town)
 "aEU" = (
 /obj/structure/curtain,
@@ -929,12 +956,12 @@
 "aGM" = (
 /obj/structure/bed/ms13/sleepingbag/red,
 /obj/effect/spawner/random/ms13/gun/tier1,
-/turf/open/floor/wood/ms13/common,
+/turf/open/floor/ms13/metal,
 /area/ms13/town)
 "aGU" = (
 /obj/effect/decal/cleanable/generic,
 /obj/effect/decal/cleanable/ash,
-/turf/open/floor/wood/ms13/common,
+/turf/open/floor/ms13/metal,
 /area/ms13/town)
 "aGY" = (
 /obj/structure/table/ms13/no_smooth/counter/wood{
@@ -992,7 +1019,7 @@
 /area/ms13/underground/tunnel)
 "aIK" = (
 /obj/machinery/vending/snack,
-/turf/open/floor/wood/ms13/common,
+/turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "aIR" = (
 /obj/structure/closet/crate/ms13/footlocker{
@@ -1000,7 +1027,7 @@
 	},
 /obj/effect/spawner/random/ms13/armor/headgear,
 /obj/effect/spawner/random/ms13/clothing/mask,
-/turf/open/floor/wood/ms13/common,
+/turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "aJd" = (
 /turf/open/floor/plating/ms13/ground/sidewalk/cracked,
@@ -1075,11 +1102,9 @@
 /turf/open/floor/ms13/tile/blue/long,
 /area/ms13/town)
 "aLt" = (
-/obj/structure/ms13/storage/large/shelf/rust{
-	dir = 8
-	},
-/obj/item/bodybag/ms13,
-/turf/open/floor/ms13/tile/blue,
+/obj/structure/closet/ms13/wall/firstaid,
+/obj/effect/spawner/random/ms13/medical/tier1,
+/turf/open/floor/wood/ms13/common,
 /area/ms13/town)
 "aLJ" = (
 /obj/structure/sign/poster/official/fruit_bowl,
@@ -1098,7 +1123,7 @@
 "aMf" = (
 /obj/structure/bed/ms13/sleepingbag/green,
 /obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/wood/ms13/common,
+/turf/open/floor/ms13/metal,
 /area/ms13/town)
 "aMS" = (
 /obj/machinery/light/ms13/bulb{
@@ -1119,7 +1144,7 @@
 "aNs" = (
 /obj/effect/decal/cleanable/blood/drip,
 /mob/living/basic/ms13/hostile_animal/gecko/ice,
-/turf/open/floor/wood/ms13/common,
+/turf/open/floor/ms13/metal,
 /area/ms13/town)
 "aNw" = (
 /turf/closed/wall/ms13/concrete,
@@ -1276,7 +1301,7 @@
 /obj/structure/ms13/storage/large/shelf/rust{
 	dir = 1
 	},
-/turf/open/floor/wood/ms13/common,
+/turf/open/floor/ms13/metal,
 /area/ms13/town)
 "aSC" = (
 /obj/structure/fence/fencenormal{
@@ -1342,7 +1367,7 @@
 /obj/structure/table/ms13/no_smooth/counter/wood{
 	dir = 4
 	},
-/turf/open/floor/wood/ms13/common,
+/turf/open/floor/ms13/tile/navy,
 /area/ms13/town)
 "aUj" = (
 /obj/effect/decal/cleanable/glass,
@@ -1380,7 +1405,7 @@
 	dir = 4
 	},
 /obj/structure/table/ms13/no_smooth/wood,
-/turf/open/floor/wood/ms13/common,
+/turf/open/floor/wood/ms13/mosaic,
 /area/ms13/town)
 "aWm" = (
 /obj/structure/chair/ms13/wood{
@@ -1471,7 +1496,7 @@
 	dir = 1;
 	pixel_y = 6
 	},
-/turf/open/floor/wood/ms13/common,
+/turf/open/floor/ms13/metal,
 /area/ms13/town)
 "aYR" = (
 /obj/structure/closet,
@@ -1503,7 +1528,7 @@
 /obj/structure/chair/sofa/right{
 	dir = 4
 	},
-/turf/open/floor/wood/ms13/carpet/green,
+/turf/open/floor/wood/ms13/carpet/shaggy,
 /area/ms13/town)
 "aZM" = (
 /obj/machinery/door/unpowered/ms13/seethrough/metal{
@@ -1516,7 +1541,7 @@
 /obj/structure/ms13/storage/store{
 	dir = 4
 	},
-/turf/open/floor/wood/ms13/common,
+/turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "bas" = (
 /obj/item/trash/energybar,
@@ -1542,6 +1567,9 @@
 /area/ms13/town)
 "bcy" = (
 /mob/living/basic/ms13/hostile_animal/pigrat,
+/obj/structure/ms13/foundation/variantsix{
+	dir = 1
+	},
 /turf/open/floor/plating/ms13/ground/mountain,
 /area/ms13/town)
 "bcE" = (
@@ -1555,17 +1583,17 @@
 	dir = 4;
 	pixel_x = -12
 	},
-/turf/open/floor/wood/ms13/common,
+/turf/open/floor/ms13/tile/navy,
 /area/ms13/town)
 "bcT" = (
 /obj/structure/table/ms13/no_smooth/large/pool,
-/turf/open/floor/wood/ms13/common,
+/turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "bdm" = (
 /obj/structure/table/ms13/no_smooth/large/pool{
 	dir = 8
 	},
-/turf/open/floor/wood/ms13/common,
+/turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "bdT" = (
 /obj/structure/chair/ms13/wood,
@@ -1635,7 +1663,7 @@
 "bfA" = (
 /obj/effect/decal/cleanable/ash,
 /obj/structure/ms13/storage/shelf/rust,
-/turf/open/floor/wood/ms13/common,
+/turf/open/floor/ms13/metal,
 /area/ms13/town)
 "bfC" = (
 /obj/structure/sink/kitchen{
@@ -1681,13 +1709,17 @@
 /obj/structure/filingcabinet/ms13/short,
 /turf/open/floor/wood/ms13/common,
 /area/ms13/town)
+"biO" = (
+/obj/structure/ms13/storage/shelf/rust,
+/turf/open/floor/wood/ms13/mosaic,
+/area/ms13/town)
 "biR" = (
 /obj/effect/decal/cleanable/glass{
 	pixel_x = 7;
 	pixel_y = 6
 	},
 /obj/effect/decal/cleanable/garbage,
-/turf/open/floor/wood/ms13/common,
+/turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "bjd" = (
 /obj/structure/table/ms13/no_smooth/large/wood/square{
@@ -1722,7 +1754,7 @@
 /obj/structure/table/ms13/no_smooth/counter/wood{
 	dir = 8
 	},
-/turf/open/floor/ms13/tile/blue,
+/turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "bjP" = (
 /obj/structure/ms13/storage/store{
@@ -1745,7 +1777,7 @@
 /obj/machinery/light/ms13/bulb/broken{
 	dir = 1
 	},
-/turf/open/floor/wood/ms13/common,
+/turf/open/floor/wood/ms13/carpet/shaggy/green,
 /area/ms13/town)
 "bkY" = (
 /obj/structure/bonfire,
@@ -1758,10 +1790,7 @@
 /turf/open/floor/wood/ms13/common,
 /area/ms13/town)
 "bme" = (
-/obj/machinery/door/unpowered/ms13/seethrough/metal{
-	dir = 4
-	},
-/turf/open/floor/wood/ms13/common,
+/turf/closed/indestructible/rock/ms13/mammoth,
 /area/ms13/town)
 "bmi" = (
 /obj/structure/table/ms13/metal,
@@ -1793,7 +1822,7 @@
 /obj/structure/table/ms13/no_smooth/large/wood/square{
 	dir = 1
 	},
-/turf/open/floor/wood/ms13/common,
+/turf/open/floor/wood/ms13/mosaic,
 /area/ms13/town)
 "bnz" = (
 /obj/structure/ms13/tv{
@@ -1914,7 +1943,7 @@
 /area/ms13/town)
 "bqS" = (
 /mob/living/basic/ms13/hostile_animal/gecko/ice,
-/turf/open/floor/wood/ms13/common,
+/turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "bry" = (
 /obj/structure/railing/ms13/solo,
@@ -1928,7 +1957,7 @@
 /obj/structure/ms13/storage/store{
 	dir = 1
 	},
-/turf/open/floor/wood/ms13/common,
+/turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "bsa" = (
 /obj/structure/table/ms13/no_smooth/metal,
@@ -2077,6 +2106,12 @@
 /obj/machinery/door/unpowered/ms13/wood/white,
 /turf/open/floor/ms13/tile,
 /area/ms13/town)
+"bxj" = (
+/obj/structure/filingcabinet/ms13{
+	dir = 4
+	},
+/turf/open/floor/wood/ms13/mosaic,
+/area/ms13/town)
 "bxr" = (
 /obj/effect/decal/cleanable/glass{
 	pixel_x = 7;
@@ -2085,7 +2120,7 @@
 /obj/structure/ms13/storage/large/shelf/rust{
 	dir = 1
 	},
-/turf/open/floor/wood/ms13/common,
+/turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "bxA" = (
 /obj/machinery/light/ms13/bulb/built,
@@ -2136,7 +2171,7 @@
 /area/ms13/town)
 "bzf" = (
 /mob/living/basic/ms13/hostile_animal/pigrat,
-/turf/open/floor/wood/ms13/common,
+/turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "bzu" = (
 /obj/structure/ms13/storage/store{
@@ -2290,7 +2325,7 @@
 	dir = 1
 	},
 /obj/structure/ms13/rug/fancy,
-/turf/open/floor/wood/ms13/common,
+/turf/open/floor/wood/ms13/mosaic,
 /area/ms13/town)
 "bEf" = (
 /obj/structure/chair/sofa/right{
@@ -2595,7 +2630,7 @@
 "bLz" = (
 /obj/structure/table/ms13/metal,
 /obj/effect/spawner/random/ms13/clothing/shoe,
-/turf/open/floor/wood/ms13/wide,
+/turf/open/floor/ms13/metal,
 /area/ms13/town)
 "bLE" = (
 /obj/effect/decal/cleanable/glass{
@@ -2700,6 +2735,7 @@
 /obj/structure/closet/crate/ms13/footlocker{
 	dir = 1
 	},
+/obj/effect/spawner/random/ms13/tools/lights,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "bPy" = (
@@ -2887,7 +2923,7 @@
 "bWL" = (
 /obj/effect/decal/cleanable/generic,
 /obj/effect/spawner/random/ms13/melee/lowrandom,
-/turf/open/floor/wood/ms13/common,
+/turf/open/floor/wood/ms13/mosaic,
 /area/ms13/town)
 "bWP" = (
 /obj/effect/decal/cleanable/glass,
@@ -2944,16 +2980,17 @@
 /obj/item/food/meat/slab,
 /obj/item/food/meat/slab,
 /obj/structure/closet/ms13/fridge,
-/turf/open/floor/ms13/tile/long,
+/turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "cay" = (
 /obj/structure/closet/ms13/fridge,
 /obj/item/food/meat/slab,
-/turf/open/floor/ms13/tile/long,
+/turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "caF" = (
-/obj/structure/ms13/storage/store,
-/turf/open/floor/ms13/tile/long,
+/obj/structure/bed/ms13/bedframe/wood,
+/obj/structure/bed/ms13/mattress/filthy,
+/turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "caM" = (
 /obj/structure/ms13/storage/shelf{
@@ -3024,6 +3061,14 @@
 	},
 /turf/open/floor/ms13/tile,
 /area/ms13/town)
+"cds" = (
+/obj/structure/table/ms13/metal,
+/obj/structure/closet/crate/ms13/cash_register{
+	dir = 1;
+	pixel_y = 6
+	},
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/town)
 "cdz" = (
 /obj/structure/kitchenspike,
 /obj/effect/decal/cleanable/blood/splatter,
@@ -3065,7 +3110,7 @@
 /obj/machinery/light/ms13/bulb/broken{
 	dir = 1
 	},
-/obj/structure/closet/crate/bin,
+/obj/structure/ms13/storage/trashcan,
 /turf/open/floor/wood/ms13/common,
 /area/ms13/town)
 "cfl" = (
@@ -3092,14 +3137,16 @@
 	desc = "It's a dead plant. You can't tell what it used to be.";
 	name = "Dead Plant"
 	},
-/turf/open/floor/wood/ms13/common,
+/turf/open/floor/wood/ms13/mosaic,
 /area/ms13/town)
 "cgu" = (
 /obj/machinery/light/ms13/bulb/built{
 	dir = 1
 	},
-/obj/structure/closet/crate/bin,
-/turf/open/floor/wood/ms13/common,
+/obj/structure/ms13/storage/trashcan{
+	pixel_y = 0
+	},
+/turf/open/floor/wood/ms13/mosaic,
 /area/ms13/town)
 "cgz" = (
 /obj/machinery/light/ms13{
@@ -3263,7 +3310,7 @@
 /area/ms13/town)
 "cks" = (
 /obj/structure/table/ms13/metal/grate,
-/turf/open/floor/wood/ms13/carpet/shaggy,
+/turf/open/floor/ms13/tile/full/green,
 /area/ms13/town)
 "ckA" = (
 /obj/item/newspaper,
@@ -3412,17 +3459,17 @@
 /turf/open/floor/ms13/metal,
 /area/ms13/town)
 "coc" = (
-/obj/structure/ms13/storage/store{
-	dir = 4
+/obj/structure/ms13/medical_curtain{
+	dir = 1
 	},
-/turf/open/floor/ms13/tile/long,
+/turf/open/floor/ms13/tile/navy,
 /area/ms13/town)
 "coB" = (
 /obj/structure/table/ms13/metal,
 /obj/structure/closet/crate/ms13/cash_register{
 	dir = 8
 	},
-/turf/open/floor/ms13/tile/long,
+/turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "coP" = (
 /obj/structure/ms13/storage/store{
@@ -3431,10 +3478,8 @@
 /turf/open/floor/ms13/tile/full/navy,
 /area/ms13/town)
 "coY" = (
-/obj/machinery/door/unpowered/ms13/seethrough/metal{
-	dir = 4
-	},
-/turf/open/floor/ms13/tile/long,
+/obj/item/trash/boritos,
+/turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "cpI" = (
 /obj/structure/table/ms13/metal,
@@ -3636,7 +3681,7 @@
 /obj/machinery/door/unpowered/ms13/seethrough/metal{
 	dir = 8
 	},
-/turf/open/floor/ms13/concrete,
+/turf/open/floor/ms13/concrete/industrial/walkway,
 /area/ms13/town)
 "cxB" = (
 /obj/effect/decal/cleanable/oil,
@@ -3661,7 +3706,7 @@
 /obj/machinery/light/ms13/bulb/built{
 	dir = 8
 	},
-/turf/open/floor/wood/ms13/common,
+/turf/open/floor/wood/ms13/mosaic,
 /area/ms13/town)
 "cyD" = (
 /obj/item/trash/can/food/peaches/maint,
@@ -3726,7 +3771,7 @@
 "cCk" = (
 /obj/structure/fluff/paper/stack,
 /obj/structure/table/ms13/no_smooth/counter/wood,
-/turf/open/floor/wood/ms13/common,
+/turf/open/floor/wood/ms13/mosaic,
 /area/ms13/town)
 "cCD" = (
 /obj/structure/table/ms13/no_smooth/counter/wood/bend{
@@ -3735,7 +3780,7 @@
 /obj/structure/closet/crate/ms13/cash_register{
 	dir = 8
 	},
-/turf/open/floor/wood/ms13/common,
+/turf/open/floor/wood/ms13/mosaic,
 /area/ms13/town)
 "cCJ" = (
 /obj/structure/table/ms13/no_smooth/large/wood/square{
@@ -3795,11 +3840,10 @@
 /turf/open/floor/wood/ms13/common,
 /area/ms13/town)
 "cEN" = (
-/obj/structure/closet/crate/bin{
-	pixel_x = -4;
-	pixel_y = 16
+/obj/structure/ms13/foundation/variantfive{
+	dir = 5
 	},
-/turf/open/floor/wood/ms13/common,
+/turf/open/floor/plating/ms13/ground/mountain,
 /area/ms13/town)
 "cEY" = (
 /obj/structure/chair/sofa/right,
@@ -3859,6 +3903,12 @@
 "cIm" = (
 /obj/item/trash/candy,
 /turf/open/floor/wood/ms13/common,
+/area/ms13/town)
+"cIo" = (
+/obj/structure/table/ms13/no_smooth/counter/wood{
+	dir = 1
+	},
+/turf/open/floor/ms13/tile/navy,
 /area/ms13/town)
 "cIv" = (
 /obj/structure/table/ms13/wood/constructed,
@@ -3981,7 +4031,7 @@
 /obj/effect/spawner/random/ms13/clothing/gloves,
 /obj/effect/spawner/random/ms13/clothing/gloves,
 /obj/effect/spawner/random/ms13/clothing/gloves,
-/turf/open/floor/wood/ms13/wide,
+/turf/open/floor/ms13/metal,
 /area/ms13/town)
 "cNr" = (
 /obj/structure/chair/sofa/left{
@@ -4111,7 +4161,7 @@
 /obj/structure/filingcabinet/ms13{
 	dir = 4
 	},
-/turf/open/floor/wood/ms13/common,
+/turf/open/floor/wood/ms13/mosaic,
 /area/ms13/town)
 "cRU" = (
 /obj/structure/table/ms13/no_smooth/counter/wood{
@@ -4127,7 +4177,7 @@
 /obj/machinery/light/ms13/bulb/broken{
 	dir = 4
 	},
-/turf/open/floor/wood/ms13/common,
+/turf/open/floor/wood/ms13/mosaic,
 /area/ms13/town)
 "cRY" = (
 /obj/effect/decal/cleanable/glass{
@@ -4164,6 +4214,9 @@
 	},
 /turf/open/floor/ms13/tile,
 /area/ms13/town)
+"cTb" = (
+/turf/open/ms13/water/deep,
+/area/ms13)
 "cTw" = (
 /obj/structure/chair/stool{
 	pixel_x = 6;
@@ -4190,7 +4243,7 @@
 /obj/structure/ms13/storage/shelf{
 	dir = 1
 	},
-/turf/open/floor/wood/ms13/common,
+/turf/open/floor/ms13/metal,
 /area/ms13/town)
 "cUC" = (
 /obj/structure/ms13/storage/shelf,
@@ -4223,11 +4276,17 @@
 /obj/machinery/door/unpowered/ms13/seethrough/metal{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
 /turf/open/floor/ms13/tile/blue/long,
 /area/ms13/town)
 "cXi" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 9
+	},
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
 	},
 /turf/open/floor/ms13/tile/long,
 /area/ms13/town)
@@ -4290,9 +4349,10 @@
 /turf/open/openspace/ms13,
 /area/ms13/underground/subway)
 "dcj" = (
-/obj/structure/table/ms13/metal,
-/obj/effect/spawner/random/ms13/medical/lowrandom,
-/turf/open/floor/wood/ms13/common,
+/obj/structure/ms13/foundation/common/varianttwo{
+	dir = 1
+	},
+/turf/open/floor/plating/ms13/ground/mountain,
 /area/ms13/town)
 "dcy" = (
 /obj/structure/ms13/storage/shelf{
@@ -4430,6 +4490,10 @@
 	dir = 4
 	},
 /turf/open/floor/ms13/tile,
+/area/ms13/town)
+"dgQ" = (
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "dhB" = (
 /obj/structure/chair/office/ms13/red{
@@ -4573,8 +4637,10 @@
 /turf/open/floor/wood/ms13/common,
 /area/ms13/town)
 "dma" = (
-/obj/machinery/door/unpowered/ms13/metal/alt,
-/turf/open/floor/wood/ms13/carpet,
+/obj/structure/ms13/storage/large/shelf/rust{
+	dir = 8
+	},
+/turf/open/floor/ms13/metal,
 /area/ms13/town)
 "dmf" = (
 /obj/effect/decal/cleanable/generic,
@@ -4672,11 +4738,8 @@
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "dpA" = (
-/obj/structure/closet/crate/bin{
-	pixel_x = -4;
-	pixel_y = 16
-	},
 /obj/effect/spawner/random/ms13/medical/tier1,
+/obj/structure/ms13/storage/trashcan,
 /turf/open/floor/ms13/tile,
 /area/ms13/town)
 "dqF" = (
@@ -5089,7 +5152,7 @@
 /obj/structure/chair/sofa/left{
 	dir = 4
 	},
-/turf/open/floor/wood/ms13/carpet/green,
+/turf/open/floor/wood/ms13/carpet/shaggy,
 /area/ms13/town)
 "dIx" = (
 /obj/structure/closet/ms13/fridge,
@@ -5136,6 +5199,11 @@
 	},
 /turf/open/floor/wood/ms13/carpet/green,
 /area/ms13/town)
+"dJW" = (
+/obj/structure/table/ms13/metal,
+/obj/effect/spawner/random/ms13/medical/tier1,
+/turf/open/floor/ms13/metal,
+/area/ms13/town)
 "dKe" = (
 /obj/machinery/door/unpowered/ms13/wood,
 /turf/open/floor/ms13/tile/large/checkered,
@@ -5168,6 +5236,10 @@
 "dLo" = (
 /obj/structure/railing/ms13/solo/industrial,
 /turf/open/openspace/ms13,
+/area/ms13/town)
+"dLI" = (
+/obj/machinery/door/unpowered/ms13/wood,
+/turf/open/floor/wood/ms13/mosaic,
 /area/ms13/town)
 "dMo" = (
 /obj/effect/decal/cleanable/blood/drip{
@@ -5261,6 +5333,10 @@
 "dRb" = (
 /obj/effect/decal/cleanable/blood/tracks,
 /obj/machinery/door/unpowered/ms13/wood/mirrored,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/town)
+"dRf" = (
+/obj/structure/bonfire,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "dRg" = (
@@ -5497,6 +5573,10 @@
 /obj/structure/table/ms13/metal,
 /turf/open/floor/ms13/tile/large/white,
 /area/ms13/town)
+"dWj" = (
+/mob/living/basic/ms13/hostile_animal/giantant,
+/turf/open/floor/ms13/metal,
+/area/ms13/town)
 "dWn" = (
 /obj/structure/closet/cabinet,
 /obj/effect/spawner/random/ms13/armor/tier1,
@@ -5634,6 +5714,10 @@
 	},
 /turf/open/floor/wood/ms13/common,
 /area/ms13/town)
+"eaF" = (
+/obj/structure/closet/cabinet,
+/turf/open/floor/wood/ms13/mosaic,
+/area/ms13/town)
 "eaJ" = (
 /obj/structure/table/ms13/metal,
 /obj/item/paper_bin{
@@ -5668,9 +5752,9 @@
 /turf/open/floor/ms13/tile/large/white,
 /area/ms13/town)
 "ecs" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/turf/open/floor/plating/ms13/ground/mountain,
-/area/ms13/underground/mountain)
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/wood/ms13/mosaic,
+/area/ms13/town)
 "ecw" = (
 /obj/structure/window/fulltile/ms13/glass,
 /obj/structure/table/ms13/low_wall/brick/alt,
@@ -5753,6 +5837,10 @@
 	dir = 8
 	},
 /turf/open/floor/wood/ms13/common,
+/area/ms13/town)
+"efa" = (
+/obj/machinery/light/ms13/bulb/broken,
+/turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "eft" = (
 /obj/effect/turf_decal/ms13/road/verticalline,
@@ -5863,6 +5951,10 @@
 /obj/structure/table/ms13/low_wall/brick/alt,
 /obj/structure/barricade/wooden/snowed,
 /turf/open/floor/wood/ms13/common,
+/area/ms13/town)
+"eju" = (
+/obj/structure/chair/ms13/wood/padded,
+/turf/open/floor/wood/ms13/mosaic,
 /area/ms13/town)
 "ejy" = (
 /obj/structure/ms13/vehicle_ruin{
@@ -6069,6 +6161,7 @@
 "eqs" = (
 /obj/effect/spawner/random/ms13/armor/tier1,
 /obj/structure/closet/crate/ms13/footlocker,
+/obj/effect/spawner/random/ms13/medical/tier1,
 /turf/open/floor/wood/ms13/common,
 /area/ms13/town)
 "erh" = (
@@ -6806,7 +6899,7 @@
 /area/ms13/underground/tunnel/maintenance)
 "ePJ" = (
 /obj/effect/spawner/random/ms13/gun/tier1,
-/turf/open/floor/wood/ms13/common,
+/turf/open/floor/ms13/metal,
 /area/ms13/town)
 "ePT" = (
 /obj/structure/table/ms13/no_smooth/counter/wood,
@@ -6976,6 +7069,10 @@
 	dir = 1
 	},
 /turf/open/floor/wood/ms13/common,
+/area/ms13/town)
+"eVg" = (
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/ms13/metal,
 /area/ms13/town)
 "eVm" = (
 /obj/machinery/light/ms13,
@@ -7330,7 +7427,7 @@
 "fgZ" = (
 /obj/structure/table/ms13/metal,
 /obj/effect/spawner/random/ms13/medical/highrandom,
-/turf/open/floor/wood/ms13/common,
+/turf/open/floor/ms13/metal,
 /area/ms13/town)
 "fhE" = (
 /obj/structure/chair/ms13/metal/unfinished,
@@ -7592,7 +7689,7 @@
 	dir = 4
 	},
 /obj/effect/spawner/random/ms13/drink/alcohol_beer,
-/turf/open/floor/wood/ms13/common,
+/turf/open/floor/ms13/tile/navy,
 /area/ms13/town)
 "foO" = (
 /obj/structure/ms13/storage/large/shelf,
@@ -7794,6 +7891,10 @@
 /obj/structure/closet/crate/ms13/medical,
 /turf/open/floor/ms13/tile/large/black,
 /area/ms13/underground/vault_atrium_middle)
+"fuW" = (
+/obj/effect/spawner/random/ms13/tools/lights,
+/turf/open/floor/wood/ms13/common,
+/area/ms13/town)
 "fuX" = (
 /obj/effect/turf_decal/ms13/road/verticalline,
 /mob/living/simple_animal/hostile/retaliate/ms13/robot/eyebot,
@@ -7848,7 +7949,7 @@
 /obj/machinery/light/ms13/bulb{
 	dir = 1
 	},
-/turf/open/floor/wood/ms13/carpet/shaggy,
+/turf/open/floor/ms13/tile/full/green,
 /area/ms13/town)
 "fxL" = (
 /obj/structure/fluff/paper/stack{
@@ -8061,7 +8162,7 @@
 /obj/structure/ms13/tv{
 	pixel_y = 12
 	},
-/turf/open/floor/wood/ms13/carpet/green,
+/turf/open/floor/wood/ms13/carpet/shaggy,
 /area/ms13/town)
 "fDi" = (
 /obj/machinery/light/ms13{
@@ -9096,7 +9197,7 @@
 /obj/item/clothing/shoes/workboots/mining,
 /obj/effect/spawner/random/ms13/armor/headgear,
 /obj/effect/spawner/random/ms13/clothing/mask,
-/turf/open/floor/wood/ms13/common,
+/turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "gjP" = (
 /obj/structure/closet/crate/ms13/vault_tec/long,
@@ -9206,7 +9307,8 @@
 /obj/effect/spawner/random/ms13/food/produce_random,
 /obj/effect/spawner/random/ms13/drink/alcohol_beer,
 /obj/effect/spawner/random/ms13/food/produce_random,
-/turf/open/floor/ms13/tile,
+/obj/item/food/canned/beans,
+/turf/open/floor/ms13/tile/navy,
 /area/ms13/town)
 "gmE" = (
 /obj/effect/decal/cleanable/blood/tracks{
@@ -9305,7 +9407,9 @@
 /turf/open/floor/wood/ms13/mosaic,
 /area/ms13/town)
 "gpn" = (
-/obj/structure/closet/crate/bin,
+/obj/structure/ms13/storage/trashcan{
+	pixel_y = 0
+	},
 /turf/open/floor/wood/ms13/mosaic,
 /area/ms13/town)
 "gpC" = (
@@ -9386,7 +9490,7 @@
 /obj/structure/table/ms13/no_smooth/counter/wood{
 	dir = 1
 	},
-/turf/open/floor/wood/ms13/carpet/shaggy,
+/turf/open/floor/ms13/tile/full/green,
 /area/ms13/town)
 "gto" = (
 /obj/machinery/power/ms13/streetlamp/corner{
@@ -9655,6 +9759,10 @@
 /obj/effect/landmark/start/ms13/knight,
 /turf/open/floor/ms13/concrete/bricks,
 /area/ms13/underground/bos)
+"gBS" = (
+/obj/effect/spawner/random/ms13/armor/lowrandom,
+/turf/open/floor/ms13/metal,
+/area/ms13/town)
 "gCc" = (
 /obj/structure/table/ms13/metal,
 /obj/item/storage/firstaid/ms13/bag/filled,
@@ -9829,7 +9937,7 @@
 	dir = 4
 	},
 /obj/effect/spawner/random/ms13/medical/lowrandom,
-/turf/open/floor/ms13/tile/blue,
+/turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "gJW" = (
 /mob/living/basic/ms13/ghoul,
@@ -9951,7 +10059,7 @@
 /obj/machinery/door/unpowered/ms13/wood/green{
 	dir = 4
 	},
-/turf/open/floor/wood/ms13/common,
+/turf/open/floor/ms13/metal,
 /area/ms13/town)
 "gNW" = (
 /obj/structure/chair/ms13/metal/unfinished{
@@ -10187,6 +10295,12 @@
 	dir = 8
 	},
 /area/ms13/underground/bos)
+"gUC" = (
+/obj/structure/table/ms13/no_smooth/counter/wood/bend{
+	dir = 8
+	},
+/turf/open/floor/ms13/tile/navy,
+/area/ms13/town)
 "gUG" = (
 /obj/effect/spawner/random/ms13/drink/soda,
 /obj/structure/table/ms13/no_smooth/counter/metal{
@@ -10311,7 +10425,7 @@
 /obj/structure/ms13/storage/vent,
 /obj/structure/table/ms13/metal/grate,
 /obj/effect/spawner/random/ms13/gun/lowrandom,
-/turf/open/floor/wood/ms13/carpet/shaggy,
+/turf/open/floor/ms13/tile/full/green,
 /area/ms13/town)
 "gYH" = (
 /obj/structure/ms13/storage/large/shelf{
@@ -10723,6 +10837,12 @@
 /obj/structure/stairs/east,
 /turf/open/floor/ms13/metal,
 /area/ms13/underground/bos)
+"hpz" = (
+/obj/structure/table/ms13/no_smooth/counter/wood{
+	dir = 4
+	},
+/turf/open/floor/wood/ms13/mosaic,
+/area/ms13/town)
 "hpG" = (
 /obj/structure/stairs,
 /turf/open/floor/plating/ms13/ground/sidewalk,
@@ -10972,12 +11092,20 @@
 	},
 /turf/open/floor/wood/ms13/carpet/green,
 /area/ms13/town)
+"hxX" = (
+/mob/living/simple_animal/hostile/tree{
+	pixel_x = -2
+	},
+/turf/open/floor/plating/ms13/ground/snow,
+/area/ms13)
 "hyB" = (
 /obj/structure/safe/ms13,
 /turf/open/floor/wood/ms13/common,
 /area/ms13/town)
 "hyE" = (
-/obj/structure/closet/crate/bin,
+/obj/structure/ms13/storage/trashcan{
+	pixel_y = 0
+	},
 /turf/open/floor/ms13/tile/large/cafeteria,
 /area/ms13/town)
 "hyH" = (
@@ -11122,8 +11250,8 @@
 /turf/open/floor/ms13/tile/brown,
 /area/ms13/town)
 "hFs" = (
-/mob/living/basic/ms13/hostile_animal/molerat,
-/turf/open/floor/wood/ms13/common,
+/obj/structure/bed/ms13/bedframe/wood,
+/turf/open/floor/wood/ms13/mosaic,
 /area/ms13/town)
 "hFw" = (
 /obj/item/ms13_small_flag/usa{
@@ -11204,13 +11332,13 @@
 /turf/open/floor/ms13/concrete,
 /area/ms13/underground/bos)
 "hJH" = (
-/obj/machinery/door/unpowered/ms13/metal{
-	dir = 4
-	},
-/turf/open/floor/ms13/tile/blue,
+/obj/machinery/iv_drip/ms13,
+/turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "hJM" = (
-/obj/structure/closet/crate/bin,
+/obj/structure/ms13/storage/trashcan{
+	pixel_y = 0
+	},
 /turf/open/floor/ms13/tile/full/navy,
 /area/ms13/town)
 "hKh" = (
@@ -11311,6 +11439,11 @@
 /obj/structure/chair/sofa/corp/left,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
+"hNf" = (
+/obj/structure/table/ms13/metal,
+/obj/effect/spawner/random/ms13/gun/lowrandom,
+/turf/open/floor/ms13/metal,
+/area/ms13/town)
 "hNl" = (
 /obj/structure/window/fulltile/ms13/glass,
 /obj/structure/table/ms13/low_wall/brick/alt,
@@ -11320,6 +11453,10 @@
 /obj/structure/bed/ms13/sleepingbag/green,
 /obj/effect/spawner/random/ms13/gun/lowrandom,
 /turf/open/floor/plating/ms13/ground/sidewalk,
+/area/ms13/town)
+"hNQ" = (
+/obj/structure/barricade/sandbags,
+/turf/open/floor/wood/ms13/mosaic,
 /area/ms13/town)
 "hNU" = (
 /obj/structure/fence/fencenormal{
@@ -11555,7 +11692,7 @@
 /area/ms13/town)
 "hUp" = (
 /obj/machinery/door/unpowered/ms13/metal/alt,
-/turf/open/floor/wood/ms13/carpet/shaggy,
+/turf/open/floor/ms13/tile/full/green,
 /area/ms13/town)
 "hUy" = (
 /obj/effect/decal/cleanable/crayon{
@@ -12028,7 +12165,7 @@
 /obj/structure/table/ms13/no_smooth/large/metal/desk{
 	dir = 1
 	},
-/turf/open/floor/wood/ms13/common,
+/turf/open/floor/wood/ms13/mosaic,
 /area/ms13/town)
 "iii" = (
 /obj/effect/decal/cleanable/oil,
@@ -12240,7 +12377,7 @@
 /area/ms13/town)
 "iom" = (
 /obj/effect/landmark/start/ms13/sawbone,
-/turf/open/floor/ms13/tile,
+/turf/open/floor/ms13/tile/navy,
 /area/ms13/town)
 "iot" = (
 /obj/effect/decal/cleanable/blood/tracks{
@@ -12297,6 +12434,13 @@
 /obj/machinery/oven,
 /turf/open/floor/ms13/tile/large/white,
 /area/ms13/town)
+"ipT" = (
+/obj/machinery/light/ms13/bulb/broken{
+	dir = 1
+	},
+/obj/structure/filingcabinet/ms13,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/town)
 "ipY" = (
 /obj/structure/chair/ms13/metal{
 	dir = 4
@@ -12305,6 +12449,12 @@
 	dir = 8
 	},
 /turf/open/floor/wood/ms13/common,
+/area/ms13/town)
+"iqm" = (
+/obj/machinery/door/unpowered/ms13/wood{
+	dir = 8
+	},
+/turf/open/floor/ms13/metal,
 /area/ms13/town)
 "iqu" = (
 /obj/structure/table/ms13/metal,
@@ -12995,7 +13145,7 @@
 /area/ms13/ncr)
 "iKa" = (
 /obj/structure/ms13/rug/mat/rubber,
-/turf/open/floor/wood/ms13/carpet/shaggy,
+/turf/open/floor/ms13/tile/full/green,
 /area/ms13/town)
 "iKO" = (
 /obj/machinery/microwave{
@@ -13033,7 +13183,7 @@
 	dir = 4
 	},
 /obj/effect/spawner/random/ms13/melee/tier1,
-/turf/open/floor/wood/ms13/common,
+/turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "iLT" = (
 /turf/closed/wall/ms13/bunker,
@@ -13331,7 +13481,7 @@
 "iSm" = (
 /obj/effect/decal/cleanable/blood/drip,
 /mob/living/basic/ms13/hostile_animal/radroach,
-/turf/open/floor/ms13/tile/blue,
+/turf/open/floor/ms13/metal,
 /area/ms13/town)
 "iSy" = (
 /obj/machinery/light/ms13/broken{
@@ -13433,6 +13583,12 @@
 	dir = 1
 	},
 /turf/open/floor/ms13/tile/large/cafeteria,
+/area/ms13/town)
+"iWA" = (
+/obj/structure/chair/ms13/wood/padded{
+	dir = 8
+	},
+/turf/open/floor/wood/ms13/mosaic,
 /area/ms13/town)
 "iWB" = (
 /obj/structure/closet/crate/ms13/footlocker{
@@ -13635,7 +13791,7 @@
 /area/ms13/town)
 "jcs" = (
 /obj/structure/table/ms13/metal/alt,
-/turf/open/floor/ms13/tile/blue,
+/turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "jcB" = (
 /obj/item/pen,
@@ -13757,6 +13913,12 @@
 	dir = 1
 	},
 /turf/open/floor/plating/ms13/ground/mountain,
+/area/ms13/town)
+"jfg" = (
+/obj/machinery/light/ms13/bulb/built{
+	dir = 4
+	},
+/turf/open/floor/wood/ms13/mosaic,
 /area/ms13/town)
 "jfk" = (
 /obj/structure/chair/sofa/corp/right,
@@ -13948,7 +14110,7 @@
 /area/ms13/town)
 "jkB" = (
 /obj/structure/ms13/rug/mat/rubber/single,
-/turf/open/floor/wood/ms13/carpet/shaggy,
+/turf/open/floor/ms13/tile/full/green,
 /area/ms13/town)
 "jkU" = (
 /obj/structure/musician/piano{
@@ -14059,25 +14221,26 @@
 "joH" = (
 /obj/effect/spawner/random/ms13/armor/lowrandom,
 /obj/structure/ms13/storage/shelf/rust,
-/turf/open/floor/wood/ms13/common,
+/turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "joL" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = -12
+/obj/structure/ms13/storage/large/shelf/rust{
+	dir = 8
 	},
-/turf/open/floor/ms13/tile/blue,
+/obj/item/bodybag/ms13,
+/turf/open/floor/ms13/metal,
 /area/ms13/town)
 "joM" = (
-/obj/machinery/light/ms13/bulb{
-	dir = 1
+/obj/item/kirbyplants/dead{
+	desc = "It's a dead plant. You can't tell what it used to be.";
+	name = "Dead Plant"
 	},
-/turf/open/floor/ms13/tile/blue,
+/turf/open/floor/wood/ms13/carpet/green,
 /area/ms13/town)
 "joQ" = (
 /obj/effect/spawner/random/ms13/melee/lowrandom,
 /obj/structure/ms13/storage/shelf,
-/turf/open/floor/wood/ms13/common,
+/turf/open/floor/ms13/metal,
 /area/ms13/town)
 "joR" = (
 /obj/machinery/light/ms13/bulb{
@@ -14246,14 +14409,19 @@
 /turf/open/floor/wood/ms13/common,
 /area/ms13/town)
 "juf" = (
-/obj/structure/toilet{
+/obj/structure/ms13/storage/bookshelf{
 	dir = 4
 	},
-/turf/open/floor/ms13/tile/blue,
+/turf/open/floor/wood/ms13/carpet/green,
 /area/ms13/town)
 "jug" = (
 /mob/living/simple_animal/hostile/ms13/robot/handy,
-/turf/open/floor/ms13/tile/blue,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/town)
+"jui" = (
+/obj/structure/table/ms13/metal,
+/obj/effect/spawner/random/ms13/tools/lights,
+/turf/open/floor/wood/ms13/common,
 /area/ms13/town)
 "juq" = (
 /obj/structure/chair/sofa/corp/right{
@@ -14354,7 +14522,7 @@
 	dir = 1;
 	pixel_y = 10
 	},
-/turf/open/floor/wood/ms13/common,
+/turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "jwl" = (
 /obj/effect/decal/cleanable/blood/old,
@@ -14377,11 +14545,11 @@
 /obj/structure/closet/crate/ms13/medical,
 /obj/effect/spawner/random/ms13/medical/tier3,
 /obj/effect/spawner/random/ms13/medical/highrandom,
-/turf/open/floor/ms13/tile/blue,
+/turf/open/floor/ms13/metal,
 /area/ms13/town)
 "jwK" = (
 /obj/structure/ms13/storage/shelf/rust,
-/turf/open/floor/ms13/tile/blue,
+/turf/open/floor/ms13/metal,
 /area/ms13/town)
 "jwP" = (
 /obj/structure/chair/office/ms13/blue{
@@ -14438,12 +14606,14 @@
 /turf/open/floor/wood/ms13/carpet/shaggy/green,
 /area/ms13/town)
 "jyx" = (
-/mob/living/basic/ms13/hostile_animal/radroach,
-/turf/open/floor/ms13/tile/blue,
+/obj/structure/chair/comfy/ms13/armchair{
+	dir = 8
+	},
+/turf/open/floor/wood/ms13/carpet/green,
 /area/ms13/town)
 "jyD" = (
 /obj/effect/decal/cleanable/blood/drip,
-/turf/open/floor/ms13/tile/blue,
+/turf/open/floor/ms13/metal,
 /area/ms13/town)
 "jyI" = (
 /obj/structure/closet/crate/ms13/medical,
@@ -14452,7 +14622,7 @@
 /turf/open/floor/ms13/tile/blue,
 /area/ms13/town)
 "jyQ" = (
-/obj/structure/closet/crate/bin,
+/obj/structure/ms13/storage/trashcan,
 /turf/open/floor/ms13/tile/blue,
 /area/ms13/town)
 "jzk" = (
@@ -14478,6 +14648,10 @@
 	},
 /obj/effect/spawner/random/ms13/clothing/hat,
 /turf/open/floor/wood/ms13/common,
+/area/ms13/town)
+"jAi" = (
+/obj/machinery/processor,
+/turf/open/floor/ms13/tile/navy,
 /area/ms13/town)
 "jAl" = (
 /obj/structure/filingcabinet/ms13/short,
@@ -14536,11 +14710,11 @@
 	pixel_x = 7;
 	pixel_y = 21
 	},
-/turf/open/floor/ms13/tile/blue,
+/turf/open/floor/ms13/metal,
 /area/ms13/town)
 "jBT" = (
 /obj/machinery/light/ms13/bulb/broken,
-/turf/open/floor/ms13/tile/blue,
+/turf/open/floor/ms13/metal,
 /area/ms13/town)
 "jBV" = (
 /obj/structure/curtain,
@@ -14568,18 +14742,18 @@
 /obj/structure/ms13/medical_curtain{
 	dir = 1
 	},
-/turf/open/floor/ms13/tile/blue,
+/turf/open/floor/ms13/tile/long,
 /area/ms13/town)
 "jCB" = (
 /obj/structure/closet/crate/ms13/medical,
 /obj/item/reagent_containers/blood/ms13/radaway,
 /obj/effect/spawner/random/ms13/medical/highrandom,
 /obj/effect/spawner/random/ms13/medical/highrandom,
-/turf/open/floor/ms13/tile/blue,
+/turf/open/floor/ms13/metal,
 /area/ms13/town)
 "jCE" = (
-/mob/living/simple_animal/hostile/ms13/robot/handy/saw,
-/turf/open/floor/ms13/tile/blue,
+/obj/structure/reagent_dispensers/water_cooler,
+/turf/open/floor/wood/ms13/carpet/green,
 /area/ms13/town)
 "jCG" = (
 /obj/effect/decal/cleanable/glass,
@@ -14681,7 +14855,8 @@
 /obj/structure/ms13/storage/large/shelf/rust{
 	dir = 4
 	},
-/turf/open/floor/ms13/tile/blue,
+/obj/effect/spawner/random/ms13/medical/highrandom,
+/turf/open/floor/ms13/metal,
 /area/ms13/town)
 "jFh" = (
 /turf/open/floor/ms13/concrete/industrial/split,
@@ -14702,7 +14877,7 @@
 "jFv" = (
 /obj/item/paper_bin,
 /obj/structure/table/ms13/metal/alt,
-/turf/open/floor/ms13/tile/blue,
+/turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "jFx" = (
 /obj/machinery/light/ms13/bulb,
@@ -14814,20 +14989,20 @@
 	},
 /obj/effect/decal/cleanable/blood,
 /obj/item/food/ms13/egg/ms13/radroach,
-/turf/open/floor/ms13/tile/blue,
+/turf/open/floor/ms13/metal,
 /area/ms13/town)
 "jHS" = (
 /obj/effect/decal/cleanable/blood/drip{
 	pixel_x = 5;
 	pixel_y = 16
 	},
-/turf/open/floor/ms13/tile/blue,
+/turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "jHW" = (
 /obj/structure/closet/ms13/wall/firstaid,
 /obj/effect/spawner/random/ms13/medical/tier1,
 /obj/effect/spawner/random/ms13/medical/lowrandom,
-/turf/open/floor/ms13/tile/blue,
+/turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "jIf" = (
 /obj/structure/filingcabinet/ms13{
@@ -14877,13 +15052,12 @@
 "jKr" = (
 /obj/machinery/light/ms13/bulb/broken,
 /mob/living/basic/ms13/hostile_animal/radroach,
-/turf/open/floor/ms13/tile/blue,
+/turf/open/floor/ms13/metal,
 /area/ms13/town)
 "jKV" = (
-/obj/structure/ms13/storage/large/shelf/rust{
-	dir = 8
-	},
-/turf/open/floor/ms13/tile/blue,
+/obj/structure/closet/ms13/wall/firstaid,
+/obj/effect/spawner/random/ms13/medical/highrandom,
+/turf/open/floor/ms13/tile,
 /area/ms13/town)
 "jLe" = (
 /obj/structure/fireplace,
@@ -14894,14 +15068,14 @@
 	pixel_x = 7;
 	pixel_y = 21
 	},
-/turf/open/floor/ms13/tile/blue,
+/turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "jLw" = (
 /obj/effect/decal/cleanable/blood/drip{
 	pixel_x = 3;
 	pixel_y = 14
 	},
-/turf/open/floor/ms13/tile/blue,
+/turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "jLK" = (
 /obj/effect/decal/cleanable/blood/drip{
@@ -14912,7 +15086,7 @@
 	pixel_x = 5;
 	pixel_y = 16
 	},
-/turf/open/floor/ms13/tile/blue,
+/turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "jLM" = (
 /obj/structure/chair/sofa/corp/left{
@@ -15002,7 +15176,7 @@
 /area/ms13/underground/vault_atrium_middle)
 "jOQ" = (
 /obj/machinery/door/unpowered/ms13/metal/mirrored,
-/turf/open/floor/ms13/tile/blue,
+/turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "jPO" = (
 /obj/structure/chair/sofa/corp/right{
@@ -15030,19 +15204,15 @@
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/wood/ms13/carpet/blue,
 /area/ms13/town)
-"jQC" = (
-/obj/structure/filingcabinet/ms13,
-/turf/open/floor/ms13/tile/blue,
-/area/ms13/town)
 "jQI" = (
 /obj/effect/decal/cleanable/blood/drip{
 	pixel_x = 16
 	},
-/turf/open/floor/ms13/tile/blue,
+/turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "jQS" = (
 /obj/structure/chair/ms13/metal,
-/turf/open/floor/ms13/tile/blue,
+/turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "jQU" = (
 /obj/item/trash/tray{
@@ -15066,7 +15236,7 @@
 "jRm" = (
 /obj/structure/closet,
 /obj/item/reagent_containers/ms13/fertilizer,
-/turf/open/floor/wood/ms13/common,
+/turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "jRt" = (
 /obj/structure/table/ms13/metal,
@@ -15075,19 +15245,19 @@
 	},
 /obj/effect/spawner/random/ms13/seeds/spores,
 /obj/effect/spawner/random/ms13/seeds/spores,
-/turf/open/floor/wood/ms13/common,
+/turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "jRA" = (
 /obj/structure/table/ms13/metal,
 /obj/item/shovel/ms13/rake,
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/spawner/random/ms13/seeds/spores,
-/turf/open/floor/wood/ms13/common,
+/turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "jRG" = (
 /obj/item/trash/candy,
 /mob/living/simple_animal/hostile/ms13/robot/handy,
-/turf/open/floor/wood/ms13/common,
+/turf/open/floor/wood/ms13/carpet/green,
 /area/ms13/town)
 "jRK" = (
 /obj/machinery/light/ms13/bulb{
@@ -15096,13 +15266,13 @@
 /obj/structure/table/ms13/no_smooth/counter/wood{
 	dir = 1
 	},
-/turf/open/floor/ms13/tile/blue,
+/turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "jSp" = (
 /obj/structure/table/ms13/no_smooth/counter/wood/bend{
 	dir = 1
 	},
-/turf/open/floor/ms13/tile/blue,
+/turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "jSt" = (
 /obj/machinery/light/ms13,
@@ -15140,14 +15310,14 @@
 /obj/structure/ms13/storage/bookshelf{
 	dir = 4
 	},
-/turf/open/floor/ms13/tile/blue,
+/turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "jUl" = (
 /obj/structure/chair/office/ms13/blue{
 	dir = 4
 	},
 /mob/living/simple_animal/hostile/ms13/robot/handy,
-/turf/open/floor/ms13/tile/blue,
+/turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "jUn" = (
 /obj/structure/table/ms13/wood,
@@ -15260,12 +15430,12 @@
 /obj/structure/table/ms13/no_smooth/counter/wood{
 	dir = 1
 	},
-/turf/open/floor/wood/ms13/common,
+/turf/open/floor/wood/ms13/carpet/green,
 /area/ms13/town)
 "jXK" = (
-/obj/structure/closet/crate/bin,
 /obj/item/trash/chips,
-/turf/open/floor/wood/ms13/common,
+/obj/structure/ms13/storage/trashcan,
+/turf/open/floor/wood/ms13/carpet/green,
 /area/ms13/town)
 "jXX" = (
 /obj/machinery/light/ms13/bulb{
@@ -15274,7 +15444,7 @@
 /obj/structure/ms13/storage/bookshelf{
 	dir = 4
 	},
-/turf/open/floor/ms13/tile/blue,
+/turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "jYd" = (
 /obj/structure/chair/office/ms13/red/broken,
@@ -15285,7 +15455,7 @@
 	pixel_x = 10;
 	pixel_y = 5
 	},
-/turf/open/floor/ms13/tile/blue,
+/turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "jYn" = (
 /obj/effect/decal/cleanable/blood/drip{
@@ -15363,18 +15533,12 @@
 /obj/machinery/hydroponics/ms13/soil,
 /turf/open/floor/plating/ms13/ground/mountain,
 /area/ms13/underground/mountain)
-"kaC" = (
-/obj/structure/table/ms13/no_smooth/counter/wood{
-	dir = 4
-	},
-/turf/open/floor/ms13/tile/blue,
-/area/ms13/town)
 "kba" = (
 /obj/structure/chair/ms13/metal{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/glass,
-/turf/open/floor/ms13/tile/blue,
+/turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "kbn" = (
 /obj/structure/table/ms13/low_wall/brick/alt,
@@ -15487,16 +15651,6 @@
 /obj/item/reagent_containers/glass/bucket/wooden,
 /turf/open/floor/plating/ms13/ground/mountain,
 /area/ms13/underground/mountain)
-"keO" = (
-/obj/effect/decal/cleanable/glass,
-/turf/open/floor/ms13/tile/blue,
-/area/ms13/town)
-"keR" = (
-/obj/structure/chair/ms13/metal{
-	dir = 8
-	},
-/turf/open/floor/ms13/tile/blue,
-/area/ms13/town)
 "keT" = (
 /obj/structure/table/ms13/low_wall/brick/alt,
 /obj/structure/window/fulltile/ms13/glass,
@@ -15553,13 +15707,13 @@
 /area/ms13/underground/mountain)
 "kgI" = (
 /obj/structure/reagent_dispensers/water_cooler,
-/turf/open/floor/ms13/tile/blue,
+/turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "kgT" = (
 /obj/structure/ms13/storage/bookshelf{
 	dir = 1
 	},
-/turf/open/floor/ms13/tile/blue,
+/turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "kha" = (
 /obj/structure/ms13/storage/vent,
@@ -15681,7 +15835,7 @@
 	dir = 4
 	},
 /obj/effect/spawner/random/ms13/medical/lowrandom,
-/turf/open/floor/ms13/tile/blue,
+/turf/open/floor/ms13/metal,
 /area/ms13/town)
 "kkA" = (
 /obj/machinery/light/ms13{
@@ -15799,7 +15953,7 @@
 /obj/structure/closet/crate/ms13/footlocker,
 /obj/effect/spawner/random/ms13/gun/tier1,
 /obj/effect/spawner/random/ms13/ammo/tier1,
-/turf/open/floor/wood/ms13/common,
+/turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "koA" = (
 /obj/structure/closet/ms13/wall/firstaid,
@@ -15810,7 +15964,7 @@
 /obj/structure/bed/ms13/sleepingbag/green,
 /obj/effect/decal/cleanable/blood/gibs/down,
 /obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/wood/ms13/common,
+/turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "koJ" = (
 /obj/structure/flora/ausbushes/fullgrass,
@@ -15879,12 +16033,12 @@
 /obj/effect/spawner/random/ms13/melee/lowrandom,
 /obj/effect/spawner/random/ms13/medical/lowrandom,
 /obj/effect/spawner/random/ms13/medical/lowrandom,
-/turf/open/floor/wood/ms13/common,
+/turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "krJ" = (
 /obj/structure/table/ms13/metal,
 /obj/effect/spawner/random/ms13/seeds/spores,
-/turf/open/floor/wood/ms13/common,
+/turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "ksl" = (
 /obj/structure/ladder/ms13/manhole,
@@ -15934,6 +16088,11 @@
 "ktL" = (
 /obj/structure/chair/ms13/metal,
 /turf/open/floor/plating/ms13/ground/sidewalk,
+/area/ms13/town)
+"ktQ" = (
+/obj/structure/table/ms13/metal,
+/obj/effect/spawner/random/ms13/drink/alcohol_beer,
+/turf/open/floor/ms13/metal,
 /area/ms13/town)
 "ktY" = (
 /obj/structure/bed/ms13/sleepingbag/green,
@@ -16043,10 +16202,6 @@
 	},
 /turf/open/floor/wood/ms13/common,
 /area/ms13/town)
-"kwg" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/turf/open/water,
-/area/ms13/underground/mountain)
 "kwi" = (
 /obj/structure/railing/ms13/solo,
 /turf/open/floor/plating/ms13/ground/sidewalk,
@@ -16116,7 +16271,7 @@
 "kyy" = (
 /obj/effect/spawner/random/ms13/drink/alcohol_beer,
 /obj/structure/ms13/storage/shelf/rust,
-/turf/open/floor/wood/ms13/common,
+/turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "kyB" = (
 /obj/structure/plasticflaps,
@@ -16263,6 +16418,12 @@
 	},
 /turf/open/floor/wood/ms13/carpet,
 /area/ms13/town)
+"kDR" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/turf/open/floor/ms13/tile/blue/long,
+/area/ms13/town)
 "kEx" = (
 /obj/structure/toilet{
 	dir = 4
@@ -16284,7 +16445,7 @@
 /obj/machinery/light/ms13/bulb{
 	dir = 1
 	},
-/turf/open/floor/wood/ms13/wide,
+/turf/open/floor/ms13/metal,
 /area/ms13/town)
 "kFu" = (
 /obj/effect/decal/cleanable/glass,
@@ -16766,7 +16927,7 @@
 	dir = 1
 	},
 /obj/effect/spawner/random/ms13/medical/lowrandom,
-/turf/open/floor/wood/ms13/common,
+/turf/open/floor/wood/ms13/carpet/green,
 /area/ms13/town)
 "kUB" = (
 /obj/machinery/light/ms13/broken{
@@ -16832,7 +16993,7 @@
 /area/ms13/town)
 "kWw" = (
 /obj/effect/landmark/start/ms13/boss,
-/turf/open/floor/wood/ms13/common,
+/turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "kWy" = (
 /obj/machinery/light/ms13/bulb/broken{
@@ -16895,7 +17056,7 @@
 "kYd" = (
 /obj/structure/closet/cabinet,
 /obj/effect/spawner/random/ms13/medical/lowrandom,
-/turf/open/floor/wood/ms13/common,
+/turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "kYf" = (
 /obj/structure/ms13/storage/shelf/rust,
@@ -17212,7 +17373,13 @@
 /obj/structure/table/ms13/no_smooth/counter/wood{
 	dir = 1
 	},
-/turf/open/floor/wood/ms13/common,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/town)
+"lhg" = (
+/obj/machinery/light/ms13/bulb{
+	dir = 8
+	},
+/turf/open/floor/ms13/tile/navy,
 /area/ms13/town)
 "lhk" = (
 /obj/structure/table/ms13/no_smooth/counter/wood{
@@ -17268,6 +17435,11 @@
 /obj/effect/decal/cleanable/ash/large,
 /turf/open/floor/wood/ms13/common,
 /area/ms13/town)
+"liC" = (
+/obj/structure/table/ms13/metal,
+/obj/effect/spawner/random/ms13/medical/lowrandom,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/ncr)
 "liT" = (
 /obj/structure/ms13/foundation/common/variantone{
 	dir = 5
@@ -17521,8 +17693,10 @@
 /turf/open/floor/wood/ms13/common,
 /area/ms13/town)
 "lqi" = (
-/obj/structure/closet/crate/bin,
 /obj/effect/decal/cleanable/generic,
+/obj/structure/ms13/storage/trashcan{
+	pixel_y = 0
+	},
 /turf/open/floor/wood/ms13/carpet,
 /area/ms13/town)
 "lqB" = (
@@ -18141,8 +18315,10 @@
 /turf/open/floor/carpet/black,
 /area/ms13/town)
 "lHe" = (
-/obj/structure/closet/crate/bin,
 /obj/effect/decal/cleanable/generic,
+/obj/structure/ms13/storage/trashcan{
+	pixel_y = 0
+	},
 /turf/open/floor/wood/ms13/common,
 /area/ms13/town)
 "lHi" = (
@@ -18183,7 +18359,9 @@
 /turf/open/floor/carpet/black,
 /area/ms13/town)
 "lHM" = (
-/obj/structure/closet/crate/bin,
+/obj/structure/ms13/storage/trashcan{
+	pixel_y = 0
+	},
 /turf/open/floor/ms13/tile/large/cafeteria,
 /area/ms13/supermarket)
 "lHQ" = (
@@ -18270,7 +18448,9 @@
 /turf/open/floor/ms13/tile/blue/long,
 /area/ms13/supermarket)
 "lLM" = (
-/obj/structure/closet/crate/bin,
+/obj/structure/ms13/storage/trashcan{
+	pixel_y = 0
+	},
 /turf/open/floor/ms13/tile/blue/long,
 /area/ms13/supermarket)
 "lMc" = (
@@ -18328,8 +18508,11 @@
 /turf/open/floor/plating/ms13/ground/road,
 /area/ms13/supermarket)
 "lOb" = (
-/obj/structure/ms13/storage/large/shelf/rust,
-/turf/open/floor/wood/ms13/common,
+/obj/machinery/vending/cola,
+/obj/machinery/light/ms13/bulb{
+	dir = 8
+	},
+/turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "lOi" = (
 /obj/effect/turf_decal/stripes{
@@ -18583,11 +18766,6 @@
 	},
 /turf/open/floor/wood/ms13/carpet,
 /area/ms13/town)
-"lXF" = (
-/obj/structure/closet/ms13/wall/firstaid,
-/obj/effect/spawner/random/ms13/medical/lowrandom,
-/turf/open/floor/ms13/tile/blue,
-/area/ms13/town)
 "lXG" = (
 /obj/structure/table/ms13/wood,
 /obj/machinery/light/ms13{
@@ -18606,7 +18784,9 @@
 /turf/open/floor/wood/ms13/common,
 /area/ms13/town)
 "lXT" = (
-/obj/structure/closet/crate/bin,
+/obj/structure/ms13/storage/trashcan{
+	pixel_y = 0
+	},
 /turf/open/floor/ms13/tile/brown,
 /area/ms13/town)
 "lYo" = (
@@ -19019,11 +19199,15 @@
 /turf/open/floor/wood/ms13/common,
 /area/ms13/town)
 "mkz" = (
-/obj/structure/closet/crate/bin,
+/obj/structure/ms13/storage/trashcan{
+	pixel_y = 0
+	},
 /turf/open/floor/wood/ms13/carpet/shaggy,
 /area/ms13/supermarket)
 "mkD" = (
-/obj/structure/closet/crate/bin,
+/obj/structure/ms13/storage/trashcan{
+	pixel_y = 0
+	},
 /turf/open/floor/ms13/tile,
 /area/ms13/supermarket)
 "mkT" = (
@@ -19326,6 +19510,13 @@
 	},
 /turf/open/floor/wood/ms13/carpet,
 /area/ms13/town)
+"mvb" = (
+/obj/item/kirbyplants/dead{
+	desc = "It's a dead plant. You can't tell what it used to be.";
+	name = "Dead Plant"
+	},
+/turf/open/floor/wood/ms13/mosaic,
+/area/ms13/town)
 "mvz" = (
 /obj/effect/decal/cleanable/glass{
 	dir = 1
@@ -19547,7 +19738,7 @@
 /turf/open/floor/wood/ms13/carpet,
 /area/ms13/town)
 "mGh" = (
-/obj/structure/closet/crate/bin,
+/obj/structure/ms13/storage/trashcan,
 /turf/open/floor/wood/ms13/carpet,
 /area/ms13/town)
 "mGN" = (
@@ -19595,17 +19786,13 @@
 "mHD" = (
 /obj/structure/closet/ms13/wall/firstaid,
 /obj/effect/spawner/random/ms13/medical/lowrandom,
-/turf/open/floor/wood/ms13/carpet/shaggy,
+/turf/open/floor/ms13/tile/full/green,
 /area/ms13/town)
 "mHQ" = (
 /obj/machinery/door/unpowered/ms13/metal/red{
 	dir = 8
 	},
 /turf/open/floor/ms13/tile/brown,
-/area/ms13/town)
-"mIj" = (
-/obj/machinery/light/ms13/bulb,
-/turf/open/floor/ms13/tile/blue,
 /area/ms13/town)
 "mIz" = (
 /obj/effect/decal/cleanable/glass{
@@ -19881,6 +20068,13 @@
 /obj/structure/table/ms13/no_smooth/metal,
 /turf/open/floor/wood/ms13/common,
 /area/ms13/ncr)
+"mTw" = (
+/obj/structure/flora/grass/jungle/b,
+/obj/structure/ms13/foundation/variantsix{
+	dir = 9
+	},
+/turf/open/floor/plating/ms13/ground/mountain,
+/area/ms13/town)
 "mTB" = (
 /obj/structure/chair/ms13/metal/broken,
 /obj/effect/decal/cleanable/glass,
@@ -19920,6 +20114,10 @@
 	dir = 4
 	},
 /turf/open/floor/ms13/tile/large/black,
+/area/ms13/town)
+"mUJ" = (
+/obj/effect/decal/cleanable/ash,
+/turf/open/floor/ms13/metal,
 /area/ms13/town)
 "mUT" = (
 /obj/machinery/light/ms13,
@@ -20081,7 +20279,7 @@
 "nbk" = (
 /obj/structure/table/ms13/metal/grate,
 /obj/effect/spawner/random/ms13/gun/tier1,
-/turf/open/floor/wood/ms13/carpet/shaggy,
+/turf/open/floor/ms13/tile/full/green,
 /area/ms13/town)
 "nbu" = (
 /obj/structure/table/ms13/no_smooth/counter/metal{
@@ -20150,7 +20348,9 @@
 /obj/machinery/light/ms13/bulb{
 	dir = 1
 	},
-/obj/structure/closet/crate/bin,
+/obj/structure/ms13/storage/trashcan{
+	pixel_y = 0
+	},
 /turf/open/floor/ms13/tile/full/navy,
 /area/ms13/town)
 "ndB" = (
@@ -20215,6 +20415,9 @@
 /obj/item/taperecorder,
 /turf/open/floor/ms13/tile/full/navy,
 /area/ms13/town)
+"nfu" = (
+/turf/open/ms13/water/shallow,
+/area/ms13)
 "nfL" = (
 /obj/structure/table/ms13/metal,
 /obj/machinery/light/ms13/bulb,
@@ -20362,6 +20565,11 @@
 /obj/item/ms13_small_flag/usa,
 /turf/open/floor/ms13/tile/full/navy,
 /area/ms13/town)
+"nkP" = (
+/obj/effect/decal/cleanable/glass,
+/obj/item/ms13/brick,
+/turf/open/floor/wood/ms13/common,
+/area/ms13/town)
 "nkQ" = (
 /obj/structure/ms13/storage/large/shelf,
 /turf/open/floor/ms13/tile/full/navy,
@@ -20373,6 +20581,10 @@
 	pixel_y = 5
 	},
 /turf/open/floor/ms13/tile/fancy,
+/area/ms13/town)
+"nlc" = (
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/wood/ms13/mosaic,
 /area/ms13/town)
 "nli" = (
 /obj/structure/window/reinforced{
@@ -20703,6 +20915,7 @@
 /obj/machinery/light/ms13/bulb{
 	dir = 8
 	},
+/obj/effect/spawner/random/ms13/medical/lowrandom,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/ncr)
 "nxY" = (
@@ -20826,7 +21039,7 @@
 	dir = 1
 	},
 /obj/effect/spawner/random/ms13/ammo/lowrandom,
-/turf/open/floor/wood/ms13/carpet/shaggy,
+/turf/open/floor/ms13/tile/full/green,
 /area/ms13/town)
 "nBP" = (
 /obj/structure/table/ms13/no_smooth/counter/wood,
@@ -21192,6 +21405,10 @@
 	},
 /turf/open/floor/wood/ms13/common,
 /area/ms13/town)
+"nOD" = (
+/obj/effect/spawner/random/ms13/clothing/shoe,
+/turf/open/floor/ms13/metal,
+/area/ms13/town)
 "nOL" = (
 /obj/effect/spawner/random/ms13/food/produce_mushrooms,
 /turf/open/floor/plating/ms13/ground/mountain,
@@ -21385,6 +21602,12 @@
 /obj/effect/spawner/random/ms13/food/produce_random,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/tribal_abandoned)
+"nUb" = (
+/obj/structure/ms13/storage/large/shelf/rust{
+	dir = 1
+	},
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/town)
 "nUx" = (
 /obj/machinery/light/ms13/bulb/broken,
 /obj/effect/decal/cleanable/blood/bubblegum,
@@ -21755,6 +21978,10 @@
 	},
 /turf/open/floor/ms13/tile/large/white,
 /area/ms13/underground/vault_atrium_middle)
+"ohH" = (
+/obj/machinery/door/unpowered/ms13/wood/green,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/town)
 "oia" = (
 /obj/effect/decal/cleanable/blood/bubblegum,
 /turf/open/floor/plating/ms13/ground/mountain,
@@ -22214,6 +22441,12 @@
 	},
 /turf/open/floor/wood/ms13/common,
 /area/ms13/town)
+"owT" = (
+/obj/structure/ms13/storage/trashcan{
+	pixel_y = 0
+	},
+/turf/open/floor/wood/ms13/common,
+/area/ms13/town)
 "oxe" = (
 /obj/structure/closet/crate/ms13/footlocker,
 /obj/effect/spawner/random/ms13/melee/lowrandom,
@@ -22267,6 +22500,7 @@
 /obj/effect/spawner/random/ms13/food/produce_safe,
 /obj/effect/spawner/random/ms13/food/produce_safe,
 /obj/effect/spawner/random/ms13/drink/soda,
+/obj/item/food/canned/beans,
 /turf/open/floor/ms13/tile,
 /area/ms13/ncr)
 "ozn" = (
@@ -22870,7 +23104,7 @@
 /obj/structure/ms13/storage/large/shelf/rust{
 	dir = 1
 	},
-/turf/open/floor/wood/ms13/common,
+/turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "puP" = (
 /obj/machinery/door/unpowered/ms13/metal{
@@ -22889,6 +23123,12 @@
 /obj/effect/spawner/random/ms13/melee/lowrandom,
 /turf/open/floor/ms13/concrete,
 /area/ms13/supermarket)
+"pvB" = (
+/obj/structure/table/ms13/no_smooth/counter/wood{
+	dir = 8
+	},
+/turf/open/floor/wood/ms13/mosaic,
+/area/ms13/town)
 "pvZ" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/wood/ms13/carpet,
@@ -23036,7 +23276,7 @@
 	dir = 1
 	},
 /obj/effect/spawner/random/ms13/melee/tier1,
-/turf/open/floor/wood/ms13/common,
+/turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "pKX" = (
 /obj/structure/chair/sofa/corp/left,
@@ -23057,6 +23297,10 @@
 "pNE" = (
 /obj/machinery/jukebox,
 /turf/open/floor/wood/ms13/common,
+/area/ms13/town)
+"pNF" = (
+/obj/effect/decal/cleanable/blood/splatter,
+/turf/open/floor/ms13/metal,
 /area/ms13/town)
 "pRj" = (
 /obj/item/reagent_containers/glass/bucket/wooden,
@@ -23092,6 +23336,21 @@
 /obj/effect/spawner/random/ms13/clothing/hat,
 /obj/structure/table/ms13/metal/grate,
 /turf/open/floor/wood/ms13/common,
+/area/ms13/town)
+"pYD" = (
+/obj/machinery/door/unpowered/ms13/wood{
+	dir = 4
+	},
+/turf/open/floor/ms13/metal,
+/area/ms13/town)
+"pZd" = (
+/obj/structure/table/ms13/no_smooth/counter/wood{
+	dir = 4
+	},
+/obj/structure/closet/crate/ms13/cash_register{
+	dir = 8
+	},
+/turf/open/floor/wood/ms13/mosaic,
 /area/ms13/town)
 "qaM" = (
 /obj/structure/chair/comfy/ms13/ergo,
@@ -23162,6 +23421,11 @@
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/open/floor/plating/ms13/ground/sidewalk,
 /area/ms13)
+"qjj" = (
+/obj/structure/table/ms13/metal,
+/obj/effect/spawner/random/ms13/tools/lights,
+/turf/open/floor/plating/ms13/ground/sidewalk,
+/area/ms13/town)
 "qjA" = (
 /obj/effect/spawner/random/ms13/melee/lowrandom,
 /turf/open/floor/wood/ms13/wide,
@@ -23210,6 +23474,7 @@
 /obj/structure/bed/ms13/bedframe/wood,
 /obj/structure/bed/ms13/mattress/yellowed,
 /obj/effect/decal/cleanable/blood/old,
+/obj/effect/spawner/random/ms13/medical/lowrandom,
 /turf/open/floor/wood/ms13/common,
 /area/ms13/town)
 "qsa" = (
@@ -23250,7 +23515,9 @@
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/tribal_abandoned)
 "qBe" = (
-/obj/structure/closet/crate/bin,
+/obj/structure/ms13/storage/trashcan{
+	pixel_y = 0
+	},
 /turf/open/floor/wood/ms13/carpet/blue,
 /area/ms13/town)
 "qCx" = (
@@ -23314,6 +23581,13 @@
 /obj/structure/table/ms13/no_smooth/counter/metal,
 /obj/item/knife/ms13,
 /turf/open/floor/ms13/tile,
+/area/ms13/town)
+"qNw" = (
+/obj/structure/ms13/storage/shelf{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood/gibs/down,
+/turf/open/floor/ms13/tile/blue/long,
 /area/ms13/town)
 "qNI" = (
 /obj/structure/table/ms13/no_smooth/counter/wood{
@@ -23388,6 +23662,12 @@
 /obj/structure/table/ms13/metal,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
+"qXR" = (
+/obj/structure/chair/sofa/right{
+	dir = 1
+	},
+/turf/open/floor/wood/ms13/mosaic,
+/area/ms13/town)
 "qYF" = (
 /obj/structure/table/ms13/no_smooth/counter/wood{
 	dir = 4
@@ -23422,6 +23702,12 @@
 	},
 /obj/structure/railing/ms13/solo,
 /turf/open/openspace/ms13,
+/area/ms13/town)
+"rdq" = (
+/obj/structure/chair/ms13/wood/padded{
+	dir = 1
+	},
+/turf/open/floor/wood/ms13/mosaic,
 /area/ms13/town)
 "rdr" = (
 /obj/structure/table/ms13/metal/alt,
@@ -23518,7 +23804,7 @@
 	dir = 1
 	},
 /obj/effect/spawner/random/ms13/gun/tier1,
-/turf/open/floor/wood/ms13/carpet/shaggy,
+/turf/open/floor/ms13/tile/full/green,
 /area/ms13/town)
 "rsO" = (
 /obj/structure/table/ms13/wood,
@@ -23649,6 +23935,11 @@
 /obj/machinery/power/ms13/streetlamp/corner,
 /turf/open/floor/plating/ms13/ground/sidewalk,
 /area/ms13)
+"rLf" = (
+/obj/structure/kitchenspike,
+/obj/item/ms13/carcass/large/radstag,
+/turf/open/floor/ms13/tile,
+/area/ms13/ncr)
 "rMe" = (
 /obj/structure/table/ms13/low_wall/reinforced/bunker,
 /turf/open/floor/ms13/metal/grate/border,
@@ -23769,9 +24060,6 @@
 /obj/structure/ms13/rug/rubber,
 /turf/open/floor/ms13/tile/long,
 /area/ms13/town)
-"sdP" = (
-/turf/open/water,
-/area/ms13/underground/mountain)
 "seD" = (
 /obj/structure/chair/stool,
 /turf/open/floor/plating/ms13/ground/snow,
@@ -23877,6 +24165,11 @@
 	},
 /turf/open/floor/ms13/metal,
 /area/ms13/underground/vault_atrium_middle)
+"srP" = (
+/obj/structure/kitchenspike,
+/obj/item/ms13/carcass/large/pigrat,
+/turf/open/floor/ms13/tile/blue/long,
+/area/ms13/town)
 "ssg" = (
 /obj/structure/table/ms13/no_smooth/counter/metal,
 /turf/open/floor/ms13/tile/long,
@@ -23889,12 +24182,22 @@
 /obj/effect/spawner/random/ms13/drink/alcohol_beer,
 /turf/open/floor/wood/ms13/common,
 /area/ms13/town)
+"svU" = (
+/obj/structure/ms13/foundation/variantone,
+/turf/open/floor/plating/ms13/ground/mountain,
+/area/ms13/town)
 "szU" = (
 /obj/structure/table/ms13/no_smooth/large/wood/desk/alt{
 	dir = 8
 	},
 /obj/effect/spawner/random/ms13/melee/tier1,
 /turf/open/floor/wood/ms13/carpet,
+/area/ms13/town)
+"sAb" = (
+/obj/machinery/door/unpowered/ms13/wood{
+	dir = 1
+	},
+/turf/open/floor/wood/ms13/carpet/green,
 /area/ms13/town)
 "sAp" = (
 /obj/structure/chair/office/ms13/red/broken,
@@ -23994,8 +24297,10 @@
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "sPT" = (
-/obj/structure/closet/crate/bin,
-/turf/open/floor/wood/ms13/common,
+/obj/structure/ms13/storage/trashcan{
+	pixel_y = 0
+	},
+/turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "sQr" = (
 /turf/open/floor/ms13/tile/large/white,
@@ -24199,6 +24504,10 @@
 /obj/structure/fence/fencenormal,
 /turf/open/floor/plating/ms13/ground/snow,
 /area/ms13)
+"trK" = (
+/obj/structure/railing/ms13/solo,
+/turf/open/floor/wood/ms13/common,
+/area/ms13)
 "ttJ" = (
 /obj/structure/window/fulltile/ms13/glass,
 /obj/structure/table/ms13/low_wall/vault,
@@ -24208,6 +24517,10 @@
 /obj/machinery/light/ms13,
 /turf/open/floor/plating/ms13/ground/sidewalk,
 /area/ms13/underground/tunnel)
+"tum" = (
+/obj/structure/bed/ms13/sleepingbag/green,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/town)
 "tuF" = (
 /obj/structure/closet/crate/ms13/footlocker{
 	dir = 8
@@ -24341,6 +24654,10 @@
 /obj/effect/spawner/random/ms13/clothing/under,
 /turf/open/floor/ms13/tile/brown,
 /area/ms13/town)
+"tZH" = (
+/obj/machinery/oven,
+/turf/open/floor/ms13/tile/navy,
+/area/ms13/town)
 "uaF" = (
 /mob/living/simple_animal/hostile/ms13/robot/protectron,
 /turf/open/floor/ms13/concrete/industrial/walkway,
@@ -24387,7 +24704,7 @@
 "ueZ" = (
 /obj/effect/spawner/random/ms13/clothing/shoe,
 /obj/structure/ms13/storage/shelf,
-/turf/open/floor/wood/ms13/common,
+/turf/open/floor/ms13/metal,
 /area/ms13/town)
 "ugj" = (
 /obj/machinery/light/ms13/bulb{
@@ -24408,6 +24725,10 @@
 "ugz" = (
 /obj/structure/closet/crate/coffin,
 /turf/open/floor/wood/ms13/wide,
+/area/ms13/town)
+"uhz" = (
+/obj/structure/table/ms13/no_smooth/counter/wood,
+/turf/open/floor/wood/ms13/mosaic,
 /area/ms13/town)
 "uiE" = (
 /obj/structure/filingcabinet/ms13/busted,
@@ -24448,8 +24769,7 @@
 /turf/open/floor/wood/ms13/carpet/green,
 /area/ms13/town)
 "usd" = (
-/obj/structure/flora/grass/jungle/b,
-/turf/open/water,
+/turf/open/ms13/water/shallow,
 /area/ms13/underground/mountain)
 "usC" = (
 /obj/machinery/door/unpowered/ms13/wood{
@@ -24474,6 +24794,9 @@
 /obj/effect/spawner/random/ms13/melee/lowrandom,
 /turf/open/floor/ms13/metal,
 /area/ms13/town)
+"uyu" = (
+/turf/open/floor/iron/stairs/right,
+/area/ms13)
 "uAa" = (
 /obj/structure/ms13/storage/bookshelf,
 /turf/open/floor/wood/ms13/mosaic,
@@ -24528,6 +24851,10 @@
 /obj/effect/spawner/random/ms13/seeds/spores,
 /turf/open/floor/plating/ms13/ground/mountain,
 /area/ms13/underground/mountain)
+"uNe" = (
+/obj/structure/bed/ms13/sleepingbag/red,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/town)
 "uNg" = (
 /obj/structure/table/ms13/no_smooth/counter/metal{
 	dir = 1
@@ -24620,6 +24947,10 @@
 	dir = 1
 	},
 /turf/open/floor/plating/ms13/ground/sidewalk,
+/area/ms13/town)
+"vbf" = (
+/obj/structure/chair/ms13/metal/stool,
+/turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "vcM" = (
 /obj/structure/ms13/storage/trashcan,
@@ -24720,6 +25051,12 @@
 /obj/effect/spawner/random/ms13/drink/soda,
 /obj/effect/spawner/random/ms13/gun/lowrandom,
 /turf/open/floor/wood/ms13/carpet/green,
+/area/ms13/town)
+"vvW" = (
+/obj/structure/chair/ms13/wood/padded{
+	dir = 4
+	},
+/turf/open/floor/wood/ms13/mosaic,
 /area/ms13/town)
 "vwT" = (
 /turf/closed/wall/ms13/vault,
@@ -24836,8 +25173,8 @@
 /turf/open/floor/ms13/tile/full/navy,
 /area/ms13/town)
 "vHU" = (
-/obj/machinery/door/unpowered/ms13/wood,
-/turf/closed/wall/ms13/brick,
+/obj/structure/bonfire,
+/turf/open/floor/ms13/metal,
 /area/ms13/town)
 "vIL" = (
 /obj/structure/table/ms13/metal,
@@ -24910,6 +25247,10 @@
 	},
 /turf/open/floor/plating/ms13/ground/sidewalk,
 /area/ms13/underground/tunnel)
+"wbT" = (
+/obj/machinery/light/ms13/bulb/built,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/town)
 "wcI" = (
 /obj/structure/ms13/storage/large/shelf{
 	dir = 8
@@ -24947,7 +25288,7 @@
 "whe" = (
 /obj/structure/ms13/storage/shelf/rust,
 /obj/effect/spawner/random/ms13/medical/lowrandom,
-/turf/open/floor/ms13/tile/blue,
+/turf/open/floor/ms13/metal,
 /area/ms13/town)
 "whH" = (
 /obj/effect/decal/cleanable/blood,
@@ -24982,6 +25323,12 @@
 	},
 /obj/machinery/light/ms13/bulb,
 /turf/open/floor/ms13/tile,
+/area/ms13/town)
+"wmv" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/turf/open/floor/wood/ms13/mosaic,
 /area/ms13/town)
 "wmR" = (
 /obj/effect/decal/cleanable/blood/drip,
@@ -25054,9 +25401,12 @@
 	},
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/underground/vault_atrium_middle)
+"wzn" = (
+/turf/open/floor/ms13/tile/full/green,
+/area/ms13/town)
 "wzu" = (
 /obj/machinery/door/unpowered/ms13/metal/mirrored/red,
-/turf/open/floor/wood/ms13/carpet,
+/turf/open/floor/wood/ms13/common,
 /area/ms13/town)
 "wAy" = (
 /obj/item/clothing/shoes/ms13/explorer,
@@ -25080,11 +25430,17 @@
 "wCR" = (
 /obj/structure/closet/cabinet,
 /obj/effect/spawner/random/ms13/gun/tier1,
-/turf/open/floor/wood/ms13/common,
+/turf/open/floor/wood/ms13/carpet/shaggy/green,
 /area/ms13/town)
 "wEs" = (
 /turf/open/openspace/ms13,
 /area/ms13/supermarket)
+"wGf" = (
+/obj/structure/ms13/storage/large/shelf/rust{
+	dir = 1
+	},
+/turf/open/floor/ms13/metal,
+/area/ms13/town)
 "wGw" = (
 /obj/structure/railing/ms13/solo{
 	dir = 4
@@ -25148,6 +25504,10 @@
 /obj/machinery/door/airlock/ms13,
 /turf/open/floor/ms13/tile/large/checkered,
 /area/ms13/underground/vault_atrium_middle)
+"wQC" = (
+/obj/machinery/vending/cigarette,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/town)
 "wQH" = (
 /obj/machinery/door/unpowered/ms13/seethrough/mirrored/metal,
 /turf/open/floor/ms13/tile/full/navy,
@@ -25233,7 +25593,7 @@
 /area/ms13/town)
 "xdr" = (
 /obj/effect/spawner/random/ms13/tools/hardware,
-/turf/open/floor/wood/ms13/common,
+/turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "xff" = (
 /obj/structure/ms13/foundation/mosaic,
@@ -25258,6 +25618,10 @@
 /turf/open/floor/ms13/concrete,
 /area/ms13/underground/bos)
 "xih" = (
+/turf/open/floor/wood/ms13/mosaic,
+/area/ms13/town)
+"xiV" = (
+/obj/structure/dresser/ms13/orange,
 /turf/open/floor/wood/ms13/mosaic,
 /area/ms13/town)
 "xjj" = (
@@ -25298,6 +25662,12 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ms13/ground/road,
 /area/ms13)
+"xpf" = (
+/obj/machinery/light/ms13/bulb/broken{
+	dir = 4
+	},
+/turf/open/floor/wood/ms13/mosaic,
+/area/ms13/town)
 "xpj" = (
 /obj/structure/closet/crate/ms13/woodcrate,
 /turf/open/floor/ms13/tile/brown,
@@ -25309,6 +25679,13 @@
 "xpz" = (
 /turf/open/floor/plating/ms13/ground/mountain,
 /area/ms13/underground/vault_outer)
+"xqY" = (
+/obj/structure/ms13/tv{
+	pixel_x = -9;
+	pixel_y = 12
+	},
+/turf/open/floor/wood/ms13/mosaic,
+/area/ms13/town)
 "xrB" = (
 /obj/structure/bed/ms13/bedframe/wood,
 /obj/structure/bed/ms13/sleepingbag/red,
@@ -25446,6 +25823,12 @@
 	},
 /turf/open/floor/ms13/tile/navy,
 /area/ms13/underground/vault_atrium_middle)
+"xKP" = (
+/obj/structure/fluff/paper/stack{
+	dir = 4
+	},
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/town)
 "xMh" = (
 /obj/structure/table/ms13/wood,
 /obj/effect/spawner/random/ms13/medical/lowrandom,
@@ -25550,6 +25933,12 @@
 "ybZ" = (
 /turf/open/floor/plating/ms13/ground/snow,
 /area/ms13/snow/deepforest)
+"yct" = (
+/obj/structure/chair/ms13/wood{
+	dir = 8
+	},
+/turf/open/floor/wood/ms13/mosaic,
+/area/ms13/town)
 "ydG" = (
 /obj/structure/chair/comfy/ms13/retro{
 	dir = 4
@@ -25600,6 +25989,11 @@
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/tribal_abandoned)
+"yju" = (
+/obj/structure/bed/ms13/bedframe/cot,
+/obj/structure/bed/ms13/mattress/yellowed,
+/turf/open/floor/wood/ms13/mosaic,
+/area/ms13/town)
 "ykd" = (
 /mob/living/basic/ms13/hostile_animal/hellpig,
 /turf/open/floor/plating/ms13/ground/snow,
@@ -26732,10 +27126,10 @@ khQ
 khQ
 khQ
 ykZ
-azN
-akl
-hZh
-wSc
+dRf
+aff
+uNe
+axO
 ykZ
 xmo
 khQ
@@ -27034,10 +27428,10 @@ khQ
 khQ
 khQ
 ykZ
-wSc
-wSc
-wSc
-wSc
+axO
+axO
+axO
+axO
 ykZ
 pyY
 xmo
@@ -27104,11 +27498,11 @@ khQ
 khQ
 khQ
 khQ
-ykZ
-ykZ
-ykZ
-ykZ
-ykZ
+fbs
+fbs
+fbs
+fbs
+fbs
 khQ
 khQ
 khQ
@@ -27337,10 +27731,10 @@ xmo
 khQ
 ykZ
 koy
-wSc
-wSc
-hFs
-hUz
+axO
+axO
+vEh
+dgQ
 xmo
 jWS
 aaD
@@ -27406,11 +27800,11 @@ khQ
 khQ
 khQ
 khQ
-ykZ
+fbs
 joQ
-wSc
-wSc
-ykZ
+gMg
+gMg
+fbs
 khQ
 khQ
 ykZ
@@ -27632,16 +28026,16 @@ khQ
 khQ
 ykZ
 jRm
-wSc
+axO
 xmo
 kaz
 xmo
 kgu
 ykZ
 koC
-wSc
-ktY
-hUz
+axO
+tum
+dgQ
 ykZ
 xmo
 kCi
@@ -27708,11 +28102,11 @@ khQ
 khQ
 khQ
 khQ
-ykZ
-iGU
-wSc
-apw
-ykZ
+fbs
+aUZ
+gMg
+jBT
+fbs
 khQ
 nML
 ykZ
@@ -27832,9 +28226,9 @@ wSc
 ylG
 ylG
 ylG
-yib
-yib
-yib
+nfu
+nfu
+nfu
 khQ
 khQ
 khQ
@@ -27934,14 +28328,14 @@ khQ
 khQ
 ykZ
 jRt
-wSc
+axO
 xmo
 xmo
 xmo
 nOL
 ykZ
 ykZ
-ykZ
+axO
 kuc
 ykZ
 ykZ
@@ -28010,15 +28404,15 @@ khQ
 khQ
 khQ
 khQ
-ykZ
-dcj
-ltO
-nDs
-ykZ
+fbs
+xCb
+pNF
+dWj
+fbs
 xsE
 nML
-rAq
-xcp
+aka
+jui
 xcp
 wSc
 wSc
@@ -28134,8 +28528,8 @@ wSc
 ylG
 ylG
 ylG
-yib
-yib
+nfu
+nfu
 yib
 khQ
 khQ
@@ -28312,11 +28706,11 @@ khQ
 khQ
 khQ
 khQ
-ykZ
+fbs
 fgZ
-xcp
-wSc
-ykZ
+hNf
+gMg
+fbs
 xsE
 xsE
 rAq
@@ -28434,9 +28828,9 @@ rAq
 wSc
 wSc
 ylG
-yib
-yib
-yib
+nfu
+nfu
+nfu
 yib
 yib
 khQ
@@ -28614,11 +29008,11 @@ khQ
 khQ
 khQ
 khQ
-ykZ
-ykZ
-ykZ
-cva
-ykZ
+fbs
+fbs
+fbs
+pYD
+fbs
 xsE
 xsE
 rAq
@@ -28736,8 +29130,8 @@ rAq
 wSc
 wSc
 ylG
-yib
-yib
+nfu
+nfu
 yib
 yib
 yib
@@ -29043,7 +29437,7 @@ muY
 muY
 yib
 yib
-yib
+cTb
 khQ
 khQ
 khQ
@@ -29151,7 +29545,7 @@ xmo
 ykZ
 ykZ
 ykZ
-wSc
+axO
 ykZ
 kzN
 xmo
@@ -29345,7 +29739,7 @@ muY
 muY
 yib
 yib
-yib
+cTb
 khQ
 khQ
 khQ
@@ -29452,9 +29846,9 @@ xmo
 khQ
 ykZ
 krG
-wSc
-wSc
-wSc
+axO
+axO
+axO
 pyY
 xmo
 jTH
@@ -29642,12 +30036,12 @@ ykZ
 wSc
 ykZ
 ylG
+nfu
+nfu
 yib
 yib
 yib
-yib
-yib
-yib
+cTb
 khQ
 khQ
 khQ
@@ -29754,8 +30148,8 @@ uMx
 khQ
 ykZ
 krJ
-wSc
-wSc
+axO
+axO
 ykZ
 khQ
 khQ
@@ -29944,13 +30338,13 @@ ylG
 ylG
 ylG
 ylG
+nfu
+nfu
 yib
 yib
-yib
-yib
-yib
-yib
-yib
+cTb
+cTb
+cTb
 khQ
 khQ
 khQ
@@ -30055,9 +30449,9 @@ khQ
 khQ
 khQ
 ykZ
-wSc
-hFs
-apw
+axO
+vEh
+efa
 ykZ
 khQ
 khQ
@@ -30245,13 +30639,13 @@ ylG
 ylG
 ylG
 ylG
+nfu
+nfu
 yib
 yib
 yib
-yib
-yib
-yib
-yib
+cTb
+cTb
 khQ
 khQ
 khQ
@@ -30357,9 +30751,9 @@ khQ
 khQ
 khQ
 ykZ
-wSc
-wSc
-wSc
+axO
+axO
+axO
 ykZ
 khQ
 khQ
@@ -30547,13 +30941,13 @@ ylG
 ylG
 ylG
 ylG
+nfu
+nfu
 yib
 yib
 yib
-yib
-yib
-yib
-yib
+cTb
+cTb
 khQ
 khQ
 khQ
@@ -30659,9 +31053,9 @@ khQ
 khQ
 khQ
 ykZ
-hUz
-wSc
-wSc
+dgQ
+axO
+axO
 ykZ
 khQ
 khQ
@@ -30849,13 +31243,13 @@ ylG
 ylG
 ylG
 ylG
+nfu
+nfu
 yib
 yib
 yib
-yib
-yib
-yib
-yib
+cTb
+cTb
 khQ
 khQ
 khQ
@@ -31151,13 +31545,13 @@ ylG
 ylG
 ylG
 ylG
+nfu
+nfu
 yib
 yib
 yib
-yib
-yib
-yib
-yib
+cTb
+cTb
 khQ
 khQ
 khQ
@@ -31453,12 +31847,12 @@ ylG
 ylG
 ylG
 ylG
-ylG
+nfu
+nfu
 yib
 yib
 yib
-yib
-yib
+cTb
 khQ
 khQ
 khQ
@@ -31755,12 +32149,12 @@ ylG
 ylG
 ylG
 ylG
-ylG
+nfu
+nfu
 yib
 yib
 yib
-yib
-yib
+cTb
 khQ
 khQ
 khQ
@@ -32057,12 +32451,12 @@ ylG
 ylG
 ylG
 ylG
-ylG
+nfu
+nfu
+nfu
 yib
 yib
-yib
-yib
-yib
+cTb
 khQ
 khQ
 khQ
@@ -32360,11 +32754,11 @@ ylG
 ylG
 ylG
 ylG
+nfu
+nfu
 yib
 yib
-yib
-yib
-yib
+cTb
 khQ
 khQ
 khQ
@@ -32662,8 +33056,8 @@ ylG
 ylG
 ylG
 sCy
-yib
-yib
+nfu
+nfu
 yib
 yib
 khQ
@@ -32964,8 +33358,8 @@ ylG
 ylG
 ylG
 ylG
-yib
-yib
+nfu
+nfu
 yib
 yib
 khQ
@@ -33243,7 +33637,7 @@ xZD
 jIO
 dIh
 aZE
-upG
+aKu
 wSc
 dRT
 lZY
@@ -33266,9 +33660,9 @@ ylG
 ylG
 ylG
 ylG
-yib
-yib
-yib
+nfu
+nfu
+nfu
 yib
 khQ
 khQ
@@ -33543,9 +33937,9 @@ gUL
 gUL
 xZD
 dAI
-upG
-upG
-upG
+aKu
+aKu
+aKu
 wSc
 eIr
 eIr
@@ -33568,9 +33962,9 @@ xsE
 xsE
 ylG
 ylG
-yib
-yib
-yib
+nfu
+nfu
+nfu
 khQ
 khQ
 khQ
@@ -33798,10 +34192,10 @@ ylG
 ylG
 ylG
 ykZ
-wSc
+xih
 aEi
 aEi
-aPV
+glW
 ids
 bfC
 bDr
@@ -33845,9 +34239,9 @@ ykT
 ykT
 xZD
 jIO
-upG
+aKu
 fDd
-upG
+aKu
 wSc
 eIr
 dUq
@@ -33870,8 +34264,8 @@ ybZ
 xsE
 ylG
 ylG
-yib
-yib
+nfu
+nfu
 khQ
 khQ
 khQ
@@ -34100,10 +34494,10 @@ ylG
 ylG
 ylG
 ykZ
-wSc
-rei
-rei
-wSc
+xih
+iiF
+iiF
+xih
 ids
 eIr
 eIr
@@ -34172,8 +34566,8 @@ ybZ
 xsE
 ylG
 ylG
-yib
-yib
+nfu
+nfu
 khQ
 khQ
 khQ
@@ -34402,10 +34796,10 @@ ylG
 ylG
 ylG
 ykZ
-wSc
+xih
 aEt
-aJy
-wSc
+yct
+xih
 ids
 eIr
 nvY
@@ -34474,8 +34868,8 @@ ybZ
 xsE
 ylG
 ylG
-yib
-yib
+nfu
+nfu
 khQ
 khQ
 khQ
@@ -34707,7 +35101,7 @@ ykZ
 ykZ
 ykZ
 ykZ
-wSc
+xih
 ykZ
 eIr
 eIr
@@ -34776,7 +35170,7 @@ ybZ
 xsE
 ylG
 ylG
-yib
+nfu
 khQ
 khQ
 khQ
@@ -35005,16 +35399,16 @@ ylG
 ylG
 ykZ
 anA
-wSc
-wSc
-wSc
+xih
+xih
+xih
 aOe
-wSc
-wSc
-wSc
-wSc
-wSc
-wSc
+xih
+xih
+xih
+xih
+xih
+xih
 ykZ
 xZD
 xZD
@@ -35306,17 +35700,17 @@ khQ
 khQ
 ylG
 aka
-anG
-wSc
-wSc
+ecs
+xih
+xih
 ihZ
 ykZ
-owq
-wSc
-wSc
-wSc
-wSc
-wSc
+uAa
+xih
+xih
+xih
+xih
+xih
 aOe
 xZD
 xZD
@@ -35608,17 +36002,17 @@ khQ
 khQ
 ylG
 ykZ
-anR
-wSc
-bus
-wSc
+hFs
+xih
+ixX
+xih
 ykZ
-owq
-wSc
-wSc
-wSc
-wSc
-wSc
+uAa
+xih
+xih
+xih
+xih
+xih
 ykZ
 xZD
 xZD
@@ -35774,7 +36168,7 @@ oXT
 scA
 scA
 ykZ
-wSc
+aLt
 wSc
 wSc
 wSc
@@ -35915,11 +36309,11 @@ ykZ
 ykZ
 ykZ
 ykZ
-owq
-wSc
-wSc
+uAa
+xih
+xih
 bny
-wSc
+xih
 bDQ
 rAq
 ylG
@@ -36215,14 +36609,14 @@ ylG
 ylG
 ylG
 ykZ
-aim
-aOe
-aQd
-wSc
-wSc
-bnz
-bus
-bEf
+biO
+dLI
+jfg
+xih
+xih
+xqY
+ixX
+qXR
 rAq
 ylG
 xZD
@@ -36378,7 +36772,7 @@ ykZ
 ykZ
 ykZ
 ykZ
-yeY
+iqm
 ykZ
 ykZ
 aqJ
@@ -36520,7 +36914,7 @@ ykZ
 ykZ
 ykZ
 ykZ
-yeY
+ixJ
 ykZ
 ykZ
 ykZ
@@ -36567,7 +36961,7 @@ cYZ
 dCf
 dKe
 wSc
-dAI
+sAb
 upG
 dWR
 jIO
@@ -36679,9 +37073,9 @@ khQ
 khQ
 khQ
 ykZ
-iGU
-wSc
-cUq
+aUZ
+gMg
+iBW
 ykZ
 bXh
 scA
@@ -36820,10 +37214,10 @@ ylG
 ykZ
 apm
 scA
-cjH
-wSc
-wSc
-cbs
+dLI
+xih
+xih
+eaF
 ykZ
 ylG
 ylG
@@ -36982,8 +37376,8 @@ khQ
 khQ
 ykZ
 ueZ
-wSc
-kvU
+gMg
+iBW
 ykZ
 sgt
 sgt
@@ -37033,7 +37427,7 @@ ylG
 ylG
 lUa
 fZG
-anG
+nkP
 aOe
 wSc
 wSc
@@ -37041,7 +37435,7 @@ hZh
 ykZ
 wSc
 adv
-wSc
+fuW
 rAq
 xsE
 xsE
@@ -37123,9 +37517,9 @@ ykZ
 ayi
 aEU
 ykZ
-wSc
-wSc
-wSc
+xih
+xih
+xih
 dTF
 ylG
 ylG
@@ -37152,10 +37546,10 @@ ylG
 ylG
 pwP
 kYd
-wSc
-wSc
-wSc
-wSc
+axO
+axO
+axO
+axO
 rbd
 dym
 xZD
@@ -37284,7 +37678,7 @@ khQ
 khQ
 ykZ
 azd
-wSc
+gMg
 cUq
 ykZ
 ykZ
@@ -37425,9 +37819,9 @@ ykZ
 ykZ
 ykZ
 ykZ
-aQf
+xiV
 aWf
-bfP
+yju
 dTF
 ylG
 ylG
@@ -37453,11 +37847,11 @@ ykZ
 ylG
 ylG
 pwP
-lOb
-wSc
-wSc
-wSc
-wSc
+bON
+axO
+axO
+axO
+axO
 pwP
 xZD
 xZD
@@ -37673,7 +38067,7 @@ nxU
 sFB
 sFB
 nKL
-nEo
+liC
 nEo
 nKL
 xsE
@@ -37755,12 +38149,12 @@ ykZ
 ylG
 ylG
 pwP
-wSc
-dlh
-iGT
-wSc
-wSc
-aOe
+axO
+fkl
+hlw
+axO
+axO
+bIy
 xZD
 xZD
 xZD
@@ -37850,7 +38244,7 @@ hzK
 oJO
 oJO
 jIO
-wSc
+vcM
 wSc
 jIO
 gbX
@@ -38057,11 +38451,11 @@ ykZ
 ylG
 ylG
 pwP
-cfl
-clu
+ipT
+xKP
 jvW
-doM
-doM
+dZl
+dZl
 pwP
 xZD
 xZD
@@ -39455,7 +39849,7 @@ ykZ
 ykZ
 ykZ
 ykZ
-scA
+jKV
 scA
 scA
 fBr
@@ -40727,7 +41121,7 @@ nKL
 ozU
 mTS
 mTS
-mTS
+rLf
 nKL
 khQ
 khQ
@@ -41516,10 +41910,10 @@ ylG
 ylG
 jIO
 jwJ
-jyx
-sIA
+iVG
+gMg
 kki
-sIA
+gMg
 jFc
 jIO
 ylG
@@ -41682,8 +42076,8 @@ ykZ
 ylG
 pwP
 nbk
-aKu
-aKu
+cks
+wzn
 pwP
 ivS
 wSc
@@ -41817,10 +42211,10 @@ ylG
 ylG
 ylG
 jIO
-sIA
-sIA
+gMg
+gMg
 jBR
-sIA
+gMg
 jHQ
 jKr
 jIO
@@ -41984,8 +42378,8 @@ ykZ
 ylG
 pwP
 cks
-aKu
-aKu
+wzn
+wzn
 hUp
 wSc
 lgK
@@ -42121,10 +42515,10 @@ ylG
 jIO
 jCB
 iSm
-sIA
-jKV
-sIA
-aLt
+gMg
+gMg
+gMg
+gMg
 jIO
 ylG
 ylG
@@ -42286,8 +42680,8 @@ ykZ
 ylG
 pwP
 cks
-aKu
-aKu
+wzn
+wzn
 pwP
 ivS
 wSc
@@ -42422,11 +42816,11 @@ ylG
 ylG
 jIO
 jwK
-sIA
+gMg
 jBT
-jIO
-jIO
-jIO
+dma
+gMg
+joL
 jIO
 jIO
 jIO
@@ -42588,8 +42982,8 @@ ykZ
 ylG
 pwP
 fxI
-aKu
-aKu
+wzn
+wzn
 pwP
 ivS
 wSc
@@ -42724,15 +43118,15 @@ ylG
 ylG
 jIO
 whe
-jyx
-sIA
+iVG
+jBT
 jIO
-sIA
-sIA
 jIO
-bhx
-dCd
-dCd
+jIO
+jIO
+joM
+juf
+juf
 kUz
 jIO
 ylG
@@ -42890,7 +43284,7 @@ tqN
 ylG
 pwP
 mHD
-aKu
+wzn
 jkB
 rsA
 wSc
@@ -43026,15 +43420,15 @@ ylG
 ylG
 jIO
 whe
-sIA
+gMg
 jyD
-jjF
+aAD
 jHS
-sIA
-jfc
-wSc
-wSc
-wSc
+axO
+kNk
+upG
+upG
+upG
 jXo
 jIO
 ylG
@@ -43192,13 +43586,13 @@ tqN
 ylG
 pwP
 gYr
-aKu
+wzn
 iKa
 gtm
 wSc
 wSc
 wSc
-vHU
+aOe
 xZD
 ykT
 ykT
@@ -43331,12 +43725,12 @@ jIO
 jIO
 jIO
 jIO
-sIA
-sIA
+axO
+axO
 jIO
-ybx
+dUy
 jRG
-wSc
+upG
 jXK
 jIO
 ylG
@@ -43633,13 +44027,13 @@ jwU
 jtV
 kCb
 jIO
-joM
-sIA
+bLg
+axO
 jIO
-wSc
-doM
-doM
-eGS
+upG
+jyx
+jyx
+jCE
 jIO
 ylG
 ylG
@@ -43931,14 +44325,14 @@ ylG
 ylG
 jIO
 sIA
-sIA
-sIA
+fiE
+fiE
 jtV
 jIO
-sIA
+axO
 jLn
 jIO
-pqf
+epS
 jIO
 jIO
 jIO
@@ -44233,15 +44627,15 @@ ylG
 ylG
 jIO
 jtC
-jCE
-sIA
+ofo
+fiE
 sIA
 jjF
-sIA
+axO
 jLw
 jIO
-sIA
-sIA
+axO
+axO
 jUe
 jXX
 jFv
@@ -44535,16 +44929,16 @@ ylG
 ylG
 jIO
 gzu
-sIA
+fiE
 jCA
 sIA
 jIO
-sIA
-sIA
-jxu
-sIA
-sIA
-sIA
+axO
+axO
+kNk
+axO
+axO
+axO
 jYd
 jcs
 jIO
@@ -44701,7 +45095,7 @@ jIO
 jIO
 jIO
 jIO
-xZD
+kAW
 xZD
 xZD
 xZD
@@ -44778,7 +45172,7 @@ rGn
 nbS
 dyV
 inJ
-xpz
+fKQ
 xpz
 xpz
 lBA
@@ -44841,13 +45235,13 @@ joR
 wpB
 sIA
 jIO
-joM
-sIA
+bLg
+axO
 jIO
-jQC
-joR
-sIA
-sIA
+enI
+cuZ
+axO
+axO
 jcs
 jIO
 ylG
@@ -45080,8 +45474,8 @@ rGn
 nbS
 dyV
 inJ
-xpz
-xpz
+fKQ
+fKQ
 xpz
 xpz
 khQ
@@ -45143,13 +45537,13 @@ jIO
 jIO
 jIO
 jIO
-sIA
-sIA
+axO
+axO
 jIO
 jIO
 jIO
 jIO
-hJH
+epS
 jIO
 jIO
 jIO
@@ -45383,8 +45777,8 @@ tJW
 dyV
 dmC
 xpz
-xpz
-xpz
+fKQ
+fKQ
 xpz
 khQ
 khQ
@@ -45439,21 +45833,21 @@ ylG
 ylG
 ylG
 jIO
-joL
-juf
+tJO
+msP
 jIO
-juf
-joL
+msP
+tJO
 jIO
 jHW
 jLK
-jjF
-sIA
+fmu
+axO
 jRK
 jUl
-sIA
-sIA
-sIA
+axO
+axO
+axO
 kgI
 jIO
 ylG
@@ -45685,8 +46079,8 @@ rge
 rge
 rge
 xpz
-xpz
-xpz
+fKQ
+fKQ
 xpz
 lBA
 khQ
@@ -45741,21 +46135,21 @@ ylG
 ylG
 ylG
 jIO
-sIA
-sIA
+oJO
+oJO
 jIO
-sIA
-sIA
+oJO
+oJO
 jIO
-sIA
-sIA
+axO
+axO
 jOQ
 jQI
 jSp
-kaC
+alV
 gJT
 bjM
-sIA
+axO
 kgT
 jIO
 ylG
@@ -45987,8 +46381,8 @@ khQ
 khQ
 khQ
 xpz
-xpz
-xpz
+fKQ
+fKQ
 xpz
 khQ
 khQ
@@ -46044,21 +46438,21 @@ ylG
 ylG
 jIO
 jIO
-hJH
+gvM
 jIO
-hJH
+gvM
 jIO
 jIO
-joM
-sIA
+bLg
+axO
 jIO
-lXF
-sIA
-sIA
-sIA
-sIA
-sIA
-mIj
+dOD
+axO
+axO
+axO
+axO
+axO
+ewx
 jIO
 ylG
 ylG
@@ -46289,8 +46683,8 @@ khQ
 khQ
 xpz
 xpz
-xpz
-xpz
+fKQ
+fKQ
 xpz
 khQ
 khQ
@@ -46345,21 +46739,21 @@ ylG
 ylG
 ylG
 jIO
-sIA
-sIA
-jwU
-sIA
-sIA
-sIA
-sIA
-sIA
+axO
+axO
+bCT
+axO
+axO
+axO
+axO
+axO
 jIO
 jQS
-sIA
+axO
 jHS
-sIA
-sIA
-keO
+axO
+axO
+aDi
 kgT
 jIO
 ylG
@@ -46591,7 +46985,7 @@ khQ
 khQ
 xpz
 xpz
-xpz
+fKQ
 xpz
 lBA
 khQ
@@ -46647,22 +47041,22 @@ ylG
 ylG
 ylG
 jIO
-sIA
+axO
 jug
-sIA
-sIA
-sIA
-sIA
-jch
-jch
+axO
+axO
+axO
+axO
+hJH
+hJH
 jIO
 jQS
-joR
-sIA
-sIA
+cuZ
+axO
+axO
 kba
-keR
-keR
+fJq
+fJq
 jIO
 ylG
 khQ
@@ -46949,8 +47343,8 @@ jIO
 jIO
 jIO
 jIO
-sIA
-sIA
+axO
+axO
 jIO
 jIO
 jIO
@@ -46960,7 +47354,7 @@ jIO
 jIO
 jIO
 jIO
-hJH
+epS
 jIO
 kbn
 keT
@@ -47251,8 +47645,8 @@ sIA
 sIA
 jwP
 jIO
-joM
-sIA
+bLg
+axO
 jIO
 jFn
 sIA
@@ -47550,17 +47944,17 @@ ylG
 ylG
 jIO
 jej
-jCE
+ofo
 sIA
 jIO
-sIA
-sIA
+axO
+axO
 jIO
 sIA
-sIA
+fiE
 jBZ
 jIO
-xZD
+kAW
 xZD
 xZD
 xZD
@@ -47795,7 +48189,7 @@ fKQ
 fKQ
 fKQ
 fKQ
-xpz
+fKQ
 fKQ
 fKQ
 fKQ
@@ -47852,14 +48246,14 @@ ylG
 ylG
 jIO
 jeR
-sIA
+fiE
 sIA
 jjF
-sIA
-sIA
+axO
+axO
 jxu
 sIA
-sIA
+fiE
 jeX
 jIO
 yic
@@ -48097,8 +48491,8 @@ xpz
 xpz
 fKQ
 fKQ
-xpz
-xpz
+fKQ
+fKQ
 xpz
 xpz
 xpz
@@ -48157,8 +48551,8 @@ jeR
 sIA
 jgT
 jIO
-sIA
-sIA
+axO
+axO
 jIO
 jgT
 sIA
@@ -48315,15 +48709,15 @@ xZD
 xZD
 jIO
 cfW
-fVQ
-wSc
-cwC
+vvW
+xih
+wmv
 cyt
 cCk
-cKU
+bxj
 cRK
-aPV
-wSc
+glW
+xih
 jIO
 ykT
 ykT
@@ -48459,8 +48853,8 @@ jIO
 jIO
 jIO
 jIO
-joM
-sIA
+bLg
+axO
 jIO
 jIO
 jIO
@@ -48616,16 +49010,16 @@ ykT
 xZD
 xZD
 bWw
-wSc
+xih
 ckn
 csH
 oLG
-wSc
-ids
-wSc
-wSc
-wSc
-wSc
+xih
+uhz
+xih
+xih
+xih
+xih
 jIO
 ykT
 ykT
@@ -48761,8 +49155,8 @@ jcB
 sIA
 jgV
 jIO
-sIA
-sIA
+axO
+axO
 jIO
 jgV
 sIA
@@ -48918,16 +49312,16 @@ ykT
 xZD
 xZD
 bWw
-wSc
+xih
 xGW
 csX
 cwV
-wSc
-ids
+xih
+uhz
 bWL
-wSc
-wSc
-wSc
+xih
+xih
+xih
 jIO
 ykT
 ykT
@@ -49060,14 +49454,14 @@ ylG
 ylG
 jIO
 jeX
-sIA
+fiE
 sIA
 jjF
-sIA
-sIA
+axO
+axO
 jxu
 sIA
-jCE
+ofo
 jFx
 jIO
 yic
@@ -49220,16 +49614,16 @@ ykT
 xZD
 xZD
 jIO
-wSc
+xih
 ewZ
 xGW
 xGW
-wSc
+xih
 cCD
-iDB
-cRU
-sTb
-wSc
+hpz
+pZd
+pvB
+xih
 jIO
 jIO
 jIO
@@ -49362,14 +49756,14 @@ ylG
 ylG
 jIO
 jfU
-sIA
-sIA
-jIO
-sIA
+fiE
 sIA
 jIO
+axO
+axO
+jIO
 sIA
-sIA
+fiE
 sIA
 jIO
 xZD
@@ -49522,22 +49916,22 @@ ykT
 xZD
 xZD
 jIO
-aFo
+nlc
 xGW
 xGW
-wSc
-wSc
-anG
-wSc
-wSc
-wSc
-wSc
-wSc
-wSc
-aPV
-wSc
-bhx
-wSc
+xGW
+xih
+ecs
+xih
+xih
+xih
+xih
+xih
+xih
+glW
+xih
+mvb
+xih
 jIO
 xZD
 xZD
@@ -49667,8 +50061,8 @@ jch
 jej
 sIA
 jIO
-joR
-sIA
+cuZ
+axO
 jIO
 jyQ
 jej
@@ -49824,7 +50218,7 @@ ykT
 xZD
 xZD
 bWA
-wSc
+xih
 ckA
 xGW
 xGW
@@ -50126,7 +50520,7 @@ ykT
 bRG
 xZD
 bWC
-adv
+eju
 xGW
 ctu
 xGW
@@ -50429,21 +50823,21 @@ xZD
 xZD
 jIO
 cgu
-aXt
-wSc
-wSc
-aXt
-bhx
-wSc
+iWA
+xih
+xih
+iWA
+mvb
+xih
 cRW
-wSc
-bgY
-wSc
-aFo
-bGm
-wSc
-aTP
-sPT
+xih
+rdq
+xih
+nlc
+xpf
+xih
+hNQ
+gpn
 jIO
 xZD
 xZD
@@ -50612,7 +51006,7 @@ lqK
 jIO
 rei
 kjG
-sPT
+owT
 jIO
 lGJ
 lHI
@@ -53926,11 +54320,11 @@ wwY
 kPA
 oJO
 kWn
-wSc
-wSc
+axO
+axO
 lhe
-wSc
-wSc
+axO
+axO
 jzk
 lwC
 mxp
@@ -54056,7 +54450,7 @@ fKq
 wSc
 wSc
 wSc
-sPT
+owT
 pwP
 cLG
 xGW
@@ -54228,11 +54622,11 @@ kMf
 oJO
 oJO
 jIO
-ybx
-wSc
-iGT
-wSc
-wSc
+bLg
+axO
+hlw
+axO
+axO
 iHD
 ibN
 mxp
@@ -54530,11 +54924,11 @@ hbA
 oJO
 oJO
 mtE
-wSc
-wSc
-iGT
-wSc
-wSc
+axO
+axO
+hlw
+axO
+axO
 giY
 giY
 mxp
@@ -54672,7 +55066,7 @@ wSc
 jbz
 cDz
 wSc
-sPT
+owT
 oPs
 ylG
 xZD
@@ -54832,13 +55226,13 @@ kMn
 oJO
 oJO
 lTc
-wSc
-wSc
+axO
+axO
 jvW
-wSc
-wSc
-wSc
-wSc
+axO
+axO
+axO
+axO
 jIO
 xZD
 xZD
@@ -54938,12 +55332,12 @@ khQ
 ylG
 ylG
 pwP
-vEq
+gNq
 aGM
-wSc
+gMg
 aSw
 pwP
-vBJ
+nUb
 bqS
 pKQ
 pwP
@@ -55134,14 +55528,14 @@ kMJ
 oJO
 oJO
 hhL
-wSc
-wSc
-iGT
-wSc
-wSc
-wSc
-wSc
-cDO
+axO
+axO
+hlw
+axO
+axO
+axO
+axO
+gUn
 xZD
 xZD
 ykT
@@ -55240,14 +55634,14 @@ khQ
 ylG
 ylG
 pwP
-vEq
-wSc
-azL
-wSc
+gNq
+gMg
+mUJ
+gMg
 pwP
-wSc
-wSc
-wSc
+axO
+axO
+axO
 bFE
 wtg
 laG
@@ -55436,13 +55830,13 @@ hzK
 oJO
 kSo
 jIO
-ybx
-wSc
+bLg
+axO
 jIO
-wSc
-wSc
-wSc
-bue
+axO
+axO
+axO
+ewx
 jIO
 xZD
 xZD
@@ -55543,13 +55937,13 @@ khQ
 ylG
 pwP
 azp
-wSc
-nyC
-wSc
+gMg
+gBS
+gMg
 pwP
-biq
-wSc
-anG
+fhX
+axO
+aDi
 bvy
 bJI
 xZD
@@ -55738,11 +56132,11 @@ jIO
 mHQ
 jIO
 jIO
-wSc
-wSc
-cDO
-wSc
-wSc
+axO
+axO
+gUn
+axO
+axO
 jzk
 jzk
 mxp
@@ -55845,13 +56239,13 @@ khQ
 ylG
 pwP
 bfA
-wSc
+gMg
 aMf
-vBJ
+wGf
 pwP
 biR
-wSc
-wSc
+axO
+axO
 pwP
 wtg
 xZD
@@ -55873,8 +56267,8 @@ cDz
 xGW
 xGW
 pwP
-xZD
-xZD
+trK
+ayn
 bLE
 ylG
 ylG
@@ -56043,8 +56437,8 @@ jIO
 jIO
 jIO
 jIO
-wSc
-wSc
+axO
+axO
 jtP
 hSW
 bJs
@@ -56146,13 +56540,13 @@ khQ
 ylG
 ylG
 pwP
-azN
+vHU
 aGU
-wmR
+jyD
 ePJ
 pwP
 pKQ
-wSc
+axO
 bxr
 bFE
 wtg
@@ -56174,9 +56568,9 @@ wSc
 wSc
 xGW
 xGW
-cCR
-xZD
-xZD
+cDO
+muY
+iHo
 xZD
 xZD
 xZD
@@ -56345,8 +56739,8 @@ jIO
 tJO
 oJO
 htH
-wSc
-wSc
+axO
+axO
 giY
 lwP
 mxp
@@ -56453,9 +56847,9 @@ pwP
 gNz
 pwP
 pwP
-wSc
-wSc
-wSc
+axO
+axO
+axO
 bFE
 bJI
 xZD
@@ -56477,8 +56871,8 @@ jbz
 xGW
 xGW
 pwP
-xZD
-xZD
+muY
+iHo
 xZD
 xZD
 xZD
@@ -56647,7 +57041,7 @@ jIO
 aXq
 oJO
 jIO
-wSc
+axO
 jIO
 bJs
 bJs
@@ -56752,12 +57146,12 @@ ylG
 ylG
 ylG
 pwP
-wSc
-wSc
+gMg
+gMg
 aYP
-wSc
-wSc
-wSc
+axO
+axO
+axO
 pwP
 wtg
 xZD
@@ -56779,8 +57173,8 @@ wSc
 xGW
 xGW
 wzu
-xZD
-xZD
+muY
+iHo
 xZD
 xZD
 xZD
@@ -56949,8 +57343,8 @@ jIO
 jIO
 jIO
 jIO
-wSc
-wSc
+axO
+axO
 cFp
 ibN
 csH
@@ -57055,10 +57449,10 @@ ylG
 ylG
 pwP
 aNs
-wSc
-drM
-wSc
-wSc
+gMg
+dJW
+axO
+axO
 psQ
 pwP
 pwP
@@ -57081,8 +57475,8 @@ cCW
 xGW
 xGW
 pwP
-xZD
-xZD
+trK
+uyu
 xZD
 ylG
 aJu
@@ -57250,9 +57644,9 @@ xZD
 jIO
 joT
 juq
-wSc
-wSc
-wSc
+axO
+axO
+axO
 cFp
 foX
 csH
@@ -57356,11 +57750,11 @@ ylG
 ylG
 ylG
 pwP
-wSc
-wmR
-vIL
-wSc
-wSc
+gMg
+jyD
+ktQ
+axO
+axO
 xdr
 pwP
 xZD
@@ -57552,12 +57946,12 @@ xZD
 jIO
 laS
 ibN
-wSc
+axO
 jIO
-ybx
-wSc
-wSc
-anG
+bLg
+axO
+axO
+aDi
 bJs
 xZD
 ykT
@@ -57658,12 +58052,12 @@ ylG
 ylG
 ylG
 pwP
-wSc
-aFo
+gMg
+eVg
 aYP
-wSc
-wSc
-wSc
+axO
+axO
+axO
 pwP
 xZD
 aJd
@@ -57692,7 +58086,7 @@ dlt
 wSc
 dlt
 wSc
-sPT
+owT
 pwP
 ylG
 xZD
@@ -57854,9 +58248,9 @@ xZD
 jIO
 laS
 ibN
-wSc
-wSc
-wSc
+axO
+axO
+axO
 cFp
 ibN
 lAh
@@ -57960,13 +58354,13 @@ ylG
 ylG
 ylG
 pwP
-xcp
-wSc
-pzP
-wSc
-wSc
-wSc
-bFH
+gNa
+gMg
+uwC
+axO
+axO
+axO
+ohH
 xZD
 xZD
 xZD
@@ -58156,9 +58550,9 @@ xZD
 jIO
 lbm
 juA
-wSc
-wSc
-wSc
+axO
+axO
+axO
 cFp
 lwN
 lAE
@@ -58262,12 +58656,12 @@ ylG
 ylG
 ylG
 pwP
-vBJ
-wSc
-wSc
-aFo
-wSc
-wSc
+wGf
+gMg
+gMg
+cxd
+axO
+axO
 pwP
 xZD
 xZD
@@ -58564,11 +58958,11 @@ ylG
 ylG
 ylG
 pwP
-wSc
-wSc
-wSc
+gMg
+gMg
+gMg
 bqS
-wSc
+axO
 iLM
 pwP
 xZD
@@ -58888,7 +59282,7 @@ fKq
 clu
 wSc
 wSc
-sPT
+owT
 pwP
 cMy
 wSc
@@ -59025,13 +59419,13 @@ rew
 ykT
 ykT
 xZD
-ylG
-ylG
-ylG
+wtg
+hxX
+wtg
 xZD
-ylG
-ylG
-ylG
+wtg
+hxX
+wtg
 xZD
 mxp
 jGu
@@ -59327,13 +59721,13 @@ rew
 ykT
 ykT
 xZD
-ylG
-ylG
-ylG
+wtg
+wtg
+wtg
 xZD
-ylG
-ylG
-ylG
+wtg
+wtg
+wtg
 xZD
 mxp
 rei
@@ -59405,7 +59799,7 @@ ylG
 ylG
 ylG
 ylG
-ylG
+wtg
 jfc
 wSc
 wSc
@@ -60255,7 +60649,7 @@ mxp
 kjG
 esY
 wSc
-sPT
+owT
 jIO
 ybx
 wSc
@@ -60572,7 +60966,7 @@ jIO
 jIO
 wgf
 jIO
-sPT
+owT
 wSc
 dCf
 dCf
@@ -60837,13 +61231,13 @@ xoN
 ykT
 ykT
 xZD
-ylG
-ylG
-ylG
+wtg
+hxX
+wtg
 xZD
-ylG
-ylG
-ylG
+wtg
+hxX
+wtg
 xZD
 mxp
 rei
@@ -61139,13 +61533,13 @@ rew
 ykT
 ykT
 xZD
-ylG
-ylG
-ylG
+wtg
+wtg
+wtg
 xZD
-ylG
-ylG
-ylG
+wtg
+wtg
+wtg
 xZD
 mxp
 jGx
@@ -62511,13 +62905,13 @@ owq
 xGW
 clU
 xGW
-sPT
+owT
 pwP
 owq
 xGW
 cSz
 cWd
-sPT
+owT
 pwP
 vEq
 wSc
@@ -62975,7 +63369,7 @@ wSc
 wSc
 nZJ
 wSc
-sPT
+owT
 jIO
 xZD
 xZD
@@ -63428,7 +63822,7 @@ pwP
 djR
 wSc
 pwP
-cEN
+vcM
 wSc
 dwP
 scA
@@ -69157,7 +69551,7 @@ bYY
 cuK
 vvF
 pwP
-cEN
+vcM
 wSc
 wSc
 pwP
@@ -69768,7 +70162,7 @@ pwP
 dsO
 xGW
 wSc
-dma
+dzl
 wSc
 aFo
 wSc
@@ -70071,7 +70465,7 @@ lqB
 xGW
 wSc
 pwP
-cEN
+vcM
 dsT
 wSc
 wSc
@@ -70274,7 +70668,7 @@ wSc
 wSc
 wSc
 eeP
-sPT
+owT
 jIO
 ndy
 xCr
@@ -70345,10 +70739,10 @@ khQ
 khQ
 pwP
 aZQ
-bjP
-xcp
+gZW
+cjk
 bzf
-wSc
+axO
 pwP
 xZD
 xZD
@@ -70646,12 +71040,12 @@ khQ
 khQ
 khQ
 pwP
-paK
-wSc
-aYP
-aFo
-wSc
-gnH
+awR
+axO
+cds
+cxd
+axO
+fmu
 xZD
 aJd
 ykT
@@ -70948,12 +71342,12 @@ khQ
 khQ
 khQ
 pwP
-wSc
-wSc
-xcp
-wSc
-wSc
-bKD
+axO
+axO
+cjk
+axO
+axO
+jOQ
 xZD
 xZD
 ykT
@@ -71250,11 +71644,11 @@ khQ
 khQ
 khQ
 pwP
-wSc
-xcp
-xcp
-wSc
-csh
+axO
+cjk
+cjk
+axO
+wbT
 pwP
 xZD
 xZD
@@ -71464,7 +71858,7 @@ jIO
 rei
 miB
 mky
-rei
+bNG
 jIO
 msP
 tJO
@@ -71552,11 +71946,11 @@ khQ
 khQ
 khQ
 pwP
-bas
-wSc
-wSc
-wSc
-anG
+lxR
+axO
+axO
+axO
+aDi
 bIS
 xZD
 xZD
@@ -71855,10 +72249,10 @@ khQ
 khQ
 pwP
 bbd
-aFo
+cxd
 brR
-cvg
-wSc
+gRs
+axO
 bFE
 bLE
 xZD
@@ -72157,10 +72551,10 @@ khQ
 khQ
 pwP
 bbC
-aaN
+svU
 brR
-cvg
-wSc
+gRs
+axO
 bKO
 xZD
 laG
@@ -72436,7 +72830,7 @@ ylG
 ylG
 ylG
 ylG
-yib
+nfu
 yib
 yib
 khQ
@@ -72458,11 +72852,11 @@ khQ
 khQ
 xmo
 aSE
-wSc
-wSc
-wSc
-wSc
-bFJ
+jcM
+svU
+axO
+axO
+dQj
 bIS
 xZD
 xZD
@@ -72736,9 +73130,9 @@ ylG
 ylG
 ylG
 ylG
-yib
-yib
-yib
+nfu
+nfu
+nfu
 yib
 yib
 khQ
@@ -72761,10 +73155,10 @@ pyY
 xmo
 aaI
 bcy
-wSc
-wSc
-wSc
-csh
+axO
+axO
+axO
+wbT
 pwP
 xZD
 xZD
@@ -73037,8 +73431,8 @@ ylG
 ylG
 ylG
 ylG
-yib
-yib
+nfu
+nfu
 yib
 yib
 yib
@@ -73062,11 +73456,11 @@ xmo
 xmo
 xmo
 aaN
-wSc
-wSc
-aaN
-bzu
-bzu
+jcS
+axO
+mTw
+wnK
+wnK
 pwP
 kAW
 xZD
@@ -73339,8 +73733,8 @@ ylG
 ylG
 wtg
 wtg
-yib
-yib
+nfu
+nfu
 yib
 yib
 yib
@@ -73641,8 +74035,8 @@ ylG
 ylG
 wtg
 wtg
-yib
-yib
+nfu
+nfu
 yib
 yib
 yib
@@ -74548,8 +74942,8 @@ ylG
 wtg
 wtg
 wtg
-wtg
-yib
+nfu
+nfu
 yib
 yib
 khQ
@@ -75480,7 +75874,7 @@ wSc
 aTy
 jIO
 bko
-wSc
+jas
 wSc
 wSc
 bKR
@@ -75782,7 +76176,7 @@ aqy
 aTH
 jIO
 wCR
-wSc
+jas
 wSc
 bGe
 aTH
@@ -79340,7 +79734,7 @@ jIO
 jIO
 nic
 nlt
-ihh
+qjj
 nic
 jIO
 jIO
@@ -82723,11 +83117,11 @@ scA
 apm
 pwP
 gmy
-scA
-aOT
-wSc
+ahE
+lhg
+ahE
 bcN
-iGT
+cIo
 sPT
 pwP
 bGU
@@ -83025,12 +83419,12 @@ scA
 scA
 pwP
 auL
-scA
-scA
-wSc
-wSc
-iGT
-wSc
+ahE
+ahE
+ahE
+ahE
+cIo
+axO
 pwP
 bGU
 ofp
@@ -83326,13 +83720,13 @@ bmu
 scA
 nLd
 pwP
-bXh
-scA
-scA
-wSc
-wSc
-wSc
-wSc
+tZH
+ahE
+ahE
+ahE
+ahE
+ahE
+axO
 pwP
 xZD
 xZD
@@ -83343,7 +83737,7 @@ ykT
 rew
 ykT
 ykT
-ykT
+tXh
 ykT
 ykT
 ykT
@@ -83353,9 +83747,9 @@ cxo
 aLq
 aLq
 jIO
+sHz
 aLq
-aLq
-aLq
+qNw
 jIO
 xZD
 khQ
@@ -83628,13 +84022,13 @@ pwP
 scA
 aps
 pwP
-aBK
-scA
-scA
-wSc
-wSc
-iGT
-wSc
+jAi
+ahE
+ahE
+ahE
+ahE
+cIo
+axO
 pwP
 pwP
 pwP
@@ -83645,7 +84039,7 @@ ykT
 rew
 ykT
 ykT
-ykT
+tXh
 ykT
 ykT
 ykT
@@ -83925,7 +84319,7 @@ khQ
 pwP
 xNi
 xNi
-wSc
+axO
 pwP
 puP
 pwP
@@ -83935,8 +84329,8 @@ pwP
 pwP
 aUh
 foE
-bmb
-wSc
+gUC
+axO
 bBC
 bGV
 pwP
@@ -83947,7 +84341,7 @@ ykT
 rew
 ykT
 ykT
-ykT
+tXh
 ykT
 ykT
 ykT
@@ -83957,8 +84351,8 @@ cxo
 aLq
 aLq
 jIO
-aLq
-aLq
+srP
+kDR
 dcy
 jIO
 xZD
@@ -84227,18 +84621,18 @@ khQ
 pwP
 pwP
 aeG
-wSc
+axO
 pwP
-wSc
+axO
 sPT
-awb
-aCa
+lOb
+wQC
 aIK
 pwP
-aUx
-aUx
-aUx
-wSc
+vbf
+vbf
+vbf
+axO
 bBI
 bHn
 rbd
@@ -84528,19 +84922,19 @@ khQ
 khQ
 pwP
 adg
-wSc
-wSc
-gnH
-wSc
-wSc
-wSc
-wSc
-wSc
-wSc
-wSc
-wSc
-wSc
-wSc
+axO
+axO
+fmu
+axO
+axO
+axO
+axO
+axO
+axO
+axO
+axO
+axO
+axO
 bBI
 bHA
 rbd
@@ -84554,10 +84948,10 @@ ykT
 xZD
 bSN
 caq
-fiE
-coc
-coc
-coc
+axO
+gZW
+gZW
+gZW
 jIO
 cGq
 cPo
@@ -84830,19 +85224,19 @@ khQ
 khQ
 pwP
 adl
-wSc
+axO
 ahr
 pwP
-wSc
-wSc
-wSc
-wSc
-wSc
-wSc
-wSc
+axO
+axO
+axO
+axO
+axO
+axO
+axO
 bcT
-wSc
-wSc
+axO
+axO
 aKu
 aKu
 pwP
@@ -84856,10 +85250,10 @@ ykT
 xZD
 mxp
 cay
-fiE
-fiE
-fiE
-fiE
+axO
+axO
+axO
+axO
 jIO
 cGL
 cQe
@@ -85135,16 +85529,16 @@ pwP
 pwP
 pwP
 pwP
-gjv
+ett
 pwP
 pwP
 pwP
-gjv
+ett
 pwP
-wSc
-wSc
+axO
+axO
 kWw
-wSc
+axO
 aKu
 bHY
 pwP
@@ -85157,11 +85551,11 @@ ykT
 ykT
 xZD
 jIO
-caF
-fiE
+gRs
+axO
 coB
-aNS
-aNS
+cjk
+cjk
 jIO
 cHj
 cQl
@@ -85436,17 +85830,17 @@ khQ
 khQ
 pwP
 joH
-aib
-wSc
+coY
+axO
 pwP
 kyy
-wSc
-wSc
+axO
+axO
 pwP
-ybx
-wSc
-wSc
-wSc
+bLg
+axO
+axO
+axO
 bBI
 bIa
 rbd
@@ -85459,11 +85853,11 @@ ykT
 ykT
 xZD
 jIO
-caF
-fiE
-fiE
-fiE
-fcN
+gRs
+axO
+axO
+axO
+axO
 jIO
 jIO
 jIO
@@ -85738,17 +86132,17 @@ khQ
 khQ
 pwP
 ahy
-wSc
+axO
 gjJ
 pwP
 awC
-wSc
+axO
 aIR
 pwP
-wSc
+axO
 bdm
-wSc
-wSc
+axO
+axO
 bBI
 bHn
 rbd
@@ -85761,11 +86155,11 @@ ykT
 ykT
 xZD
 mxp
-fcN
-fiE
-fiE
-fiE
-fcN
+cay
+axO
+axO
+axO
+axO
 jIO
 fiE
 cQp
@@ -86039,18 +86433,18 @@ khQ
 khQ
 khQ
 pwP
-alO
-wSc
-alO
+caF
+axO
+caF
 pwP
-alO
-wSc
-alO
+caF
+axO
+caF
 pwP
-wSc
-wSc
-wSc
-wSc
+axO
+axO
+axO
+axO
 bCj
 bIh
 pwP
@@ -86063,12 +86457,12 @@ ykT
 ykT
 xZD
 bSX
-fcN
-fiE
-fiE
-fiE
-fiE
-fiE
+cay
+axO
+axO
+axO
+axO
+fmu
 fiE
 fiE
 fiE
@@ -86351,7 +86745,7 @@ pwP
 pwP
 aVm
 pwP
-bme
+sPN
 pwP
 rbd
 pwP
@@ -86367,7 +86761,7 @@ xZD
 jIO
 mxp
 jIO
-coY
+sPN
 jIO
 mxp
 jIO
@@ -87244,11 +87638,11 @@ khQ
 khQ
 khQ
 khQ
-jIO
-jIO
-jIO
-jIO
-jIO
+hiq
+bme
+hiq
+hiq
+hiq
 jIO
 jIO
 jIO
@@ -87306,7 +87700,7 @@ xsE
 xsE
 xsE
 jIO
-sPT
+owT
 wSc
 eiL
 dxz
@@ -87546,13 +87940,13 @@ khQ
 khQ
 khQ
 khQ
-jIO
+hiq
 adm
-aeP
+bcN
 ahE
 wSc
 akl
-wSc
+bTw
 jIO
 hYk
 sUu
@@ -87623,7 +88017,7 @@ wSc
 wSc
 wSc
 jIO
-sPT
+owT
 esY
 wSc
 eeP
@@ -87848,12 +88242,12 @@ khQ
 khQ
 khQ
 khQ
-jIO
+hiq
 adD
 iom
 ahE
-wSc
-wSc
+ajm
+amp
 wSc
 gnH
 sUu
@@ -88150,12 +88544,12 @@ khQ
 khQ
 khQ
 khQ
-jIO
+bme
 adG
-scA
 ahE
-wSc
-wSc
+coc
+cEN
+dcj
 wSc
 jIO
 lDF
@@ -88175,7 +88569,7 @@ ykT
 rew
 ykT
 ykT
-ykT
+tXh
 bTt
 mBi
 mBi
@@ -88452,12 +88846,12 @@ khQ
 khQ
 khQ
 khQ
-jIO
-jIO
-jIO
-jIO
+bme
+bme
+hiq
+bme
 aim
-wSc
+amq
 apw
 jIO
 hLI
@@ -88477,7 +88871,7 @@ ykT
 rew
 ykT
 ykT
-ykT
+tXh
 bTt
 mBi
 mBi
@@ -88779,7 +89173,7 @@ ykT
 rew
 ykT
 ykT
-ykT
+tXh
 bTt
 mBi
 mBi
@@ -89685,7 +90079,7 @@ ykT
 rew
 ykT
 ykT
-ykT
+tXh
 bTt
 mBi
 mBi
@@ -89987,7 +90381,7 @@ ykT
 rew
 ykT
 ykT
-ykT
+tXh
 bTt
 mBi
 mBi
@@ -90289,7 +90683,7 @@ ykT
 rew
 ykT
 ykT
-ykT
+tXh
 bTt
 mBi
 mBi
@@ -90874,7 +91268,7 @@ xmo
 xmo
 xmo
 xmo
-aaD
+khQ
 khQ
 khQ
 khQ
@@ -91168,15 +91562,15 @@ khQ
 "}
 (218,1,1) = {"
 khQ
+khQ
 aaD
 xmo
+kaz
 xmo
 xmo
+kaz
 xmo
-xmo
-xmo
-xmo
-xmo
+khQ
 khQ
 khQ
 khQ
@@ -91254,7 +91648,7 @@ eMI
 wSc
 eeP
 wSc
-sPT
+owT
 jIO
 ylG
 ylG
@@ -91471,14 +91865,14 @@ khQ
 (219,1,1) = {"
 khQ
 khQ
+khQ
 xmo
 xmo
 xmo
 xmo
 xmo
 xmo
-xmo
-xmo
+khQ
 khQ
 khQ
 khQ
@@ -91773,14 +92167,14 @@ khQ
 (220,1,1) = {"
 khQ
 khQ
+khQ
+aaD
 xmo
 xmo
+kaz
 xmo
 xmo
-xmo
-xmo
-xmo
-xmo
+aaD
 khQ
 khQ
 khQ
@@ -91840,7 +92234,7 @@ clq
 wSc
 wSc
 jIO
-sPT
+wSc
 wSc
 wSc
 wSc
@@ -92074,15 +92468,15 @@ khQ
 "}
 (221,1,1) = {"
 khQ
-aaD
+khQ
+khQ
+khQ
 xmo
 xmo
 xmo
 xmo
 xmo
-xmo
-xmo
-xmo
+khQ
 khQ
 khQ
 khQ
@@ -92378,13 +92772,13 @@ khQ
 khQ
 khQ
 khQ
-xmo
-xmo
-xmo
-xmo
-xmo
+khQ
 khQ
 aaD
+khQ
+khQ
+aaD
+khQ
 khQ
 khQ
 khQ
@@ -92680,11 +93074,6 @@ khQ
 khQ
 khQ
 khQ
-aaD
-khQ
-aaD
-xmo
-xmo
 khQ
 khQ
 khQ
@@ -92696,11 +93085,16 @@ khQ
 khQ
 khQ
 khQ
-jIO
-jIO
-jIO
-jIO
-jIO
+khQ
+khQ
+khQ
+khQ
+khQ
+hiq
+hiq
+bme
+hiq
+hiq
 bON
 axO
 axO
@@ -92745,7 +93139,7 @@ wSc
 wSc
 wSc
 esY
-wSc
+owT
 jIO
 jIO
 bSX
@@ -92998,11 +93392,11 @@ khQ
 khQ
 khQ
 khQ
-jIO
+hiq
 cNl
-axO
-lSm
-jIO
+gMg
+nOD
+hiq
 axO
 axO
 axO
@@ -93300,11 +93694,11 @@ khQ
 khQ
 khQ
 khQ
-jIO
+hiq
 kFr
-axO
-axO
-axO
+gMg
+gMg
+gMg
 axO
 axO
 axO
@@ -93602,11 +93996,11 @@ khQ
 khQ
 khQ
 khQ
-jIO
+hiq
 bLz
-axO
-axO
-jIO
+gMg
+gMg
+hiq
 dQy
 dQy
 axO
@@ -93876,7 +94270,7 @@ xmo
 xmo
 xmo
 xmo
-sdP
+usd
 khQ
 khQ
 khQ
@@ -93904,11 +94298,11 @@ khQ
 khQ
 khQ
 khQ
-jIO
-jIO
-jIO
-jIO
-jIO
+hiq
+hiq
+bme
+bme
+hiq
 jIO
 jIO
 sPN
@@ -94177,10 +94571,10 @@ khQ
 pyY
 xmo
 xmo
-sdP
-sdP
-sdP
-sdP
+usd
+usd
+usd
+usd
 khQ
 khQ
 khQ
@@ -94209,7 +94603,7 @@ khQ
 khQ
 khQ
 khQ
-jIO
+bme
 lDb
 kPF
 xZD
@@ -94478,12 +94872,12 @@ nKM
 nKM
 xmo
 xmo
-ecs
-sdP
-sdP
-sdP
-sdP
-sdP
+xmo
+usd
+usd
+usd
+usd
+usd
 khQ
 khQ
 khQ
@@ -94780,12 +95174,12 @@ mwX
 nKM
 xmo
 keL
-sdP
-sdP
-sdP
-sdP
-sdP
-sdP
+usd
+usd
+usd
+usd
+usd
+usd
 khQ
 khQ
 khQ
@@ -95085,9 +95479,9 @@ xmo
 ovC
 ovC
 ovC
-sdP
-sdP
-sdP
+usd
+usd
+usd
 khQ
 khQ
 khQ
@@ -95387,8 +95781,8 @@ xmo
 ovC
 ovC
 ovC
-sdP
-sdP
+usd
+usd
 khQ
 khQ
 khQ
@@ -95684,13 +96078,13 @@ omM
 qAp
 ooY
 nKM
-ecs
 xmo
-sdP
-sdP
-sdP
-sdP
-kwg
+xmo
+usd
+usd
+usd
+usd
+usd
 khQ
 khQ
 khQ
@@ -95987,11 +96381,11 @@ nKM
 nKM
 nKM
 nKM
-xmo
+pyY
 xmo
 usd
-sdP
-sdP
+usd
+usd
 khQ
 khQ
 khQ

--- a/_maps/map_files/Mammoth/Mammoth.dmm
+++ b/_maps/map_files/Mammoth/Mammoth.dmm
@@ -4644,6 +4644,7 @@
 /obj/structure/ms13/storage/large/shelf/rust{
 	dir = 8
 	},
+/obj/effect/spawner/random/ms13/medical/bloodbag,
 /turf/open/floor/ms13/metal,
 /area/ms13/town)
 "dmf" = (
@@ -7894,6 +7895,7 @@
 /obj/effect/spawner/random/ms13/medical/highrandom,
 /obj/effect/spawner/random/ms13/medical/highrandom,
 /obj/structure/closet/crate/ms13/medical,
+/obj/effect/spawner/random/ms13/medical/bloodbag,
 /turf/open/floor/ms13/tile/large/black,
 /area/ms13/underground/vault_atrium_middle)
 "fuW" = (
@@ -8031,6 +8033,7 @@
 "fyR" = (
 /obj/structure/table/ms13/metal,
 /obj/effect/spawner/random/ms13/melee/lowrandom,
+/obj/effect/spawner/random/ms13/medical/bloodbag,
 /turf/open/floor/ms13/tile/blue/long,
 /area/ms13/town)
 "fzw" = (
@@ -15811,6 +15814,7 @@
 	},
 /obj/effect/spawner/random/ms13/medical/highrandom,
 /obj/effect/spawner/random/ms13/medical/lowrandom,
+/obj/effect/spawner/random/ms13/medical/bloodbag,
 /turf/open/floor/ms13/tile/large/black,
 /area/ms13/underground/vault_atrium_middle)
 "kjK" = (
@@ -23337,6 +23341,7 @@
 "pTS" = (
 /obj/effect/spawner/random/ms13/medical/lowrandom,
 /obj/structure/closet/cabinet,
+/obj/effect/spawner/random/ms13/medical/bloodbag,
 /turf/open/floor/wood/ms13/common,
 /area/ms13/town)
 "pVl" = (
@@ -25852,6 +25857,11 @@
 	},
 /turf/open/floor/ms13/tile/navy,
 /area/ms13/underground/vault_atrium_middle)
+"xJJ" = (
+/obj/structure/table/ms13/metal,
+/obj/effect/spawner/random/ms13/medical/bloodbag,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/ncr)
 "xKP" = (
 /obj/structure/fluff/paper/stack{
 	dir = 4
@@ -38097,7 +38107,7 @@ sFB
 sFB
 nKL
 liC
-nEo
+xJJ
 nKL
 xsE
 xsE

--- a/_maps/map_files/Mammoth/Mammoth.dmm
+++ b/_maps/map_files/Mammoth/Mammoth.dmm
@@ -162,6 +162,7 @@
 /obj/effect/decal/cleanable/blood/gibs/core,
 /obj/effect/spawner/random/ms13/medical/lowrandom,
 /obj/effect/spawner/random/ms13/medical/lowrandom,
+/obj/effect/spawner/random/ms13/medical/lowrandom,
 /turf/open/floor/ms13/tile/navy,
 /area/ms13/town)
 "adP" = (
@@ -2620,7 +2621,7 @@
 "bLz" = (
 /obj/structure/table/ms13/metal,
 /obj/effect/spawner/random/ms13/clothing/shoe,
-/turf/open/floor/ms13/metal,
+/turf/open/floor/ms13/tile/large/black,
 /area/ms13/town)
 "bLE" = (
 /obj/effect/decal/cleanable/glass{
@@ -4025,7 +4026,7 @@
 /obj/effect/spawner/random/ms13/clothing/gloves,
 /obj/effect/spawner/random/ms13/clothing/gloves,
 /obj/effect/spawner/random/ms13/clothing/gloves,
-/turf/open/floor/ms13/metal,
+/turf/open/floor/ms13/tile/large/black,
 /area/ms13/town)
 "cNr" = (
 /obj/structure/chair/sofa/left{
@@ -16441,7 +16442,7 @@
 /obj/machinery/light/ms13/bulb{
 	dir = 1
 	},
-/turf/open/floor/ms13/metal,
+/turf/open/floor/ms13/tile/large/black,
 /area/ms13/town)
 "kFu" = (
 /obj/effect/decal/cleanable/glass,
@@ -21406,7 +21407,7 @@
 /area/ms13/town)
 "nOD" = (
 /obj/effect/spawner/random/ms13/clothing/shoe,
-/turf/open/floor/ms13/metal,
+/turf/open/floor/ms13/tile/large/black,
 /area/ms13/town)
 "nOL" = (
 /obj/effect/spawner/random/ms13/food/produce_mushrooms,
@@ -93411,7 +93412,7 @@ khQ
 khQ
 hiq
 cNl
-gMg
+mMQ
 nOD
 hiq
 axO
@@ -93713,9 +93714,9 @@ khQ
 khQ
 hiq
 kFr
-gMg
-gMg
-gMg
+mMQ
+mMQ
+mMQ
 axO
 axO
 axO
@@ -94015,8 +94016,8 @@ khQ
 khQ
 hiq
 bLz
-gMg
-gMg
+mMQ
+mMQ
 hiq
 dQy
 dQy

--- a/_maps/map_files/Mammoth/Mammoth.dmm
+++ b/_maps/map_files/Mammoth/Mammoth.dmm
@@ -120,15 +120,8 @@
 /area/ms13/town)
 "adm" = (
 /obj/structure/table/ms13/metal,
-/obj/item/retractor{
-	pixel_x = 4;
-	pixel_y = 2
-	},
-/obj/item/hemostat{
-	pixel_x = -5
-	},
-/obj/item/scalpel{
-	pixel_y = 16
+/obj/item/storage/firstaid/ms13/bag/filled{
+	pixel_y = 6
 	},
 /turf/open/floor/ms13/tile/navy,
 /area/ms13/town)
@@ -168,10 +161,7 @@
 /obj/structure/table/ms13/metal,
 /obj/effect/decal/cleanable/blood/gibs/core,
 /obj/effect/spawner/random/ms13/medical/lowrandom,
-/obj/effect/spawner/random/ms13/medical/highrandom,
-/obj/item/storage/firstaid/ms13/bag/filled{
-	pixel_y = 6
-	},
+/obj/effect/spawner/random/ms13/medical/lowrandom,
 /turf/open/floor/ms13/tile/navy,
 /area/ms13/town)
 "adP" = (
@@ -654,7 +644,6 @@
 /obj/effect/spawner/random/ms13/drink/alcohol_beer,
 /obj/effect/spawner/random/ms13/drink/alcohol_beer,
 /obj/effect/spawner/random/ms13/food/produce_random,
-/obj/item/food/canned/beans,
 /turf/open/floor/ms13/tile/navy,
 /area/ms13/town)
 "auO" = (
@@ -1554,8 +1543,10 @@
 /turf/open/floor/wood/ms13/carpet,
 /area/ms13/town)
 "bbd" = (
-/obj/item/food/canned/beans,
-/obj/structure/ms13/storage/store,
+/obj/structure/table/ms13/no_smooth/large/metal,
+/obj/machinery/light/ms13/bulb{
+	dir = 1
+	},
 /turf/open/floor/wood/ms13/common,
 /area/ms13/town)
 "bbC" = (
@@ -2140,7 +2131,6 @@
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "bxL" = (
-/obj/item/food/canned/beans,
 /obj/structure/ms13/storage/shelf/rust{
 	dir = 1
 	},
@@ -2218,11 +2208,11 @@
 /obj/structure/chair/sofa/corp/left{
 	dir = 4
 	},
-/turf/open/floor/wood/ms13/carpet/shaggy,
+/turf/open/floor/wood/ms13/carpet/shaggy/green,
 /area/ms13/town)
 "bBI" = (
 /obj/structure/table/ms13/metal,
-/turf/open/floor/wood/ms13/carpet/shaggy,
+/turf/open/floor/wood/ms13/carpet/shaggy/green,
 /area/ms13/town)
 "bBJ" = (
 /obj/structure/closet/crate/ms13/woodcrate,
@@ -2248,7 +2238,7 @@
 /obj/structure/chair/sofa/corp/right{
 	dir = 8
 	},
-/turf/open/floor/wood/ms13/carpet/shaggy,
+/turf/open/floor/wood/ms13/carpet/shaggy/green,
 /area/ms13/town)
 "bCk" = (
 /obj/machinery/light/ms13/bulb{
@@ -2470,13 +2460,13 @@
 /obj/structure/chair/sofa/corp/corner{
 	dir = 1
 	},
-/turf/open/floor/wood/ms13/carpet/shaggy,
+/turf/open/floor/wood/ms13/carpet/shaggy/green,
 /area/ms13/town)
 "bHn" = (
 /obj/structure/chair/sofa/corp{
 	dir = 1
 	},
-/turf/open/floor/wood/ms13/carpet/shaggy,
+/turf/open/floor/wood/ms13/carpet/shaggy/green,
 /area/ms13/town)
 "bHy" = (
 /obj/structure/table/ms13/no_smooth/counter/metal{
@@ -2490,18 +2480,18 @@
 	dir = 1
 	},
 /obj/effect/landmark/start/ms13/enforcer,
-/turf/open/floor/wood/ms13/carpet/shaggy,
+/turf/open/floor/wood/ms13/carpet/shaggy/green,
 /area/ms13/town)
 "bHY" = (
-/obj/machinery/light/ms13/bulb,
-/turf/open/floor/wood/ms13/carpet/shaggy,
+/obj/structure/closet/ms13/fridge,
+/turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "bIa" = (
 /obj/structure/chair/sofa/corp/right{
 	dir = 1
 	},
 /obj/effect/landmark/start/ms13/enforcer,
-/turf/open/floor/wood/ms13/carpet/shaggy,
+/turf/open/floor/wood/ms13/carpet/shaggy/green,
 /area/ms13/town)
 "bId" = (
 /obj/structure/curtain/bounty,
@@ -2511,7 +2501,7 @@
 /obj/structure/chair/sofa/corp/corner{
 	dir = 8
 	},
-/turf/open/floor/wood/ms13/carpet/shaggy,
+/turf/open/floor/wood/ms13/carpet/shaggy/green,
 /area/ms13/town)
 "bIk" = (
 /obj/item/trash/semki{
@@ -4218,9 +4208,6 @@
 	},
 /turf/open/floor/ms13/tile,
 /area/ms13/town)
-"cTb" = (
-/turf/open/ms13/water/deep,
-/area/ms13)
 "cTw" = (
 /obj/structure/chair/stool{
 	pixel_x = 6;
@@ -9315,7 +9302,6 @@
 /obj/effect/spawner/random/ms13/food/produce_random,
 /obj/effect/spawner/random/ms13/drink/alcohol_beer,
 /obj/effect/spawner/random/ms13/food/produce_random,
-/obj/item/food/canned/beans,
 /turf/open/floor/ms13/tile/navy,
 /area/ms13/town)
 "gmE" = (
@@ -13520,7 +13506,7 @@
 /area/ms13/ncr)
 "iTU" = (
 /mob/living/basic/ms13/hostile_animal/mirelurk,
-/turf/open/ms13/water/medium,
+/turf/open/floor/plating/ms13/ground/ice,
 /area/ms13)
 "iUb" = (
 /obj/structure/toilet,
@@ -20431,9 +20417,6 @@
 /obj/item/taperecorder,
 /turf/open/floor/ms13/tile/full/navy,
 /area/ms13/town)
-"nfu" = (
-/turf/open/ms13/water/shallow,
-/area/ms13)
 "nfL" = (
 /obj/structure/table/ms13/metal,
 /obj/machinery/light/ms13/bulb,
@@ -21958,9 +21941,7 @@
 /turf/open/floor/plating/ms13/ground/mountain,
 /area/ms13/underground/mountain)
 "ogP" = (
-/mob/living/simple_animal/hostile/retaliate/ms13/slepnir{
-	dir = 8
-	},
+/mob/living/simple_animal/hostile/retaliate/ms13/slepnir,
 /turf/open/floor/plating/ms13/ground/snow,
 /area/ms13/snow/deepforest)
 "ogZ" = (
@@ -22517,7 +22498,6 @@
 /obj/effect/spawner/random/ms13/food/produce_safe,
 /obj/effect/spawner/random/ms13/food/produce_safe,
 /obj/effect/spawner/random/ms13/drink/soda,
-/obj/item/food/canned/beans,
 /turf/open/floor/ms13/tile,
 /area/ms13/ncr)
 "ozn" = (
@@ -22935,6 +22915,10 @@
 	},
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/tribal_abandoned)
+"pas" = (
+/obj/effect/landmark/start/ms13/wastelander,
+/turf/open/floor/plating/ms13/ground/road,
+/area/ms13/town)
 "paK" = (
 /obj/machinery/light/ms13/bulb/broken{
 	dir = 1
@@ -26012,7 +25996,7 @@
 /turf/open/floor/ms13/concrete,
 /area/ms13/town)
 "yib" = (
-/turf/open/ms13/water/medium,
+/turf/open/floor/plating/ms13/ground/ice,
 /area/ms13)
 "yic" = (
 /obj/structure/ms13/phone,
@@ -28259,9 +28243,9 @@ wSc
 ylG
 ylG
 ylG
-nfu
-nfu
-nfu
+yib
+yib
+yib
 khQ
 khQ
 khQ
@@ -28561,8 +28545,8 @@ wSc
 ylG
 ylG
 ylG
-nfu
-nfu
+yib
+yib
 yib
 khQ
 khQ
@@ -28861,9 +28845,9 @@ rAq
 wSc
 wSc
 ylG
-nfu
-nfu
-nfu
+yib
+yib
+yib
 yib
 yib
 khQ
@@ -29163,8 +29147,8 @@ rAq
 wSc
 wSc
 ylG
-nfu
-nfu
+yib
+yib
 yib
 yib
 yib
@@ -29470,7 +29454,7 @@ muY
 muY
 yib
 yib
-cTb
+yib
 khQ
 khQ
 khQ
@@ -29772,7 +29756,7 @@ muY
 muY
 yib
 yib
-cTb
+yib
 khQ
 khQ
 khQ
@@ -30069,12 +30053,12 @@ ykZ
 wSc
 ykZ
 ylG
-nfu
-nfu
 yib
 yib
 yib
-cTb
+yib
+yib
+yib
 khQ
 khQ
 khQ
@@ -30371,13 +30355,13 @@ ylG
 ylG
 ylG
 ylG
-nfu
-nfu
 yib
 yib
-cTb
-cTb
-cTb
+yib
+yib
+yib
+yib
+yib
 khQ
 khQ
 khQ
@@ -30672,13 +30656,13 @@ ylG
 ylG
 ylG
 ylG
-nfu
-nfu
 yib
 yib
 yib
-cTb
-cTb
+yib
+yib
+yib
+yib
 khQ
 khQ
 khQ
@@ -30974,13 +30958,13 @@ ylG
 ylG
 ylG
 ylG
-nfu
-nfu
 yib
 yib
 yib
-cTb
-cTb
+yib
+yib
+yib
+yib
 khQ
 khQ
 khQ
@@ -31276,13 +31260,13 @@ ylG
 ylG
 ylG
 ylG
-nfu
-nfu
 yib
 yib
 yib
-cTb
-cTb
+yib
+yib
+yib
+yib
 khQ
 khQ
 khQ
@@ -31578,13 +31562,13 @@ ylG
 ylG
 ylG
 ylG
-nfu
-nfu
 yib
 yib
 yib
-cTb
-cTb
+yib
+yib
+yib
+yib
 khQ
 khQ
 khQ
@@ -31880,12 +31864,12 @@ ylG
 ylG
 ylG
 ylG
-nfu
-nfu
 yib
 yib
 yib
-cTb
+yib
+yib
+yib
 khQ
 khQ
 khQ
@@ -32182,12 +32166,12 @@ ylG
 ylG
 ylG
 ylG
-nfu
-nfu
 yib
 yib
 yib
-cTb
+yib
+yib
+yib
 khQ
 khQ
 khQ
@@ -32484,12 +32468,12 @@ ylG
 ylG
 ylG
 ylG
-nfu
-nfu
-nfu
 yib
 yib
-cTb
+yib
+yib
+yib
+yib
 khQ
 khQ
 khQ
@@ -32787,11 +32771,11 @@ ylG
 ylG
 ylG
 ylG
-nfu
-nfu
 yib
 yib
-cTb
+yib
+yib
+yib
 khQ
 khQ
 khQ
@@ -33089,8 +33073,8 @@ ylG
 ylG
 ylG
 ylG
-nfu
-nfu
+yib
+yib
 yib
 yib
 khQ
@@ -33391,8 +33375,8 @@ ylG
 ylG
 ylG
 ylG
-nfu
-nfu
+yib
+yib
 yib
 yib
 khQ
@@ -33693,9 +33677,9 @@ ylG
 ylG
 ylG
 ylG
-nfu
-nfu
-nfu
+yib
+yib
+yib
 yib
 khQ
 khQ
@@ -33995,9 +33979,9 @@ xsE
 xsE
 ylG
 ylG
-nfu
-nfu
-nfu
+yib
+yib
+yib
 khQ
 khQ
 khQ
@@ -34297,8 +34281,8 @@ ybZ
 xsE
 ylG
 ylG
-nfu
-nfu
+yib
+yib
 khQ
 khQ
 khQ
@@ -34599,8 +34583,8 @@ ybZ
 xsE
 ylG
 ylG
-nfu
-nfu
+yib
+yib
 khQ
 khQ
 khQ
@@ -34901,8 +34885,8 @@ ybZ
 xsE
 ylG
 ylG
-nfu
-nfu
+yib
+yib
 khQ
 khQ
 khQ
@@ -35203,7 +35187,7 @@ ybZ
 xsE
 ylG
 ylG
-nfu
+yib
 khQ
 khQ
 khQ
@@ -36713,8 +36697,8 @@ ylG
 xsE
 ylG
 xsE
-ybZ
 ogP
+ybZ
 khQ
 khQ
 khQ
@@ -72281,7 +72265,7 @@ khQ
 khQ
 khQ
 pwP
-bbd
+cvg
 cxd
 brR
 gRs
@@ -72863,7 +72847,7 @@ ylG
 ylG
 ylG
 ylG
-nfu
+yib
 yib
 yib
 khQ
@@ -73163,9 +73147,9 @@ ylG
 ylG
 ylG
 ylG
-nfu
-nfu
-nfu
+yib
+yib
+yib
 yib
 yib
 khQ
@@ -73464,8 +73448,8 @@ ylG
 ylG
 ylG
 ylG
-nfu
-nfu
+yib
+yib
 yib
 yib
 yib
@@ -73766,8 +73750,8 @@ ylG
 ylG
 wtg
 wtg
-nfu
-nfu
+yib
+yib
 yib
 yib
 yib
@@ -74068,8 +74052,8 @@ ylG
 ylG
 wtg
 wtg
-nfu
-nfu
+yib
+yib
 yib
 yib
 yib
@@ -74975,8 +74959,8 @@ ylG
 wtg
 wtg
 wtg
-nfu
-nfu
+yib
+yib
 yib
 yib
 khQ
@@ -78553,7 +78537,7 @@ jIO
 mRK
 sUu
 sUu
-mBi
+pas
 mBi
 mBi
 sUu
@@ -85270,8 +85254,8 @@ axO
 bcT
 axO
 axO
-aKu
-aKu
+jas
+jas
 pwP
 xZD
 xZD
@@ -85572,8 +85556,8 @@ axO
 axO
 kWw
 axO
-aKu
-bHY
+jas
+olh
 pwP
 yic
 xZD
@@ -86188,7 +86172,7 @@ ykT
 ykT
 xZD
 mxp
-cay
+bHY
 axO
 axO
 axO
@@ -86490,7 +86474,7 @@ ykT
 ykT
 xZD
 bSX
-cay
+bHY
 axO
 axO
 axO
@@ -87672,7 +87656,7 @@ khQ
 khQ
 khQ
 hiq
-bme
+hiq
 hiq
 hiq
 hiq
@@ -88577,7 +88561,7 @@ khQ
 khQ
 khQ
 khQ
-bme
+hiq
 adG
 ahE
 coc
@@ -88825,7 +88809,7 @@ ylG
 ylG
 ylG
 ylG
-sCy
+ylG
 ylG
 ylG
 ylG
@@ -88879,10 +88863,10 @@ khQ
 khQ
 khQ
 khQ
-bme
-bme
 hiq
-bme
+hiq
+hiq
+hiq
 aim
 amq
 apw
@@ -89185,7 +89169,7 @@ khQ
 jIO
 aeX
 wSc
-wSc
+azh
 akY
 wSc
 mxp
@@ -89787,7 +89771,7 @@ khQ
 khQ
 khQ
 jIO
-mCu
+bbd
 wSc
 aiu
 wSc
@@ -90391,7 +90375,7 @@ khQ
 khQ
 khQ
 jIO
-ybx
+wSc
 wSc
 aju
 amq
@@ -91598,10 +91582,10 @@ khQ
 khQ
 aaD
 xmo
-kaz
 xmo
 xmo
-kaz
+xmo
+xmo
 xmo
 khQ
 khQ
@@ -92204,7 +92188,7 @@ khQ
 aaD
 xmo
 xmo
-kaz
+xmo
 xmo
 xmo
 aaD
@@ -93125,7 +93109,7 @@ khQ
 khQ
 hiq
 hiq
-bme
+hiq
 hiq
 hiq
 bON
@@ -94333,8 +94317,8 @@ khQ
 khQ
 hiq
 hiq
-bme
-bme
+hiq
+hiq
 hiq
 jIO
 jIO

--- a/_maps/map_files/Mammoth/Mammoth_above.dmm
+++ b/_maps/map_files/Mammoth/Mammoth_above.dmm
@@ -5840,6 +5840,9 @@
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /turf/closed/wall/ms13/scrap/white,
 /area/ms13/town)
+"tU" = (
+/turf/closed/wall/ms13/brick,
+/area/ms13/town)
 "tW" = (
 /obj/item/chair/ms13/metal/unfinished,
 /turf/open/floor/wood/ms13/common,
@@ -10570,7 +10573,7 @@
 /turf/open/floor/ms13/metal,
 /area/ms13/town)
 "KV" = (
-/obj/structure/railing/ms13/solo,
+/obj/structure/railing/ms13/sewer,
 /turf/open/floor/plating/ms13/ground/snow,
 /area/ms13)
 "KW" = (
@@ -12002,10 +12005,10 @@
 /turf/open/floor/wood/ms13/common,
 /area/ms13/town)
 "PN" = (
-/obj/structure/railing/ms13/solo{
-	dir = 4
+/obj/structure/railing/ms13/sewer{
+	dir = 8
 	},
-/turf/open/floor/ms13/concrete,
+/turf/open/floor/plating/ms13/ground/snow,
 /area/ms13)
 "PO" = (
 /obj/structure/ms13/foundation/common/variantone{
@@ -12769,8 +12772,10 @@
 /turf/open/floor/ms13/tile/large/white,
 /area/ms13/town)
 "Sw" = (
-/obj/structure/railing/ms13/solo,
-/turf/open/floor/ms13/concrete,
+/obj/structure/railing/ms13/sewer{
+	dir = 1
+	},
+/turf/open/floor/plating/ms13/ground/snow,
 /area/ms13)
 "Sx" = (
 /obj/machinery/door/unpowered/ms13/metal{
@@ -81723,7 +81728,7 @@ AP
 AP
 AP
 AP
-gS
+Am
 LG
 bJ
 bJ
@@ -82025,7 +82030,7 @@ HL
 ND
 AP
 AP
-Vj
+tU
 bJ
 SB
 SB
@@ -85040,8 +85045,8 @@ KV
 YW
 YW
 YW
+YW
 Sw
-vR
 vR
 vR
 vR
@@ -85339,10 +85344,10 @@ vR
 vR
 vR
 KV
-PN
-PN
-PN
-PN
+YW
+YW
+YW
+YW
 vR
 vR
 vR
@@ -85641,10 +85646,10 @@ PY
 PY
 vR
 vR
-vR
-vR
-vR
-vR
+PN
+PN
+PN
+PN
 vR
 vR
 vR

--- a/_maps/map_files/Mammoth/Mammoth_above.dmm
+++ b/_maps/map_files/Mammoth/Mammoth_above.dmm
@@ -9541,10 +9541,6 @@
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /turf/open/floor/wood/ms13/common,
 /area/ms13/town)
-"Hu" = (
-/obj/structure/flora/rock/pile,
-/turf/open/floor/plating/ms13/ground/mountain,
-/area/ms13/underground/mountain)
 "Hv" = (
 /obj/structure/table/ms13/wood,
 /obj/item/storage/fancy/cigarettes/cigars{
@@ -11825,11 +11821,6 @@
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /turf/open/floor/wood/ms13/common,
 /area/ms13/town)
-"Pj" = (
-/obj/structure/flora/rock/pile,
-/obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/mountain,
-/turf/open/floor/plating/ms13/ground/mountain,
-/area/ms13/underground/tunnel/maintenance)
 "Pk" = (
 /obj/structure/table/ms13/metal,
 /obj/item/folder/yellow{
@@ -63389,7 +63380,7 @@ NN
 NN
 wr
 wr
-Pj
+wr
 wr
 rH
 PY
@@ -70308,7 +70299,7 @@ PY
 rH
 aA
 jq
-Pj
+wr
 jq
 SJ
 jq
@@ -70615,7 +70606,7 @@ jq
 jq
 jq
 jq
-Pj
+wr
 aA
 rH
 rH
@@ -71804,7 +71795,7 @@ zq
 Zh
 zq
 zq
-Hu
+zq
 PY
 PY
 PY
@@ -72404,7 +72395,7 @@ PY
 PY
 PY
 PY
-Hu
+zq
 zq
 zq
 zq
@@ -73314,7 +73305,7 @@ PY
 zq
 zq
 zq
-Hu
+zq
 PY
 PY
 PY
@@ -73914,7 +73905,7 @@ PY
 PY
 PY
 zq
-Hu
+zq
 zq
 zq
 zq

--- a/_maps/map_files/Mammoth/Mammoth_above.dmm
+++ b/_maps/map_files/Mammoth/Mammoth_above.dmm
@@ -445,13 +445,6 @@
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /turf/open/floor/wood/ms13/carpet/shaggy/green,
 /area/ms13/town)
-"bB" = (
-/obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
-/obj/machinery/door/unpowered/ms13/seethrough/metal{
-	dir = 4
-	},
-/turf/open/floor/wood/ms13/common,
-/area/ms13/town)
 "bC" = (
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /obj/machinery/light/ms13{
@@ -2413,12 +2406,6 @@
 	dir = 1
 	},
 /area/ms13/town)
-"iq" = (
-/obj/structure/railing/ms13/sewer{
-	dir = 4
-	},
-/turf/open/floor/plating/ms13/roof,
-/area/ms13)
 "ir" = (
 /obj/structure/table/ms13/metal,
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/mountain,
@@ -4616,9 +4603,6 @@
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
-"pH" = (
-/turf/open/openspace/ms13,
-/area/ms13/underground/mountain)
 "pI" = (
 /obj/structure/railing/ms13/solo,
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/mountain,
@@ -5103,14 +5087,7 @@
 /area/ms13/underground/vault_atrium_upper)
 "ru" = (
 /obj/structure/barricade/sandbags,
-/obj/structure/railing/ms13/sewer{
-	dir = 8
-	},
 /turf/open/floor/wood/ms13/common,
-/area/ms13)
-"rv" = (
-/obj/structure/lattice/catwalk,
-/turf/open/floor/plating/ms13/roof/metal,
 /area/ms13)
 "rw" = (
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
@@ -5864,12 +5841,6 @@
 	},
 /turf/open/openspace/ms13,
 /area/ms13/town)
-"ub" = (
-/obj/structure/railing/ms13/sewer{
-	dir = 1
-	},
-/turf/open/openspace/ms13,
-/area/ms13)
 "uc" = (
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /obj/effect/spawner/random/ms13/clothing/shoe,
@@ -6178,12 +6149,6 @@
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /turf/open/floor/wood/ms13/carpet/shaggy,
 /area/ms13/town)
-"vl" = (
-/obj/structure/railing/ms13/sewer{
-	dir = 8
-	},
-/turf/open/floor/wood/ms13/common,
-/area/ms13)
 "vm" = (
 /obj/structure/ms13/storage/trashcan,
 /turf/open/floor/wood/ms13/common,
@@ -7733,13 +7698,6 @@
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /turf/open/openspace/ms13,
 /area/ms13/town)
-"AZ" = (
-/obj/structure/barricade/sandbags,
-/obj/structure/railing/ms13/sewer{
-	dir = 8
-	},
-/turf/open/floor/plating/ms13/roof,
-/area/ms13)
 "Ba" = (
 /obj/structure/bed/ms13/bedframe/metal,
 /obj/structure/bed/ms13/mattress/dirty,
@@ -9283,12 +9241,6 @@
 	},
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/ncr)
-"GB" = (
-/obj/structure/railing/ms13/sewer{
-	dir = 8
-	},
-/turf/open/floor/plating/ms13/roof,
-/area/ms13)
 "GD" = (
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /obj/structure/fluff/paper/stack{
@@ -10572,10 +10524,6 @@
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /turf/open/floor/ms13/metal,
 /area/ms13/town)
-"KV" = (
-/obj/structure/railing/ms13/sewer,
-/turf/open/floor/plating/ms13/ground/snow,
-/area/ms13)
 "KW" = (
 /obj/structure/chair/ms13/metal/unfinished{
 	dir = 4
@@ -11248,7 +11196,6 @@
 /turf/open/floor/ms13/metal,
 /area/ms13/town)
 "Nj" = (
-/obj/item/trash/can/food/beans,
 /obj/machinery/light/ms13{
 	dir = 8
 	},
@@ -12004,12 +11951,6 @@
 /obj/machinery/door/unpowered/ms13/metal/mirrored,
 /turf/open/floor/wood/ms13/common,
 /area/ms13/town)
-"PN" = (
-/obj/structure/railing/ms13/sewer{
-	dir = 8
-	},
-/turf/open/floor/plating/ms13/ground/snow,
-/area/ms13)
 "PO" = (
 /obj/structure/ms13/foundation/common/variantone{
 	dir = 1
@@ -12771,12 +12712,6 @@
 	},
 /turf/open/floor/ms13/tile/large/white,
 /area/ms13/town)
-"Sw" = (
-/obj/structure/railing/ms13/sewer{
-	dir = 1
-	},
-/turf/open/floor/plating/ms13/ground/snow,
-/area/ms13)
 "Sx" = (
 /obj/machinery/door/unpowered/ms13/metal{
 	dir = 8
@@ -14691,9 +14626,6 @@
 /obj/structure/ms13/storage/trashcan,
 /turf/open/floor/ms13/concrete,
 /area/ms13/supermarket)
-"YW" = (
-/turf/open/floor/ms13/concrete,
-/area/ms13)
 "YZ" = (
 /obj/structure/fence/fencenormal,
 /turf/open/floor/plating/ms13/roof,
@@ -24033,7 +23965,7 @@ PY
 PY
 LH
 LH
-Ir
+LH
 Ir
 Ir
 Ir
@@ -24335,7 +24267,7 @@ PY
 PY
 LH
 LH
-Ir
+LH
 Ir
 Ir
 Ir
@@ -24637,7 +24569,7 @@ PY
 PY
 PY
 LH
-Ir
+LH
 Ir
 Ir
 Ir
@@ -24939,7 +24871,7 @@ PY
 PY
 PY
 LH
-Ir
+LH
 Ir
 Ir
 Ir
@@ -25241,7 +25173,7 @@ PY
 PY
 PY
 LH
-Ir
+LH
 Ir
 Ir
 Ir
@@ -70844,17 +70776,17 @@ PY
 PY
 PY
 PY
-vl
-vl
-vl
-vl
-vl
+Ho
+Ho
+Ho
+Ho
+Ho
 rm
 ru
 ru
-vl
-vl
-vl
+Ho
+Ho
+Ho
 rm
 LH
 LH
@@ -70869,14 +70801,14 @@ rm
 ru
 ru
 ru
-vl
-vl
+Ho
+Ho
 rm
-vl
-vl
-vl
-vl
-vl
+Ho
+Ho
+Ho
+Ho
+Ho
 PY
 PY
 PY
@@ -71474,8 +71406,8 @@ Ho
 Ho
 Ho
 Ho
-QL
-QL
+Ho
+Ho
 Ho
 Ho
 Ho
@@ -71776,8 +71708,8 @@ Ho
 Ho
 Ho
 LH
-QY
-QY
+LH
+LH
 LH
 LH
 LH
@@ -72078,14 +72010,14 @@ LH
 LH
 LH
 LH
-QY
-QY
 LH
 LH
 LH
 LH
 LH
-pH
+LH
+LH
+LH
 PY
 PY
 PY
@@ -72380,8 +72312,8 @@ LH
 LH
 LH
 bJ
-Bc
-Bc
+bJ
+bJ
 bJ
 bJ
 bJ
@@ -76000,8 +75932,8 @@ LH
 LH
 bJ
 bJ
-Bc
-Bc
+bJ
+bJ
 bJ
 bJ
 bJ
@@ -76302,8 +76234,8 @@ LH
 LH
 LH
 LH
-QY
-QY
+LH
+LH
 LH
 LH
 LH
@@ -76604,8 +76536,8 @@ LH
 LH
 LH
 LH
-QY
-QY
+LH
+LH
 LH
 LH
 LH
@@ -76906,8 +76838,8 @@ LH
 LH
 Wg
 Wg
-rv
-rv
+Wg
+Wg
 Wg
 Wg
 Wg
@@ -79935,7 +79867,7 @@ Wg
 LH
 LH
 LH
-PY
+LH
 PY
 PY
 PY
@@ -80228,8 +80160,8 @@ LH
 LH
 Wg
 Wg
-rv
-rv
+Wg
+Wg
 Wg
 Wg
 Wg
@@ -80521,7 +80453,6 @@ He
 XI
 bJ
 bJ
-ub
 LH
 LH
 LH
@@ -80530,8 +80461,9 @@ LH
 LH
 LH
 LH
-QY
-QY
+LH
+LH
+LH
 LH
 LH
 LH
@@ -80823,17 +80755,17 @@ He
 XI
 bJ
 bJ
-GB
-AZ
-AZ
-AZ
-AZ
-AZ
-GB
-ub
+bJ
+SO
+SO
+SO
+SO
+SO
+bJ
 LH
-QY
-QY
+LH
+LH
+LH
 LH
 LH
 LH
@@ -81132,10 +81064,10 @@ tm
 GE
 SO
 bJ
-ub
+LH
 np
-BH
-BH
+np
+np
 np
 np
 np
@@ -82038,7 +81970,7 @@ tl
 SB
 SB
 bJ
-ub
+LH
 np
 np
 np
@@ -82340,7 +82272,7 @@ bo
 px
 SB
 bJ
-ub
+LH
 np
 np
 np
@@ -82642,7 +82574,7 @@ bo
 px
 SB
 bJ
-ub
+LH
 np
 np
 np
@@ -82944,7 +82876,7 @@ bo
 mo
 SB
 bJ
-ub
+LH
 np
 np
 np
@@ -83246,7 +83178,7 @@ ns
 px
 SB
 bJ
-ub
+LH
 LH
 LH
 LH
@@ -83547,8 +83479,8 @@ SB
 SB
 SB
 SB
-iq
-ub
+bJ
+LH
 LH
 LH
 LH
@@ -83844,7 +83776,7 @@ AP
 uf
 Vj
 Al
-ub
+LH
 LH
 LH
 LH
@@ -84146,7 +84078,7 @@ AP
 AP
 Vj
 QY
-ub
+LH
 LH
 LH
 LH
@@ -84448,7 +84380,7 @@ Pi
 To
 XI
 QY
-ub
+LH
 LH
 LH
 LH
@@ -84741,8 +84673,8 @@ XI
 XI
 XI
 XI
-bB
-bB
+XI
+XI
 XI
 XI
 XI
@@ -85041,12 +84973,12 @@ vR
 vR
 vR
 vR
-KV
-YW
-YW
-YW
-YW
-Sw
+vR
+vR
+vR
+vR
+vR
+vR
 vR
 vR
 vR
@@ -85343,11 +85275,11 @@ vR
 vR
 vR
 vR
-KV
-YW
-YW
-YW
-YW
+vR
+vR
+vR
+vR
+vR
 vR
 vR
 vR
@@ -85646,10 +85578,10 @@ PY
 PY
 vR
 vR
-PN
-PN
-PN
-PN
+vR
+vR
+vR
+vR
 vR
 vR
 vR

--- a/_maps/map_files/Mammoth/Mammoth_above.dmm
+++ b/_maps/map_files/Mammoth/Mammoth_above.dmm
@@ -445,6 +445,13 @@
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /turf/open/floor/wood/ms13/carpet/shaggy/green,
 /area/ms13/town)
+"bB" = (
+/obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
+/obj/machinery/door/unpowered/ms13/seethrough/metal{
+	dir = 4
+	},
+/turf/open/floor/wood/ms13/common,
+/area/ms13/town)
 "bC" = (
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /obj/machinery/light/ms13{
@@ -1913,13 +1920,6 @@
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
-"gM" = (
-/obj/structure/barricade/sandbags,
-/obj/structure/railing/ms13/solo{
-	dir = 8
-	},
-/turf/open/floor/wood/ms13/common,
-/area/ms13)
 "gN" = (
 /obj/item/stack/cable_coil/five,
 /obj/effect/spawner/random/ms13/tools/hardware,
@@ -2414,7 +2414,7 @@
 	},
 /area/ms13/town)
 "iq" = (
-/obj/structure/railing/ms13/solo{
+/obj/structure/railing/ms13/sewer{
 	dir = 4
 	},
 /turf/open/floor/plating/ms13/roof,
@@ -5102,10 +5102,10 @@
 /turf/open/floor/wood/ms13/mosaic,
 /area/ms13/underground/vault_atrium_upper)
 "ru" = (
-/obj/structure/railing/ms13/solo{
+/obj/structure/barricade/sandbags,
+/obj/structure/railing/ms13/sewer{
 	dir = 8
 	},
-/obj/structure/barricade/sandbags,
 /turf/open/floor/wood/ms13/common,
 /area/ms13)
 "rv" = (
@@ -5862,7 +5862,7 @@
 /turf/open/openspace/ms13,
 /area/ms13/town)
 "ub" = (
-/obj/structure/railing/ms13/solo{
+/obj/structure/railing/ms13/sewer{
 	dir = 1
 	},
 /turf/open/openspace/ms13,
@@ -6176,12 +6176,11 @@
 /turf/open/floor/wood/ms13/carpet/shaggy,
 /area/ms13/town)
 "vl" = (
-/obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
-/obj/structure/filingcabinet/ms13{
-	dir = 4
+/obj/structure/railing/ms13/sewer{
+	dir = 8
 	},
-/turf/open/floor/ms13/metal,
-/area/ms13/town)
+/turf/open/floor/wood/ms13/common,
+/area/ms13)
 "vm" = (
 /obj/structure/ms13/storage/trashcan,
 /turf/open/floor/wood/ms13/common,
@@ -7733,7 +7732,7 @@
 /area/ms13/town)
 "AZ" = (
 /obj/structure/barricade/sandbags,
-/obj/structure/railing/ms13/solo{
+/obj/structure/railing/ms13/sewer{
 	dir = 8
 	},
 /turf/open/floor/plating/ms13/roof,
@@ -8258,6 +8257,13 @@
 	},
 /turf/open/floor/iron/stairs/medium,
 /area/ms13/underground/vault_atrium_upper)
+"CW" = (
+/obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
+/obj/structure/filingcabinet/ms13{
+	dir = 4
+	},
+/turf/open/floor/ms13/metal,
+/area/ms13/town)
 "CY" = (
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /obj/structure/table/ms13/no_smooth/large/metal/desk/alt,
@@ -9275,7 +9281,7 @@
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/ncr)
 "GB" = (
-/obj/structure/railing/ms13/solo{
+/obj/structure/railing/ms13/sewer{
 	dir = 8
 	},
 /turf/open/floor/plating/ms13/roof,
@@ -10737,6 +10743,11 @@
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /turf/open/floor/ms13/metal,
 /area/ms13/town)
+"LB" = (
+/obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
+/obj/structure/fence/fencenormal,
+/turf/open/floor/ms13/metal,
+/area/ms13/town)
 "LC" = (
 /obj/effect/landmark/start/ms13/sergeant,
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
@@ -12185,6 +12196,13 @@
 /obj/structure/weightmachine/weightlifter,
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /turf/open/floor/wood/ms13/wide,
+/area/ms13/town)
+"Qz" = (
+/obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
+/obj/machinery/door/unpowered/ms13/metal{
+	dir = 1
+	},
+/turf/open/floor/ms13/tile,
 /area/ms13/town)
 "QA" = (
 /obj/effect/turf_decal/stripes/line{
@@ -70821,17 +70839,17 @@ PY
 PY
 PY
 PY
-pK
-pK
-pK
-pK
-pK
+vl
+vl
+vl
+vl
+vl
 rm
 ru
 ru
-pK
-pK
-pK
+vl
+vl
+vl
 rm
 LH
 LH
@@ -70843,17 +70861,17 @@ LH
 LH
 LH
 rm
-gM
-gM
-gM
-pK
-pK
+ru
+ru
+ru
+vl
+vl
 rm
-pK
-pK
-pK
-pK
-pK
+vl
+vl
+vl
+vl
+vl
 PY
 PY
 PY
@@ -78071,14 +78089,14 @@ bJ
 XI
 CD
 AP
-Ix
+Qz
 Kc
 XI
 AP
 AP
 XI
 qf
-Ix
+XG
 AP
 AP
 XI
@@ -78675,14 +78693,14 @@ bJ
 XI
 GM
 AP
-Ix
+Qz
 Kc
 XI
 AP
 AP
 XI
 qf
-Ix
+XG
 AP
 wQ
 XI
@@ -81748,11 +81766,11 @@ LH
 LH
 LH
 Cj
-He
-He
-He
-He
-FW
+Cj
+Cj
+Cj
+Cj
+ax
 AP
 AP
 JJ
@@ -82050,10 +82068,10 @@ LH
 LH
 Cj
 Cj
-Cj
-Cj
-Cj
-Cj
+CW
+CW
+LB
+qP
 Cj
 Fa
 Cj
@@ -82353,9 +82371,9 @@ LH
 Cj
 wV
 KT
-vl
+gA
 Jf
-ZJ
+AP
 AP
 AP
 Cj
@@ -82608,7 +82626,7 @@ AP
 AP
 XI
 ks
-Ix
+XG
 AP
 oH
 XI
@@ -83212,7 +83230,7 @@ AP
 AP
 XI
 ks
-Ix
+XG
 AP
 AP
 XI
@@ -84718,8 +84736,8 @@ XI
 XI
 XI
 XI
-lo
-lo
+bB
+bB
 XI
 XI
 XI
@@ -85369,10 +85387,10 @@ LH
 LH
 LH
 LH
-LH
-LH
-LH
-LH
+Ir
+Ir
+Ir
+Ir
 LH
 LH
 LH
@@ -85671,10 +85689,10 @@ LH
 LH
 LH
 LH
-LH
-LH
-LH
-LH
+Ir
+Ir
+Ir
+Ir
 LH
 LH
 LH
@@ -85973,10 +85991,10 @@ LH
 LH
 LH
 LH
-LH
-LH
-LH
-LH
+Ir
+Ir
+Ir
+Ir
 LH
 LH
 LH
@@ -86274,11 +86292,11 @@ RK
 RK
 RK
 RK
-PY
 LH
-LH
-LH
-LH
+Ir
+Ir
+Ir
+Ir
 LH
 LH
 LH
@@ -86576,9 +86594,9 @@ PY
 PY
 PY
 RK
-PY
-PY
-PY
+LH
+LH
+LH
 LH
 LH
 LH
@@ -86881,7 +86899,7 @@ PY
 PY
 PY
 PY
-PY
+LH
 LH
 LH
 LH

--- a/_maps/map_files/Mammoth/Mammoth_above.dmm
+++ b/_maps/map_files/Mammoth/Mammoth_above.dmm
@@ -49,7 +49,7 @@
 /area/ms13/town)
 "ah" = (
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
-/obj/structure/closet/crate/bin,
+/obj/structure/ms13/storage/trashcan,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/supermarket)
 "aj" = (
@@ -1913,6 +1913,13 @@
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
+"gM" = (
+/obj/structure/barricade/sandbags,
+/obj/structure/railing/ms13/solo{
+	dir = 8
+	},
+/turf/open/floor/wood/ms13/common,
+/area/ms13)
 "gN" = (
 /obj/item/stack/cable_coil/five,
 /obj/effect/spawner/random/ms13/tools/hardware,
@@ -2406,6 +2413,12 @@
 	dir = 1
 	},
 /area/ms13/town)
+"iq" = (
+/obj/structure/railing/ms13/solo{
+	dir = 4
+	},
+/turf/open/floor/plating/ms13/roof,
+/area/ms13)
 "ir" = (
 /obj/structure/table/ms13/metal,
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/mountain,
@@ -2646,11 +2659,6 @@
 	},
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/ncr)
-"jd" = (
-/obj/structure/closet/crate/bin,
-/obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
-/turf/open/floor/wood/ms13/common,
-/area/ms13/town)
 "je" = (
 /obj/structure/closet/crate/ms13/vault_tec/long,
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/mountain,
@@ -5029,8 +5037,8 @@
 /turf/open/floor/wood/ms13/common,
 /area/ms13/town)
 "ri" = (
-/obj/structure/closet/crate/bin,
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
+/obj/structure/ms13/storage/trashcan,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "rj" = (
@@ -5094,11 +5102,15 @@
 /turf/open/floor/wood/ms13/mosaic,
 /area/ms13/underground/vault_atrium_upper)
 "ru" = (
-/obj/structure/railing/ms13/solo,
 /obj/structure/railing/ms13/solo{
-	dir = 4
+	dir = 8
 	},
-/turf/open/floor/ms13/concrete,
+/obj/structure/barricade/sandbags,
+/turf/open/floor/wood/ms13/common,
+/area/ms13)
+"rv" = (
+/obj/structure/lattice/catwalk,
+/turf/open/floor/plating/ms13/roof/metal,
 /area/ms13)
 "rw" = (
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
@@ -5529,10 +5541,10 @@
 /turf/open/floor/wood/ms13/common,
 /area/ms13/town)
 "sS" = (
-/obj/structure/closet/crate/bin,
 /obj/structure/railing/ms13/solo{
 	dir = 8
 	},
+/obj/structure/ms13/storage/trashcan,
 /turf/open/floor/wood/ms13/common,
 /area/ms13)
 "sT" = (
@@ -5849,6 +5861,12 @@
 	},
 /turf/open/openspace/ms13,
 /area/ms13/town)
+"ub" = (
+/obj/structure/railing/ms13/solo{
+	dir = 1
+	},
+/turf/open/openspace/ms13,
+/area/ms13)
 "uc" = (
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /obj/effect/spawner/random/ms13/clothing/shoe,
@@ -5971,14 +5989,6 @@
 	dir = 4
 	},
 /turf/open/openspace/ms13,
-/area/ms13/town)
-"uC" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/closet/crate/bin,
-/obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
-/turf/open/floor/wood/ms13/common,
 /area/ms13/town)
 "uD" = (
 /obj/structure/ms13/storage/bookshelf{
@@ -6173,7 +6183,7 @@
 /turf/open/floor/ms13/metal,
 /area/ms13/town)
 "vm" = (
-/obj/structure/closet/crate/bin,
+/obj/structure/ms13/storage/trashcan,
 /turf/open/floor/wood/ms13/common,
 /area/ms13/town)
 "vo" = (
@@ -6852,6 +6862,12 @@
 	dir = 4
 	},
 /area/ms13/underground/tunnel)
+"xP" = (
+/obj/structure/chair/ms13/metal/broken{
+	dir = 8
+	},
+/turf/open/floor/wood/ms13/common,
+/area/ms13)
 "xQ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -7374,11 +7390,6 @@
 	},
 /turf/open/floor/wood/ms13/common,
 /area/ms13/town)
-"zJ" = (
-/obj/structure/closet/crate/bin,
-/obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
-/turf/open/floor/wood/ms13/mosaic,
-/area/ms13/town)
 "zK" = (
 /obj/structure/window/reinforced,
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
@@ -7520,11 +7531,8 @@
 /turf/open/openspace/ms13,
 /area/ms13/town)
 "Al" = (
-/obj/structure/lattice/catwalk,
 /obj/structure/ladder/ms13,
-/obj/structure/railing{
-	dir = 6
-	},
+/obj/structure/lattice/catwalk,
 /turf/open/openspace/ms13,
 /area/ms13)
 "Am" = (
@@ -7723,6 +7731,13 @@
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /turf/open/openspace/ms13,
 /area/ms13/town)
+"AZ" = (
+/obj/structure/barricade/sandbags,
+/obj/structure/railing/ms13/solo{
+	dir = 8
+	},
+/turf/open/floor/plating/ms13/roof,
+/area/ms13)
 "Ba" = (
 /obj/structure/bed/ms13/bedframe/metal,
 /obj/structure/bed/ms13/mattress/dirty,
@@ -8438,7 +8453,6 @@
 /turf/open/floor/wood/ms13/wide,
 /area/ms13)
 "DL" = (
-/obj/structure/closet/crate/bin,
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /obj/structure/railing/ms13/solo/industrial{
 	dir = 8
@@ -9260,6 +9274,12 @@
 	},
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/ncr)
+"GB" = (
+/obj/structure/railing/ms13/solo{
+	dir = 8
+	},
+/turf/open/floor/plating/ms13/roof,
+/area/ms13)
 "GD" = (
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /obj/structure/fluff/paper/stack{
@@ -11038,7 +11058,7 @@
 /area/ms13/town)
 "MD" = (
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
-/obj/structure/closet/crate/bin,
+/obj/structure/ms13/storage/trashcan,
 /turf/open/floor/ms13/tile/brown,
 /area/ms13/town)
 "ME" = (
@@ -12232,10 +12252,9 @@
 /turf/open/floor/ms13/concrete,
 /area/ms13/underground/tunnel/maintenance)
 "QL" = (
-/obj/structure/table/ms13/low_wall/brick,
-/obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
+/obj/structure/lattice/catwalk,
 /turf/open/floor/wood/ms13/common,
-/area/ms13/town)
+/area/ms13)
 "QM" = (
 /obj/effect/decal/cleanable/blood/gibs,
 /obj/effect/decal/cleanable/blood,
@@ -12823,7 +12842,7 @@
 /area/ms13/underground/tunnel/maintenance)
 "SL" = (
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
-/obj/structure/closet/crate/bin,
+/obj/structure/ms13/storage/trashcan,
 /turf/open/floor/wood/ms13/mosaic,
 /area/ms13/town)
 "SM" = (
@@ -13179,7 +13198,7 @@
 /area/ms13/ncr)
 "Ub" = (
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
-/obj/structure/closet/crate/bin,
+/obj/structure/ms13/storage/trashcan,
 /turf/open/floor/wood/ms13/mosaic,
 /area/ms13/supermarket)
 "Uc" = (
@@ -14008,7 +14027,7 @@
 /area/ms13/supermarket)
 "WO" = (
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
-/obj/structure/closet/crate/bin,
+/obj/structure/ms13/storage/trashcan,
 /turf/open/floor/wood/ms13/common,
 /area/ms13/town)
 "WP" = (
@@ -14654,8 +14673,8 @@
 /turf/open/floor/wood/ms13/common,
 /area/ms13/town)
 "YV" = (
-/obj/structure/closet/crate/bin,
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
+/obj/structure/ms13/storage/trashcan,
 /turf/open/floor/ms13/concrete,
 /area/ms13/supermarket)
 "YW" = (
@@ -47965,7 +47984,7 @@ DG
 DG
 DG
 hd
-zJ
+SL
 YA
 YA
 LH
@@ -49770,7 +49789,7 @@ bJ
 bJ
 bJ
 YA
-zJ
+SL
 Fs
 bN
 no
@@ -58978,7 +58997,7 @@ AP
 AP
 qX
 Cj
-jd
+WO
 yi
 yi
 GK
@@ -62271,7 +62290,7 @@ Cj
 Cj
 Cj
 AP
-uC
+WO
 eH
 as
 AP
@@ -70811,17 +70830,17 @@ PY
 PY
 PY
 PY
-Ho
-Ho
-Ho
-Ho
-Ho
+pK
+pK
+pK
+pK
+pK
 rm
-Ho
-Ho
-Ho
-Ho
-Ho
+ru
+ru
+pK
+pK
+pK
 rm
 LH
 LH
@@ -70833,17 +70852,17 @@ LH
 LH
 LH
 rm
-Ho
-Ho
-Ho
-Ho
-Ho
+gM
+gM
+gM
+pK
+pK
 rm
-Ho
-Ho
-Ho
-Ho
-Ho
+pK
+pK
+pK
+pK
+pK
 PY
 PY
 PY
@@ -71125,17 +71144,17 @@ Ho
 Ho
 Ho
 Ho
+QL
+QY
+QY
+QY
+QY
+QY
+QY
+QY
+QL
 Ho
-LH
-LH
-LH
-LH
-LH
-LH
-LH
-Ho
-Ho
-Ho
+xP
 Ho
 Ho
 Ho
@@ -71427,22 +71446,22 @@ Ho
 Ho
 Ho
 Ho
-Ho
-LH
-LH
-LH
-LH
-LH
-LH
-LH
-Ho
-Ho
-Ho
+QL
+QY
+QY
+QY
+QY
+QY
+QY
+QY
+QL
 Ho
 Ho
 Ho
 Ho
 Ho
+QL
+QL
 Ho
 Ho
 Ho
@@ -71743,8 +71762,8 @@ Ho
 Ho
 Ho
 LH
-LH
-LH
+QY
+QY
 LH
 LH
 LH
@@ -72045,8 +72064,8 @@ LH
 LH
 LH
 LH
-LH
-LH
+QY
+QY
 LH
 LH
 LH
@@ -72347,8 +72366,8 @@ LH
 LH
 LH
 bJ
-bJ
-bJ
+Bc
+Bc
 bJ
 bJ
 bJ
@@ -72622,7 +72641,7 @@ PY
 PY
 PY
 PY
-PY
+bJ
 bJ
 bJ
 bJ
@@ -72924,7 +72943,7 @@ PY
 PY
 PY
 PY
-PY
+bJ
 bJ
 bJ
 bJ
@@ -73226,7 +73245,7 @@ PY
 PY
 PY
 PY
-PY
+bJ
 XI
 JB
 JB
@@ -73528,7 +73547,7 @@ PY
 PY
 PY
 PY
-PY
+bJ
 XI
 fL
 gA
@@ -73830,7 +73849,7 @@ PY
 PY
 PY
 PY
-PY
+bJ
 XI
 TY
 gA
@@ -74132,7 +74151,7 @@ PY
 PY
 PY
 PY
-PY
+bJ
 XI
 mR
 gA
@@ -74433,8 +74452,8 @@ PY
 PY
 PY
 PY
-PY
-PY
+bJ
+bJ
 XI
 XI
 XI
@@ -75967,8 +75986,8 @@ LH
 LH
 bJ
 bJ
-bJ
-bJ
+Bc
+Bc
 bJ
 bJ
 bJ
@@ -76269,8 +76288,8 @@ LH
 LH
 LH
 LH
-LH
-LH
+QY
+QY
 LH
 LH
 LH
@@ -76571,8 +76590,8 @@ LH
 LH
 LH
 LH
-LH
-LH
+QY
+QY
 LH
 LH
 LH
@@ -76873,8 +76892,8 @@ LH
 LH
 Wg
 Wg
-Wg
-Wg
+rv
+rv
 Wg
 Wg
 Wg
@@ -80195,8 +80214,8 @@ LH
 LH
 Wg
 Wg
-Wg
-Wg
+rv
+rv
 Wg
 Wg
 Wg
@@ -80488,6 +80507,7 @@ He
 XI
 bJ
 bJ
+ub
 LH
 LH
 LH
@@ -80496,9 +80516,8 @@ LH
 LH
 LH
 LH
-LH
-LH
-LH
+QY
+QY
 LH
 LH
 LH
@@ -80790,17 +80809,17 @@ He
 XI
 bJ
 bJ
-bJ
-SO
-SO
-SO
-SO
-SO
-bJ
+GB
+AZ
+AZ
+AZ
+AZ
+AZ
+GB
+ub
 LH
-LH
-LH
-LH
+QY
+QY
 LH
 LH
 LH
@@ -81093,16 +81112,16 @@ XI
 XI
 XI
 bJ
-SO
+bJ
 bJ
 tm
 GE
 SO
 bJ
-LH
+ub
 np
-np
-np
+BH
+BH
 np
 np
 np
@@ -81459,7 +81478,7 @@ cf
 AP
 JJ
 AP
-jd
+WO
 CP
 LH
 HX
@@ -81695,7 +81714,7 @@ AP
 AP
 AP
 AP
-QL
+gS
 LG
 bJ
 bJ
@@ -82005,7 +82024,7 @@ tl
 SB
 SB
 bJ
-LH
+ub
 np
 np
 np
@@ -82307,7 +82326,7 @@ bo
 px
 SB
 bJ
-LH
+ub
 np
 np
 np
@@ -82609,7 +82628,7 @@ bo
 px
 SB
 bJ
-LH
+ub
 np
 np
 np
@@ -82911,7 +82930,7 @@ bo
 mo
 SB
 bJ
-LH
+ub
 np
 np
 np
@@ -83213,7 +83232,7 @@ ns
 px
 SB
 bJ
-LH
+ub
 LH
 LH
 LH
@@ -83514,8 +83533,8 @@ SB
 SB
 SB
 SB
-bJ
-LH
+iq
+ub
 LH
 LH
 LH
@@ -83811,7 +83830,7 @@ AP
 uf
 Vj
 Al
-LH
+ub
 LH
 LH
 LH
@@ -84112,8 +84131,8 @@ AP
 AP
 AP
 Vj
-LH
-LH
+QY
+ub
 LH
 LH
 LH
@@ -84414,8 +84433,8 @@ AP
 Pi
 To
 XI
-LH
-LH
+QY
+ub
 LH
 LH
 LH
@@ -84708,8 +84727,8 @@ XI
 XI
 XI
 XI
-AP
-AP
+lo
+lo
 XI
 XI
 XI
@@ -85314,7 +85333,7 @@ KV
 PN
 PN
 PN
-ru
+PN
 vR
 vR
 vR

--- a/_maps/map_files/Mammoth/Mammoth_below.dmm
+++ b/_maps/map_files/Mammoth/Mammoth_below.dmm
@@ -3017,6 +3017,7 @@
 "lq" = (
 /obj/structure/closet,
 /obj/item/storage/box/bodybags,
+/obj/effect/spawner/random/ms13/medical/bloodbag,
 /turf/open/floor/ms13/metal,
 /area/ms13/underground/bos)
 "lr" = (

--- a/_maps/map_files/Mammoth/Mammoth_below.dmm
+++ b/_maps/map_files/Mammoth/Mammoth_below.dmm
@@ -214,6 +214,13 @@
 	},
 /turf/open/floor/plating/ms13/ground/mountain,
 /area/ms13/underground/underground_town)
+"aK" = (
+/obj/structure/lattice/catwalk/ms13,
+/obj/structure/railing/ms13/sewer{
+	dir = 8
+	},
+/turf/open/ms13/water/sewer/deep,
+/area/ms13/underground/mountain)
 "aL" = (
 /obj/structure/bed/ms13/mattress/stained,
 /turf/open/floor/plating/ms13/ground/mountain,
@@ -281,6 +288,13 @@
 /obj/structure/ms13/storage/vent,
 /turf/open/floor/ms13/metal,
 /area/ms13/underground/enclave_base)
+"ba" = (
+/obj/structure/lattice/catwalk/ms13,
+/obj/structure/railing/ms13/sewer{
+	dir = 4
+	},
+/turf/open/ms13/water/sewer/deep,
+/area/ms13/underground/mountain)
 "bb" = (
 /obj/structure/table/ms13/metal,
 /obj/effect/spawner/random/ms13/gun/lowrandom,
@@ -3066,6 +3080,13 @@
 	},
 /turf/open/floor/wood/ms13/carpet,
 /area/ms13/underground/enclave_base)
+"lB" = (
+/obj/structure/lattice/catwalk/ms13,
+/obj/structure/railing/ms13/sewer{
+	dir = 8
+	},
+/turf/open/ms13/water/sewer/medium,
+/area/ms13/underground/mountain)
 "lC" = (
 /obj/effect/spawner/random/ms13/armor/tier1,
 /obj/machinery/light/ms13/bulb/broken{
@@ -5507,6 +5528,9 @@
 /area/ms13/underground/sewer)
 "uu" = (
 /obj/structure/lattice/catwalk/ms13,
+/obj/structure/railing/ms13/sewer{
+	dir = 8
+	},
 /turf/open/ms13/water/sewer/shallow,
 /area/ms13/underground/mountain)
 "uv" = (
@@ -5962,6 +5986,9 @@
 /area/ms13/underground/mountain)
 "wg" = (
 /obj/structure/lattice/catwalk/ms13,
+/obj/structure/railing/ms13/sewer{
+	dir = 4
+	},
 /turf/open/ms13/water/sewer/medium,
 /area/ms13/underground/mountain)
 "wh" = (
@@ -6179,6 +6206,16 @@
 /obj/machinery/door/unpowered/ms13/seethrough/grate,
 /turf/open/floor/ms13/metal/plate,
 /area/ms13/underground/sewer)
+"xa" = (
+/obj/structure/lattice/catwalk/ms13,
+/obj/structure/railing/ms13/sewer{
+	dir = 4
+	},
+/obj/structure/railing/ms13/sewer{
+	dir = 1
+	},
+/turf/open/ms13/water/sewer/deep,
+/area/ms13/underground/mountain)
 "xb" = (
 /obj/machinery/light/ms13,
 /turf/open/floor/ms13/metal/pipe,
@@ -11469,6 +11506,9 @@
 /obj/structure/disposalpipe/broken{
 	dir = 8
 	},
+/obj/structure/railing/ms13/sewer{
+	dir = 1
+	},
 /turf/open/ms13/water/sewer/deep,
 /area/ms13/underground/mountain)
 "QX" = (
@@ -13813,6 +13853,13 @@
 "ZO" = (
 /obj/structure/rustic_extractor,
 /turf/open/floor/plating/ms13/ground/mountain,
+/area/ms13/underground/mountain)
+"ZP" = (
+/obj/structure/lattice/catwalk/ms13,
+/obj/structure/railing/ms13/sewer{
+	dir = 4
+	},
+/turf/open/ms13/water/sewer/shallow,
 /area/ms13/underground/mountain)
 "ZQ" = (
 /obj/machinery/power/port_gen/pacman{
@@ -44794,7 +44841,7 @@ AQ
 YO
 YO
 ZW
-pq
+bd
 pq
 pq
 pq
@@ -78636,8 +78683,8 @@ pq
 QV
 xq
 wl
-xq
-wg
+aK
+lB
 uu
 uu
 EM
@@ -78935,13 +78982,13 @@ lU
 fU
 fU
 pq
-xq
-xq
+xa
+ba
 wg
 wg
 wg
-uu
-uu
+ZP
+ZP
 EM
 rb
 kx

--- a/_maps/map_files/Mammoth/Mammoth_below.dmm
+++ b/_maps/map_files/Mammoth/Mammoth_below.dmm
@@ -8402,10 +8402,6 @@
 	},
 /turf/open/floor/ms13/tile/brown,
 /area/ms13/town)
-"Fk" = (
-/obj/structure/flora/rock/pile,
-/turf/open/floor/plating/ms13/ground/mountain,
-/area/ms13/underground/mountain)
 "Fl" = (
 /obj/machinery/door/airlock/ms13,
 /turf/open/floor/ms13/tile/brown,
@@ -8518,11 +8514,6 @@
 "FG" = (
 /turf/open/floor/wood/ms13/carpet,
 /area/ms13/underground/underground_town)
-"FH" = (
-/obj/structure/flora/grass/jungle/b,
-/obj/structure/flora/rock/pile,
-/turf/open/floor/plating/ms13/ground/mountain,
-/area/ms13/underground/mountain)
 "FI" = (
 /obj/structure/chair/pew{
 	dir = 1
@@ -12237,11 +12228,6 @@
 /obj/structure/ms13/storage/trashcan,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/underground/vault_atrium_lower)
-"TN" = (
-/obj/structure/flora/rock/pile,
-/obj/effect/decal/cleanable/blood/tracks,
-/turf/open/floor/plating/ms13/ground/mountain,
-/area/ms13/underground/mountain)
 "TO" = (
 /obj/machinery/light/ms13/bulb,
 /turf/open/floor/ms13/concrete/industrial,
@@ -12829,10 +12815,6 @@
 "VU" = (
 /turf/open/floor/ms13/metal/warning,
 /area/ms13/underground/army_bunker)
-"VV" = (
-/obj/structure/flora/rock/pile,
-/turf/open/ms13/water/sewer/shallow,
-/area/ms13/underground/mountain)
 "VX" = (
 /obj/effect/turf_decal/stripes/line,
 /mob/living/simple_animal/hostile/ms13/robot/protectron,
@@ -60928,7 +60910,7 @@ fU
 fU
 fU
 IR
-Fk
+kx
 kx
 bV
 bV
@@ -66063,7 +66045,7 @@ fU
 fU
 fU
 fU
-Fk
+kx
 kx
 kx
 bV
@@ -66372,7 +66354,7 @@ bV
 bV
 Yb
 kx
-Fk
+kx
 bV
 eR
 bV
@@ -68173,7 +68155,7 @@ fU
 fU
 fU
 Ja
-Fk
+kx
 kx
 kx
 fU
@@ -68787,7 +68769,7 @@ bV
 bV
 bV
 bV
-FH
+Yb
 Wu
 kx
 kx
@@ -69388,7 +69370,7 @@ fU
 kx
 df
 kx
-Fk
+kx
 kx
 bV
 bV
@@ -69695,7 +69677,7 @@ kx
 kx
 bV
 bV
-VV
+bV
 Ei
 fU
 fU
@@ -72092,14 +72074,14 @@ kx
 kx
 kx
 kx
-Fk
+kx
 bV
 bV
 bV
 kx
 kx
 Yb
-Fk
+kx
 yq
 fU
 fU
@@ -72712,7 +72694,7 @@ bV
 kx
 kx
 Ei
-Fk
+kx
 bV
 bV
 kx
@@ -73307,7 +73289,7 @@ Yr
 jL
 Yr
 Yr
-TN
+Yr
 Yr
 SO
 kx
@@ -73618,7 +73600,7 @@ fU
 fU
 fU
 Yb
-Fk
+kx
 df
 kx
 kx

--- a/_maps/map_files/Mammoth/Mammoth_below.dmm
+++ b/_maps/map_files/Mammoth/Mammoth_below.dmm
@@ -551,11 +551,10 @@
 /obj/machinery/light/ms13/bulb/built{
 	dir = 1
 	},
-/obj/structure/closet/crate/bin,
-/obj/effect/spawner/random/ms13/medical/lowrandom,
 /obj/machinery/light/ms13{
 	dir = 1
 	},
+/obj/structure/ms13/storage/trashcan,
 /turf/open/floor/wood/ms13/common,
 /area/ms13/underground/underground_town)
 "bY" = (
@@ -1959,11 +1958,6 @@
 /obj/effect/spawner/random/ms13/clothing/shoe,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/underground/sewer)
-"ht" = (
-/obj/structure/closet/crate/bin,
-/obj/effect/spawner/random/ms13/medical/lowrandom,
-/turf/open/floor/ms13/concrete,
-/area/ms13/underground/subway)
 "hu" = (
 /obj/machinery/light/ms13/bulb{
 	dir = 1
@@ -4567,7 +4561,6 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/blood/old,
-/obj/effect/mob_spawn/human/skeleton/alive,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/underground/underground_town)
 "qZ" = (
@@ -5336,7 +5329,6 @@
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/underground/underground_town)
 "tN" = (
-/obj/effect/mob_spawn/human/skeleton/alive,
 /obj/effect/spawner/random/ms13/ammo/lowrandom,
 /turf/open/floor/plating/ms13/ground/mountain,
 /area/ms13/underground/mountain)
@@ -7505,7 +7497,7 @@
 /turf/open/floor/wood/ms13/common,
 /area/ms13/underground/underground_town)
 "BS" = (
-/obj/structure/closet/crate/bin,
+/obj/structure/ms13/storage/trashcan,
 /turf/open/floor/wood/ms13/carpet,
 /area/ms13/underground/underground_town)
 "BT" = (
@@ -9435,6 +9427,7 @@
 /obj/machinery/light/ms13{
 	dir = 1
 	},
+/obj/structure/ms13/storage/trashcan,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/underground/vault_atrium_lower)
 "IO" = (
@@ -9964,9 +9957,9 @@
 /turf/open/floor/ms13/concrete/bricks,
 /area/ms13/underground/sewer)
 "KT" = (
-/obj/effect/mob_spawn/human/skeleton/alive,
-/turf/open/floor/plating/ms13/ground/mountain,
-/area/ms13/underground/mountain)
+/obj/structure/ms13/storage/trashcan,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/underground/vault_atrium_lower)
 "KU" = (
 /obj/structure/table/ms13/no_smooth/counter/wood{
 	dir = 1
@@ -10693,7 +10686,7 @@
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "NG" = (
-/obj/structure/closet/crate/bin,
+/obj/structure/ms13/storage/trashcan,
 /turf/open/floor/ms13/tile/large/cafeteria,
 /area/ms13/underground/sewer)
 "NH" = (
@@ -12240,6 +12233,7 @@
 /area/ms13/underground/army_bunker)
 "TM" = (
 /obj/machinery/light/ms13,
+/obj/structure/ms13/storage/trashcan,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/underground/vault_atrium_lower)
 "TN" = (
@@ -12522,7 +12516,7 @@
 	},
 /area/ms13/underground/vault_atrium_lower)
 "UN" = (
-/obj/structure/closet/crate/bin,
+/obj/structure/ms13/storage/trashcan,
 /turf/open/floor/ms13/concrete,
 /area/ms13/underground/subway)
 "UO" = (
@@ -13224,7 +13218,7 @@
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "Xw" = (
-/obj/structure/closet/crate/bin,
+/obj/structure/ms13/storage/trashcan,
 /turf/open/floor/wood/ms13/common,
 /area/ms13/underground/underground_town)
 "Xx" = (
@@ -26972,7 +26966,7 @@ fU
 fU
 fU
 EI
-Le
+KT
 Le
 oM
 Ly
@@ -49024,7 +49018,7 @@ EQ
 fU
 kx
 kx
-KT
+kx
 fU
 fU
 fU
@@ -49308,7 +49302,7 @@ oQ
 pv
 fU
 fU
-KT
+kx
 kx
 kx
 fU
@@ -54152,7 +54146,7 @@ fU
 fU
 pH
 kx
-KT
+kx
 kx
 kx
 Wu
@@ -56560,7 +56554,7 @@ EQ
 EQ
 fU
 kx
-KT
+kx
 wQ
 kx
 kx
@@ -58914,7 +58908,7 @@ bV
 kx
 Vz
 kx
-kx
+Ng
 Vz
 kx
 kx
@@ -58974,7 +58968,7 @@ ff
 zh
 EQ
 kx
-KT
+kx
 kx
 kx
 kx
@@ -65871,7 +65865,7 @@ nJ
 nJ
 nJ
 nJ
-tY
+UN
 kL
 tY
 tY
@@ -69505,7 +69499,7 @@ fU
 fU
 fU
 nJ
-ht
+UN
 tY
 tY
 tY
@@ -71889,7 +71883,7 @@ fU
 fU
 fU
 Vz
-kx
+Rt
 kx
 Vz
 Vz

--- a/_maps/map_files/Mammoth/Mammoth_below.dmm
+++ b/_maps/map_files/Mammoth/Mammoth_below.dmm
@@ -524,21 +524,6 @@
 	},
 /turf/open/floor/ms13/concrete,
 /area/ms13/town)
-"bS" = (
-/obj/item/gun/ballistic/revolver/ms13/rev357/police{
-	pixel_x = -4;
-	pixel_y = 4
-	},
-/obj/item/gun/ballistic/revolver/ms13/rev357/police{
-	pixel_x = -4
-	},
-/obj/item/gun/ballistic/revolver/ms13/rev357/police{
-	pixel_x = -4;
-	pixel_y = -4
-	},
-/obj/structure/table/ms13/metal/alt,
-/turf/open/floor/ms13/metal,
-/area/ms13/underground/vault_atrium_lower)
 "bT" = (
 /obj/structure/flora/grass/jungle/b,
 /obj/effect/decal/cleanable/blood/bubblegum,
@@ -729,7 +714,6 @@
 /area/ms13/underground/underground_town)
 "cB" = (
 /obj/structure/table/ms13/metal,
-/obj/item/trash/can/food/beans,
 /turf/open/floor/wood/ms13/carpet,
 /area/ms13/underground/mountain)
 "cC" = (
@@ -737,10 +721,6 @@
 /obj/effect/spawner/random/ms13/seeds/spores,
 /turf/open/floor/plating/ms13/ground/mountain,
 /area/ms13/underground/mountain)
-"cD" = (
-/obj/item/trash/can/food/beans,
-/turf/open/floor/wood/ms13/common,
-/area/ms13/underground/underground_town)
 "cE" = (
 /obj/structure/chair/ms13/wood{
 	dir = 8
@@ -1938,7 +1918,7 @@
 /area/ms13/underground/enclave_base)
 "hk" = (
 /obj/machinery/power/smes/magical,
-/turf/open/floor/ms13/metal/pipe,
+/turf/open/floor/ms13/metal/grate/border/warning,
 /area/ms13/underground/vault_atrium_lower)
 "hl" = (
 /obj/effect/mob_spawn/human/corpse/ms13/wastelander,
@@ -2147,10 +2127,6 @@
 /obj/effect/spawner/random/ms13/clothing/hat,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/underground/underground_town)
-"ib" = (
-/obj/item/trash/can/food/beans,
-/turf/open/floor/ms13/concrete/industrial,
-/area/ms13/underground/army_bunker)
 "ic" = (
 /obj/structure/closet,
 /obj/machinery/light/ms13/bulb/built{
@@ -2924,10 +2900,6 @@
 /obj/structure/table/ms13/crafting/workbench,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/ncr)
-"kV" = (
-/obj/item/trash/can/food/beans,
-/turf/open/floor/wood/ms13/wide,
-/area/ms13/underground/underground_town)
 "kW" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/open/floor/plating/ms13/ground/mountain,
@@ -5590,7 +5562,6 @@
 /turf/open/ms13/water/sewer/medium,
 /area/ms13/underground/sewer)
 "uG" = (
-/obj/item/restraints/handcuffs,
 /obj/item/restraints/handcuffs{
 	pixel_y = 10
 	},
@@ -6577,11 +6548,6 @@
 /obj/structure/table/ms13/crafting/workbench,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/underground/sewer)
-"ys" = (
-/obj/item/trash/can/food/beans,
-/obj/structure/table/ms13/wood,
-/turf/open/floor/wood/ms13/wide,
-/area/ms13/underground/underground_town)
 "yt" = (
 /obj/structure/table/ms13/metal,
 /obj/item/paper_bin{
@@ -7293,7 +7259,6 @@
 /obj/machinery/light/ms13/bulb{
 	dir = 1
 	},
-/obj/item/trash/can/food/beans,
 /obj/structure/ms13/foundation/common/variantfour{
 	dir = 4
 	},
@@ -11364,13 +11329,6 @@
 	},
 /turf/open/floor/plating/ms13/ground/mountain,
 /area/ms13/underground/vault_atrium_lower)
-"Qt" = (
-/obj/item/trash/can/food/beans,
-/obj/structure/table/ms13/no_smooth/counter/wood{
-	dir = 1
-	},
-/turf/open/floor/ms13/tile,
-/area/ms13/underground/underground_town)
 "Qu" = (
 /obj/structure/table/ms13/metal,
 /obj/effect/spawner/random/ms13/melee/tier2,
@@ -12095,14 +12053,6 @@
 "Tf" = (
 /obj/structure/table/ms13/metal/alt,
 /obj/item/claymore/ms13/baton,
-/obj/item/claymore/ms13/baton{
-	pixel_x = 3;
-	pixel_y = 4
-	},
-/obj/item/claymore/ms13/baton{
-	pixel_x = 6;
-	pixel_y = 8
-	},
 /turf/open/floor/ms13/metal,
 /area/ms13/underground/vault_atrium_lower)
 "Tg" = (
@@ -12317,11 +12267,6 @@
 	},
 /turf/open/floor/wood/ms13/carpet,
 /area/ms13/underground/underground_town)
-"Ua" = (
-/obj/structure/table/ms13/metal/grate,
-/obj/item/trash/can/food/beans,
-/turf/open/floor/ms13/concrete/industrial,
-/area/ms13/underground/army_bunker)
 "Ub" = (
 /obj/item/storage/firstaid/ms13/bag/filled,
 /obj/structure/ms13/storage/shelf,
@@ -20266,7 +20211,7 @@ fU
 fU
 iR
 VR
-kV
+ff
 yJ
 ff
 iR
@@ -27757,7 +27702,7 @@ kx
 Xl
 fi
 az
-cD
+az
 zC
 Oy
 EQ
@@ -27920,7 +27865,7 @@ sP
 sP
 Ly
 oM
-bS
+Bx
 US
 Tf
 oM
@@ -43764,7 +43709,7 @@ FO
 en
 oc
 SR
-Qt
+nd
 TF
 az
 az
@@ -52665,7 +52610,7 @@ EQ
 Au
 EQ
 Zc
-ys
+WP
 WP
 ff
 EQ
@@ -83923,7 +83868,7 @@ Su
 Ut
 Qb
 Ut
-Ua
+UR
 cT
 fU
 cT
@@ -85128,10 +85073,10 @@ fU
 fU
 cT
 Ut
-ib
 Ut
 Ut
-ib
+Ut
+Ut
 Ut
 Xo
 Ut

--- a/mojave/effects/spawners/lootdrop/medicalloot.dm
+++ b/mojave/effects/spawners/lootdrop/medicalloot.dm
@@ -53,8 +53,8 @@
 			/obj/effect/spawner/random/ms13/medical/tier2 = 55,
 			/obj/effect/spawner/random/ms13/medical/tier3 = 45
 			)
-
-/obj/effect/spawner/random/ms13/medical/BloodBag
+^^
+/obj/effect/spawner/random/ms13/medical/bloodbag
 	name = "Blood bag spawners"
 	spawn_loot_count = 3
 	spawn_loot_chance = 100

--- a/mojave/effects/spawners/lootdrop/medicalloot.dm
+++ b/mojave/effects/spawners/lootdrop/medicalloot.dm
@@ -53,3 +53,17 @@
 			/obj/effect/spawner/random/ms13/medical/tier2 = 55,
 			/obj/effect/spawner/random/ms13/medical/tier3 = 45
 			)
+
+/obj/effect/spawner/random/ms13/medical/BloodBag
+	name = "Blood bag spawners"
+	spawn_loot_count = 3
+	spawn_loot_chance = 100
+	loot = list(
+			/obj/item/reagent_containers/blood/ms13/a_plus = 15,
+			/obj/item/reagent_containers/blood/ms13/a_minus = 15,
+			/obj/item/reagent_containers/blood/ms13/b_plus = 15,
+			/obj/item/reagent_containers/blood/ms13/b_minus = 15,
+			/obj/item/reagent_containers/blood/ms13/o_plus = 15,
+			/obj/item/reagent_containers/blood/ms13/o_minus = 10,
+			/obj/item/reagent_containers/blood/ms13/radaway = 15
+			)

--- a/mojave/effects/spawners/lootdrop/medicalloot.dm
+++ b/mojave/effects/spawners/lootdrop/medicalloot.dm
@@ -53,7 +53,7 @@
 			/obj/effect/spawner/random/ms13/medical/tier2 = 55,
 			/obj/effect/spawner/random/ms13/medical/tier3 = 45
 			)
-^^
+
 /obj/effect/spawner/random/ms13/medical/bloodbag
 	name = "Blood bag spawners"
 	spawn_loot_count = 3


### PR DESCRIPTION
## About The Pull Request
- Replaces all TG trashbins with Infras trash cans
- Added Bloodbag spawners ( 2 in vault, 1 in each faction )
- Removed Skeleton spawners
- Replaced a few common wood tile buildings with more varients of wood ( mosaic, wide, fancy )
- Removed all rock/piles from Mammoth
- Added depth to the lakes
- A bit of fixing.

## Why It's Good For The Game
Kinda cute 

## Screenshots

![grafik](https://user-images.githubusercontent.com/69112131/147010221-d2824c31-b821-4fdf-9b4d-5169d15bcb11.png)
Removed TG Headphones

![grafik](https://user-images.githubusercontent.com/69112131/147010286-afdce1a7-6269-41a2-804c-9b85c4aaca99.png)
Removed the brickwall underneath the door

![grafik](https://user-images.githubusercontent.com/69112131/147010355-abc90b9a-bc7f-454c-96b8-f2cfbc0e9562.png)
Gave the Sawbones surgical tools

![grafik](https://user-images.githubusercontent.com/69112131/147010387-61de3c39-85d2-46d6-91b6-4d06c319c0e6.png)
Replaced the carpet underneath the door with wood tiles.



