### PR TITLE
remove maintenance panel text

### DIFF
--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -43,7 +43,7 @@
 	var/can_crush = TRUE /// Whether or not the door can crush mobs.
 	var/sparks = TRUE /// MOJAVE SUN EDIT
 
-/obj/machinery/door/examine(mob/user)
+/*/obj/machinery/door/examine(mob/user) //MOJAVE SUN EDUT START
 	. = ..()
 	if(red_alert_access)
 		if(SSsecurity_level.current_level >= SEC_LEVEL_RED)
@@ -55,7 +55,7 @@
 /obj/machinery/door/check_access_list(list/access_list)
 	if(red_alert_access && SSsecurity_level.current_level >= SEC_LEVEL_RED)
 		return TRUE
-	return ..()
+	return ..() */ //MOJAVE SUN EDIT END
 
 /obj/machinery/door/Initialize(mapload)
 	. = ..()

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -43,19 +43,23 @@
 	var/can_crush = TRUE /// Whether or not the door can crush mobs.
 	var/sparks = TRUE /// MOJAVE SUN EDIT
 
-/*/obj/machinery/door/examine(mob/user) //MOJAVE SUN EDUT START
+/obj/machinery/door/examine(mob/user)
 	. = ..()
+	/*MOJAVE SUN EDIT BEGIN
 	if(red_alert_access)
 		if(SSsecurity_level.current_level >= SEC_LEVEL_RED)
 			. += span_notice("Due to a security threat, its access requirements have been lifted!")
 		else
 			. += span_notice("In the event of a red alert, its access requirements will automatically lift.")
 	. += span_notice("Its maintenance panel is <b>screwed</b> in place.")
+	*///MOJAVE SUN EDIT END
 
 /obj/machinery/door/check_access_list(list/access_list)
+	/*MOJAVE SUN EDIT BEGIN
 	if(red_alert_access && SSsecurity_level.current_level >= SEC_LEVEL_RED)
 		return TRUE
-	return ..() */ //MOJAVE SUN EDIT END
+	*///MOJAVE SUN EDIT END
+	return ..()
 
 /obj/machinery/door/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This comments out the text on doors saying that they have a maintenance panel, simple as.

## Why It's Good For The Game

A simple wooden/metal door would not have a maintenance panel.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:

del: comments out maintenance panel text from examining doors.

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
