### PR TITLE
Basic workbench functionality and stop-gap crafting menu

### DIFF
--- a/code/__DEFINES/construction.dm
+++ b/code/__DEFINES/construction.dm
@@ -110,6 +110,18 @@
 #define CAT_CHEMISTRY "Chemistry"
 #define CAT_ATMOSPHERIC "Atmospheric"
 
+// tablecrafting interface types - MOJAVE EDIT START
+
+#define CAT_MEDICAL "Medical"
+
+#define CRAFTING_BENCH_HANDS      1<<0
+#define CRAFTING_BENCH_GENERAL    1<<1
+#define CRAFTING_BENCH_ELECTRIC   1<<2
+#define CRAFTING_BENCH_ARMTAILOR  1<<3
+#define CRAFTING_BENCH_WEAPONS    1<<4
+#define CRAFTING_BENCH_RELOADING  1<<5
+// tablecrafting interface types - MOJAVE EDIT END
+
 //rcd modes
 #define RCD_FLOORWALL 0
 #define RCD_AIRLOCK 1

--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -797,3 +797,13 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 
 /// This mob heals from cult pylons.
 #define TRAIT_HEALS_FROM_CULT_PYLONS "heals_from_cult_pylons"
+
+
+// MOJAVE JOB TRAITS START
+
+/*
+* trait granted by medical jobs - allows crafting proper medical equipment
+*/
+#define TRAIT_MEDICAL_TRAINING "medical_training"
+
+// MOJAVE JOB TRAITS END

--- a/code/datums/components/crafting/crafting.dm
+++ b/code/datums/components/crafting/crafting.dm
@@ -1,9 +1,12 @@
-/datum/component/personal_crafting/Initialize()
-	return
-	/* MOJAVE EDIT
+// MOJAVE EDIT - CRAFTING BENCHES START
+/datum/component/personal_crafting/Initialize(crafting_interface=CRAFTING_BENCH_HANDS)
+	src.crafting_interface = crafting_interface // MOJAVE EDIT - CRAFTING BENCHES
 	if(ismob(parent))
-		RegisterSignal(parent, COMSIG_MOB_CLIENT_LOGIN, .proc/create_mob_button)
-	*/
+		return // no hand crafting
+		// RegisterSignal(parent, COMSIG_MOB_CLIENT_LOGIN, .proc/create_mob_button)
+	else // Alt click because workbenches are tables, so putting items on them triggers a click
+		RegisterSignal(parent, COMSIG_CLICK_CTRL, .proc/component_ui_interact_workbench)
+// MOJAVE EDIT - CRAFTING BENCHES END
 
 /datum/component/personal_crafting/proc/create_mob_button(mob/user, client/CL)
 	SIGNAL_HANDLER
@@ -24,6 +27,7 @@
 					CAT_WEAPON,
 					CAT_AMMO,
 				),
+				CAT_MEDICAL,
 				CAT_ROBOT = CAT_NONE,
 				CAT_MISC = CAT_NONE,
 				CAT_PRIMAL = CAT_NONE,
@@ -205,9 +209,16 @@
 				for(var/content in get_turf(a))
 					if(istype(content, R.result))
 						return ", object already present."
-			//If we're a mob we'll try a do_after; non mobs will instead instantly construct the item
-			if(ismob(a) && !do_after(a, R.time, target = a))
-				return "."
+			// MOJAVE EDIT - CRAFTING BENCHES START
+			if(ismob(a))
+				var/mob/crafting_mob = a
+				// If we are a mob, check we still have desired traits (if any)
+				if(R.trait && crafting_mob.mind && !HAS_TRAIT(crafting_mob.mind, R.trait))
+					return ", missing trait"
+				//If we're a mob we'll try a do_after; non mobs will instead instantly construct the item
+				if(!do_after(a, R.time, target = a))
+					return "."
+			// MOJAVE EDIT - CRAFTING BENCHES END
 			contents = get_surroundings(a,R.blacklist)
 			if(!check_contents(a, R, contents))
 				return ", missing component."
@@ -359,14 +370,25 @@
 			container.emptyStorage()
 		qdel(DL)
 
+// MOJAVE-EDIT
+/datum/component/personal_crafting/proc/component_ui_interact_workbench(datum/source, mob/user)
+	SIGNAL_HANDLER
+
+	//MOJAVE EDIT - Only require user to be the component owner, for hand crafting
+	if(source == parent)
+		INVOKE_ASYNC(src, .proc/ui_interact, user)
+
 /datum/component/personal_crafting/proc/component_ui_interact(atom/movable/screen/craft/image, location, control, params, user)
 	SIGNAL_HANDLER
 
 	if(user == parent)
 		INVOKE_ASYNC(src, .proc/ui_interact, user)
 
+
 /datum/component/personal_crafting/ui_state(mob/user)
-	return GLOB.not_incapacitated_turf_state
+	if(crafting_interface == CRAFTING_BENCH_HANDS)
+		return GLOB.not_incapacitated_turf_state
+	return GLOB.default_state
 
 //For the UI related things we're going to assume the user is a mob rather than typesetting it to an atom as the UI isn't generated if the parent is an atom
 /datum/component/personal_crafting/ui_interact(mob/user, datum/tgui/ui)
@@ -394,6 +416,16 @@
 	for(var/rec in GLOB.crafting_recipes)
 		var/datum/crafting_recipe/R = rec
 
+		// MOJAVE EDIT - CRAFTING BENCHES START
+		// Check we are the correct workbench for this
+		if(!(R.crafting_interface & src.crafting_interface))
+			continue
+
+		// Check we have the traits that teach these -- traits might be in their body or noggin
+		if(R.trait && user?.mind && !HAS_TRAIT(user.mind, R.trait))
+			continue
+		// MOJAVE EDIT - CRAFTING BENCHES END
+
 		if(!R.always_available && !(R.type in user?.mind?.learned_recipes)) //User doesn't actually know how to make this.
 			continue
 
@@ -414,6 +446,16 @@
 
 		if(R.name == "") //This is one of the invalid parents that sneaks in
 			continue
+
+		// MOJAVE EDIT - CRAFTING BENCHES START
+		// Check we are the correct workbench for this
+		if(!(R.crafting_interface & src.crafting_interface))
+			continue
+
+		// Check we have the traits that teach these
+		if(R.trait && user?.mind && !HAS_TRAIT(user.mind, R.trait))
+			continue
+		// MOJAVE EDIT - CRAFTING BENCHES END
 
 		if(!R.always_available && !(R.type in user?.mind?.learned_recipes)) //User doesn't actually know how to make this.
 			continue

--- a/code/datums/components/crafting/crafting.dm
+++ b/code/datums/components/crafting/crafting.dm
@@ -384,11 +384,12 @@
 	if(user == parent)
 		INVOKE_ASYNC(src, .proc/ui_interact, user)
 
-
+// MOJAVE SUN EDIT BEGIN
 /datum/component/personal_crafting/ui_state(mob/user)
 	if(crafting_interface == CRAFTING_BENCH_HANDS)
 		return GLOB.not_incapacitated_turf_state
 	return GLOB.default_state
+// MOJAVE SUN EDIT END
 
 //For the UI related things we're going to assume the user is a mob rather than typesetting it to an atom as the UI isn't generated if the parent is an atom
 /datum/component/personal_crafting/ui_interact(mob/user, datum/tgui/ui)

--- a/code/datums/components/crafting/recipes.dm
+++ b/code/datums/components/crafting/recipes.dm
@@ -18,6 +18,7 @@
 	var/category = CAT_NONE //where it shows up in the crafting UI
 	var/subcategory = CAT_NONE
 	var/always_available = TRUE //Set to FALSE if it needs to be learned first.
+	var/trait // Trait required
 	/// Additonal requirements text shown in UI
 	var/additional_req_text
 	///Required machines for the craft, set the assigned value of the typepath to CRAFTING_MACHINERY_CONSUME or CRAFTING_MACHINERY_USE. Lazy associative list: type_path key -> flag value.

--- a/code/datums/components/crafting/recipes.dm
+++ b/code/datums/components/crafting/recipes.dm
@@ -18,7 +18,7 @@
 	var/category = CAT_NONE //where it shows up in the crafting UI
 	var/subcategory = CAT_NONE
 	var/always_available = TRUE //Set to FALSE if it needs to be learned first.
-	var/trait // Trait required
+	var/trait // MOJAVE SUN ADD - Trait required for crafting
 	/// Additonal requirements text shown in UI
 	var/additional_req_text
 	///Required machines for the craft, set the assigned value of the typepath to CRAFTING_MACHINERY_CONSUME or CRAFTING_MACHINERY_USE. Lazy associative list: type_path key -> flag value.

--- a/mojave/jobs/job_types/ncr/medic.dm
+++ b/mojave/jobs/job_types/ncr/medic.dm
@@ -9,6 +9,8 @@
 
 	display_order = JOB_DISPLAY_ORDER_MS13_MEDIC
 
+	mind_traits = list(TRAIT_MEDICAL_TRAINING)
+
 /datum/outfit/job/ms13/ncr/medic
 	name = "_NCR Medic"
 	jobtype = /datum/job/ms13/ncr/medic

--- a/mojave/modules/crafting/recipes/recipes.dm
+++ b/mojave/modules/crafting/recipes/recipes.dm
@@ -1,0 +1,39 @@
+
+
+
+// Used to filter crafting recipes based on what you are crafting with
+// i.e CRAFTING_BENCH_HANDS is the default crafting menu (hidden at time of writing)
+// the general crafting bench only shows recipes with CRAFTING_BENCH_GENERAL, etc.
+// treat this is a flag, so recipes can be shared between (i.e bandages on GENERAL and ARMTAILOR)
+/datum/crafting_recipe/var/crafting_interface = CRAFTING_BENCH_HANDS
+
+// Used to display relevant recipes - match to the recipe's crafting_interface
+/datum/component/personal_crafting/var/crafting_interface = CRAFTING_BENCH_HANDS
+
+
+
+// TG Recipes carried over
+/datum/crafting_recipe/spear/crafting_interface = CRAFTING_BENCH_HANDS | CRAFTING_BENCH_GENERAL
+/datum/crafting_recipe/ipickaxe/crafting_interface = CRAFTING_BENCH_HANDS | CRAFTING_BENCH_GENERAL
+
+/datum/crafting_recipe/sutures_shitty
+	name = "Jurry-Rigged Sutures"
+	result = /obj/item/stack/medical/suture/emergency
+	time = 10
+	tool_paths = list()
+	reqs = list(/obj/item/stack/sheet/ms13/scrap=1, /obj/item/stack/sheet/cloth = 3)
+	category = CAT_MEDICAL
+	crafting_interface = CRAFTING_BENCH_GENERAL
+
+// Requires medical training
+/datum/crafting_recipe/sutures
+	name = "Quality Sutures"
+	result = /obj/item/stack/medical/suture
+	time = 10
+	tool_paths = list()
+	trait = TRAIT_MEDICAL_TRAINING
+	reqs = list(/obj/item/stack/sheet/ms13/scrap=1, /obj/item/stack/sheet/cloth = 3)
+	category = CAT_MEDICAL
+	crafting_interface = CRAFTING_BENCH_GENERAL
+
+

--- a/mojave/structures/table.dm
+++ b/mojave/structures/table.dm
@@ -259,28 +259,39 @@
 	bound_width = 64
 	smoothing_flags = NONE
 	canSmoothWith = null
+	var/crafting_interface = CRAFTING_BENCH_GENERAL
+
+/obj/structure/table/ms13/crafting/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/personal_crafting, crafting_interface)
 
 /obj/structure/table/ms13/crafting/workbench
 	name = "workbench"
 	desc = "A basic workbench. Solid metal surface and a few tools to help you make basic tools and items you require."
 	icon_state = "workbench"
+	crafting_interface = CRAFTING_BENCH_GENERAL
 
+// TODO FIX
 /obj/structure/table/ms13/crafting/ammobench
 	name = "loading bench"
 	desc = "An ammo loading bench, with some tools that assist you in assembling cartridges to send towards your foe."
 	icon_state = "ammobench"
+	crafting_interface = CRAFTING_BENCH_RELOADING
 
 /obj/structure/table/ms13/crafting/armorbench
 	name = "tailoring bench"
 	desc = "A sturdy bench. It's got an anvil and sewing machine, it'd be a good surface to try and fabricate clothing or armor with."
 	icon_state = "armorbench"
+	crafting_interface = CRAFTING_BENCH_ARMTAILOR
 
 /obj/structure/table/ms13/crafting/weaponbench
 	name = "weapon bench"
 	desc = "A large bench with a functional drill press and a vice. Would be useful in creating and assembling weapons, to the best of your ability anyways."
 	icon_state = "weaponbench"
+	crafting_interface = CRAFTING_BENCH_WEAPONS
 
 /obj/structure/table/ms13/crafting/tinkerbench
 	name = "tinkering bench"
 	desc = "A large bench with a power supply hooked up to it. There's a soldering iron and a few other tools scattered about to assist you in making electronic components."
 	icon_state = "tinkerbench"
+	crafting_interface = CRAFTING_BENCH_ELECTRIC

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4230,6 +4230,7 @@
 #include "mojave\machinery\machinery.dm"
 #include "mojave\machinery\medical.dm"
 #include "mojave\machinery\terminals.dm"
+#include "mojave\modules\crafting\recipes\recipes.dm"
 #include "mojave\modules\outdoor_effects\code\_onclick\hud\fullscreen.dm"
 #include "mojave\modules\outdoor_effects\code\_onclick\hud\rendering\plane_master.dm"
 #include "mojave\modules\outdoor_effects\code\controllers\subsystem\outdoor_effects.dm"


### PR DESCRIPTION
 - trait based crafting
 - crafting bench functionality

ctrl click workbenches to access crafting menu

@Hekzder 

for crafting benches use crafting_interface on the crafting bench and recipe defines
i.e in mojave/modules/crafting/recipes/recipes.dm I added spears and improvised pickaxes
these are visible in general workbenches and handcrafting (which is disabled atm).
this is set using `crafting_interface = CRAFTING_BENCH_HANDS | CRAFTING_BENCH_GENERAL`


for trait based crafting, I have added medical training to the NCR medic

add traits to traits.dm
add trait to mind_traits in jobs (i.e mojave/jobs/job_types/ncr/medic.dm )
set trait in recipe to require the trait to craft/be visible

this is used for sutures - only visible to medics
contract with emergency sutures - visible to everyone


lmk if stuck xo