### PR TITLE
Nerfs gamer TG movement and anchors closet subtypes

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -205,7 +205,7 @@ GLOBAL_DATUM_INIT(fire_overlay, /mutable_appearance, mutable_appearance('icons/e
 
 //MOJAVE EDIT CHANGE BEGIN
 	var/log_pickup_and_drop = FALSE //For logging in the attack logs certain items (mostly weapons) being equipped, dropped, or taken into hand
-//MOJAVE EDIT CHANGE END 
+//MOJAVE EDIT CHANGE END
 
 	/// Used in obj/item/examine to give additional notes on what the weapon does, separate from the predetermined output variables
 	var/offensive_notes
@@ -235,7 +235,7 @@ GLOBAL_DATUM_INIT(fire_overlay, /mutable_appearance, mutable_appearance('icons/e
 		if(damtype == BRUTE)
 			hitsound = "swing_hit"
 
-	add_weapon_description()
+//	add_weapon_description() MOJAVE SUN EDIT: We don't need this!
 
 	SEND_GLOBAL_SIGNAL(COMSIG_GLOB_NEW_ITEM, src)
 	if(LAZYLEN(embedding))

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -186,8 +186,10 @@
 	. = ..()
 	if(welded)
 		. += span_notice("It's welded shut.")
-/*	if(anchored) // MOJAVE SUN EDIT BEGIN
-		. += span_notice("It is <b>bolted</b> to the ground.") */ // MOJAVE SUN EDIT END - No false reports, kids.
+	/* // MOJAVE SUN EDIT BEGIN
+	if(anchored)
+		. += span_notice("It is <b>bolted</b> to the ground.")
+	*/ // MOJAVE SUN EDIT END - No false reports, kids.
 	if(opened)
 		. += span_notice("The parts are <b>welded</b> together.")
 	else if(secure && !opened)

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -11,6 +11,7 @@
 	integrity_failure = 0.25
 	armor = list(MELEE = 20, BULLET = 10, LASER = 10, ENERGY = 0, BOMB = 10, BIO = 0, FIRE = 70, ACID = 60)
 	blocks_emissive = EMISSIVE_BLOCK_GENERIC
+	anchored = TRUE // MOJAVE EDIT - Revert after CAT
 
 	/// The overlay for the closet's door
 	var/obj/effect/overlay/closet_door/door_obj
@@ -54,7 +55,7 @@
 	var/material_drop = /obj/item/stack/sheet/ms13/scrap //MOJAVE EDIT - Drops our own scrap metal instead of TG iron. Revert after CAT
 	var/material_drop_amount = 1 //MOJAVE EDIT - Original value is 2. Revert after CAT
 	var/delivery_icon = "deliverycloset" //which icon to use when packagewrapped. null to be unwrappable.
-	var/anchorable = TRUE
+	var/anchorable = FALSE // MOJAVE EDIT - Original value is TRUE. Probably revert after CAT.
 	var/icon_welded = "welded"
 	/// How close being inside of the thing provides complete pressure safety. Must be between 0 and 1!
 	contents_pressure_protection = 0

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -186,8 +186,8 @@
 	. = ..()
 	if(welded)
 		. += span_notice("It's welded shut.")
-	if(anchored)
-		. += span_notice("It is <b>bolted</b> to the ground.")
+/*	if(anchored) // MOJAVE SUN EDIT BEGIN
+		. += span_notice("It is <b>bolted</b> to the ground.") */ // MOJAVE SUN EDIT END - No false reports, kids.
 	if(opened)
 		. += span_notice("The parts are <b>welded</b> together.")
 	else if(secure && !opened)

--- a/code/modules/mob/living/carbon/carbon_defines.dm
+++ b/code/modules/mob/living/carbon/carbon_defines.dm
@@ -11,6 +11,8 @@
 	usable_hands = 0 //Populated on init through list/bodyparts
 	mobility_flags = MOBILITY_FLAGS_CARBON_DEFAULT
 	blocks_emissive = NONE
+	throw_range = 2 // MOJAVE SUN EDIT - No more gamer combat
+	throw_speed = 1 // MOJAVE SUN EDIT - Slow em down, too.
 	///List of [/obj/item/organ] in the mob. They don't go in the contents for some reason I don't want to know.
 	var/list/internal_organs = list()
 	///Same as [above][/mob/living/carbon/var/internal_organs], but stores "slot ID" - "organ" pairs for easy access.

--- a/code/modules/mob/living/living_movement.dm
+++ b/code/modules/mob/living/living_movement.dm
@@ -39,7 +39,7 @@
 	if(pulling)
 		if(isliving(pulling))
 			var/mob/living/L = pulling
-			if(!slowed_by_drag || L.body_position == STANDING_UP || L.buckled || grab_state >= GRAB_AGGRESSIVE)
+			if(!slowed_by_drag || L.buckled || grab_state >= GRAB_AGGRESSIVE) // MOJAVE SUN EDIT: Original = 	if(!slowed_by_drag || L.body_position == STANDING_UP || L.buckled || grab_state >= GRAB_AGGRESSIVE)
 				remove_movespeed_modifier(/datum/movespeed_modifier/bulky_drag)
 				return
 			add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/bulky_drag, multiplicative_slowdown = PULL_PRONE_SLOWDOWN)

--- a/mojave/structures/storage/crates.dm
+++ b/mojave/structures/storage/crates.dm
@@ -6,6 +6,7 @@
 	icon = 'mojave/icons/structure/crates.dmi'
 	drag_slowdown = 1
 	max_integrity = 300
+	anchored = TRUE
 
 /obj/structure/closet/crate/ms13/woodcrate
 	name = "\improper wooden crate"


### PR DESCRIPTION

## About The Pull Request
Another small PR to help us avoid GAMING during CAT. This PR disables a large portion of TG corpse combat.

This PR basically kills off snaking in theory, as drag slowdown now applies even if the other guy is standing up. Long live the king.

You can now only throw a dude two tiles away. It could potentially be useful in melee combat, but corpses no longer fly across screens.

Closets are also anchored down now. No more loot dragging.

## Why It's Good For The Game

F13 players have been TG gaming for way too long. Time to step out of your shells!
