### PR TITLE
Misc. tweaks and fixes after first CAT

### DIFF
--- a/_maps/map_files/Mammoth/Mammoth.dmm
+++ b/_maps/map_files/Mammoth/Mammoth.dmm
@@ -2371,12 +2371,6 @@
 /mob/living/basic/ms13/ghoul/frozen,
 /turf/open/floor/plating/ms13/ground/sidewalk,
 /area/ms13)
-"bUI" = (
-/obj/structure/ms13/storage/shelf,
-/obj/effect/spawner/random/ms13/drink/alcohol,
-/obj/effect/spawner/random/ms13/drink/alcohol,
-/turf/open/floor/ms13/tile/large/black,
-/area/ms13/underground/vault_atrium_middle)
 "bUQ" = (
 /obj/machinery/door/unpowered/ms13/metal/alt{
 	dir = 1
@@ -2536,6 +2530,7 @@
 /obj/effect/spawner/random/ms13/food/produce_safe,
 /obj/effect/spawner/random/ms13/food/produce_safe,
 /obj/structure/closet/ms13/fridge,
+/obj/effect/spawner/random/ms13/food/produce_safe,
 /turf/open/floor/ms13/tile/long,
 /area/ms13/underground/vault_atrium_middle)
 "ccd" = (
@@ -6425,10 +6420,10 @@
 /area/ms13/tribal_abandoned)
 "fcY" = (
 /obj/structure/table/ms13/metal,
-/obj/effect/spawner/random/ms13/medical/lowrandom,
 /obj/machinery/light/ms13{
 	dir = 1
 	},
+/obj/item/storage/firstaid/ms13/bag/filled,
 /turf/open/floor/ms13/tile/large/white,
 /area/ms13/underground/vault_atrium_middle)
 "fdh" = (
@@ -6613,6 +6608,7 @@
 /obj/effect/spawner/random/ms13/food/produce_safe,
 /obj/effect/spawner/random/ms13/food/produce_safe,
 /obj/structure/closet/ms13/fridge,
+/obj/effect/spawner/random/ms13/food/produce_safe,
 /turf/open/floor/ms13/tile/long,
 /area/ms13/underground/vault_atrium_middle)
 "fko" = (
@@ -6849,9 +6845,6 @@
 /area/ms13/underground/vault_atrium_middle)
 "fsl" = (
 /obj/structure/closet/crate/ms13/woodcrate,
-/obj/effect/spawner/random/ms13/drink/soda,
-/obj/effect/spawner/random/ms13/drink/soda,
-/obj/effect/spawner/random/ms13/drink/soda,
 /obj/effect/spawner/random/ms13/drink/soda,
 /obj/effect/spawner/random/ms13/drink/soda,
 /obj/effect/spawner/random/ms13/drink/soda,
@@ -8610,6 +8603,9 @@
 /area/ms13/underground/tunnel/maintenance)
 "gup" = (
 /obj/structure/table/rolling/ms13,
+/obj/item/storage/firstaid/ms13/bag/filled{
+	pixel_y = 6
+	},
 /turf/open/floor/ms13/metal,
 /area/ms13/underground/bos)
 "guA" = (
@@ -8871,7 +8867,7 @@
 /area/ms13/underground/vault_atrium_middle)
 "gCE" = (
 /obj/structure/table/ms13/metal,
-/obj/item/stack/medical/ointment/ms13/cream,
+/obj/effect/spawner/random/ms13/medical/tier1,
 /turf/open/floor/ms13/tile/large/white,
 /area/ms13/underground/vault_atrium_middle)
 "gCK" = (
@@ -8879,10 +8875,6 @@
 	dir = 8
 	},
 /turf/open/floor/wood/ms13/carpet/shaggy/blue,
-/area/ms13/underground/vault_atrium_middle)
-"gCR" = (
-/obj/structure/closet/crate/ms13/woodcrate,
-/turf/open/floor/ms13/tile/large/black,
 /area/ms13/underground/vault_atrium_middle)
 "gDn" = (
 /obj/structure/table/ms13/metal,
@@ -19818,7 +19810,6 @@
 /area/ms13/ncr)
 "nvG" = (
 /obj/structure/table/ms13/metal,
-/obj/item/surgical_drapes,
 /obj/item/clothing/suit/apron/surgical,
 /turf/open/floor/ms13/tile,
 /area/ms13/ncr)
@@ -19927,10 +19918,7 @@
 /area/ms13/ncr)
 "nzs" = (
 /obj/structure/table/ms13/metal,
-/obj/item/cautery,
-/obj/item/scalpel{
-	pixel_y = 9
-	},
+/obj/item/storage/firstaid/ms13/bag/filled,
 /turf/open/floor/ms13/tile,
 /area/ms13/ncr)
 "nzw" = (
@@ -23974,6 +23962,7 @@
 /area/ms13/underground/tunnel/maintenance)
 "tmz" = (
 /obj/structure/table/ms13/metal,
+/obj/effect/spawner/random/ms13/medical/lowrandom,
 /turf/open/floor/ms13/tile/large/white,
 /area/ms13/underground/vault_atrium_middle)
 "tmE" = (
@@ -33021,7 +33010,7 @@ khQ
 khQ
 khQ
 ylm
-bUI
+oFE
 vfS
 fna
 fsl
@@ -33326,7 +33315,7 @@ ylm
 oFE
 vfS
 fna
-gCR
+fsl
 ylm
 alc
 pGA

--- a/_maps/map_files/Mammoth/Mammoth_below.dmm
+++ b/_maps/map_files/Mammoth/Mammoth_below.dmm
@@ -688,10 +688,6 @@
 	},
 /turf/open/floor/plating/ms13/ground/mountain,
 /area/ms13/underground/underground_town)
-"acp" = (
-/obj/structure/ore_box,
-/turf/open/floor/plating/ms13/ground/mountain,
-/area/ms13/underground/mountain)
 "acq" = (
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/plating/ms13/ground/mountain,
@@ -59349,7 +59345,7 @@ akx
 akx
 akx
 akx
-acp
+akx
 akx
 akx
 aNR

--- a/_maps/map_files/Mammoth/Mammoth_below.dmm
+++ b/_maps/map_files/Mammoth/Mammoth_below.dmm
@@ -2696,6 +2696,7 @@
 /obj/effect/spawner/random/ms13/drink/alcohol,
 /obj/effect/spawner/random/ms13/drink/alcohol,
 /obj/effect/spawner/random/ms13/drink/alcohol,
+/obj/effect/spawner/random/ms13/drink/alcohol,
 /turf/open/floor/wood/ms13/mosaic,
 /area/ms13/underground/vault_atrium_lower)
 "ajI" = (
@@ -3588,7 +3589,7 @@
 /obj/structure/ms13/foundation/variantsix{
 	dir = 8
 	},
-/obj/structure/ms13/torch,
+/obj/structure/bonfire/ms13/fire_barrel/prelit,
 /turf/open/floor/plating/ms13/ground/mountain,
 /area/ms13/underground/vault_atrium_lower)
 "amT" = (
@@ -8205,6 +8206,7 @@
 	dir = 4
 	},
 /obj/effect/spawner/random/ms13/drink/alcohol,
+/obj/effect/spawner/random/ms13/drink/alcohol,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/underground/vault_atrium_lower)
 "aDG" = (
@@ -10698,10 +10700,6 @@
 /mob/living/basic/ms13/hostile_animal/molerat,
 /turf/open/floor/plating/ms13/ground/mountain,
 /area/ms13/underground/mountain)
-"aMA" = (
-/obj/structure/ms13/torch,
-/turf/open/floor/wood/ms13/wide,
-/area/ms13/underground/vault_atrium_lower)
 "aMB" = (
 /obj/structure/table/ms13/metal,
 /obj/machinery/light/ms13/bulb/broken{
@@ -13916,11 +13914,6 @@
 /obj/structure/railing/ms13/sewer,
 /turf/open/floor/ms13/metal/pipe,
 /area/ms13/underground/sewer)
-"aYq" = (
-/obj/item/storage/box/handcuffs,
-/obj/structure/table/ms13/metal,
-/turf/open/floor/ms13/metal,
-/area/ms13/underground/bos)
 "aYr" = (
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/open/floor/plating/ms13/ground/mountain,
@@ -14190,6 +14183,7 @@
 /obj/structure/table/ms13/no_smooth/counter/wood{
 	dir = 4
 	},
+/obj/effect/spawner/random/ms13/drink/alcohol,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/underground/vault_atrium_lower)
 "aZq" = (
@@ -14747,6 +14741,13 @@
 /obj/structure/ms13/skeleton,
 /turf/open/floor/plating/ms13/ground/mountain,
 /area/ms13/underground/underground_town)
+"kSv" = (
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 8
+	},
+/obj/structure/bonfire/ms13/fire_barrel/prelit,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/underground/vault_atrium_lower)
 "kSH" = (
 /obj/structure/ms13/storage/shelf{
 	dir = 8
@@ -15094,6 +15095,13 @@
 /obj/effect/spawner/random/ms13/crafting/electrical,
 /turf/open/floor/ms13/metal/plate,
 /area/ms13/underground/sewer)
+"xfy" = (
+/obj/structure/table/ms13/metal,
+/obj/item/restraints/handcuffs,
+/obj/item/restraints/handcuffs,
+/obj/item/restraints/handcuffs,
+/turf/open/floor/ms13/metal,
+/area/ms13/underground/bos)
 "xhI" = (
 /obj/structure/chair/ms13/overlaypickup/plastic{
 	dir = 8
@@ -26713,7 +26721,7 @@ aoM
 avf
 aZp
 saV
-aZp
+saV
 aUB
 aLe
 aLe
@@ -28527,7 +28535,7 @@ aEI
 aEI
 aEI
 aEI
-aRG
+kSv
 aLe
 aoM
 aLy
@@ -28828,7 +28836,7 @@ aoM
 aLe
 aLe
 aLe
-aMA
+aLe
 aRG
 aLe
 aoM
@@ -72955,7 +72963,7 @@ aJn
 azt
 azt
 alU
-amo
+xfy
 azt
 azt
 aBU
@@ -73257,7 +73265,7 @@ aFL
 aGH
 azt
 alU
-aYq
+amo
 azt
 azt
 aBU

--- a/mojave/effects/spawners/lootdrop/drinkloot.dm
+++ b/mojave/effects/spawners/lootdrop/drinkloot.dm
@@ -23,7 +23,7 @@
 /obj/effect/spawner/random/ms13/drink/soda_uncommon
 	name = "uncommon cola spawner"
 	icon_state = "ms13_cola"
-	spawn_loot_chance = 25
+	spawn_loot_chance = 35
 	loot = list(
 		/obj/item/reagent_containers/food/drinks/soda_cans/ms13/nuka_quartz,
 		/obj/item/reagent_containers/food/drinks/soda_cans/ms13/nuka_cranberry,
@@ -62,7 +62,7 @@
 /obj/effect/spawner/random/ms13/drink/alcohol_beer
 	name = "beer spawner"
 	icon_state = "ms13_beer"
-	spawn_loot_chance = 35
+	spawn_loot_chance = 40
 
 	loot = list(
 		/obj/item/reagent_containers/food/drinks/bottle/ms13/trooper_beer,
@@ -73,7 +73,7 @@
 /obj/effect/spawner/random/ms13/drink/alcohol_uncommon // Breathe some artificial inflation up in there
 	name = "uncommon alcohol spawner"
 	icon_state = "ms13_alcohol"
-	spawn_loot_chance = 25
+	spawn_loot_chance = 35
 
 	loot = list(
 		/obj/item/reagent_containers/food/drinks/bottle/ms13/sake,

--- a/mojave/items/dogtags.dm
+++ b/mojave/items/dogtags.dm
@@ -137,7 +137,7 @@
 /obj/item/card/id/ms13/sawbone
 	name = "sawbone's patch"
 	desc = "A nice rectangular patch with a little hole to loop a string through if you really wanted to. It's a bit bloody."
-	assignment = "Raider Sawbones"
+	assignment = "Raider Sawbone"
 	icon_state = "sawbone"
 
 /obj/item/card/id/ms13/enforcer
@@ -185,22 +185,22 @@
 	icon_state = "bos_holotag"
 
 /obj/item/card/id/ms13/bos/headpaladin
-	assignment = "Head Paladin"
+	assignment = "BoS Head Paladin"
 
 /obj/item/card/id/ms13/bos/paladin
-	assignment = "Paladin"
+	assignment = "BoS Paladin"
 
 /obj/item/card/id/ms13/bos/knight
-	assignment = "Knight"
+	assignment = "BoS Knight"
 
 /obj/item/card/id/ms13/bos/initiate
-	assignment = "Initiate"
+	assignment = "BoS Initiate"
 
 /obj/item/card/id/ms13/bos/headscribe
-	assignment = "Head Scribe"
+	assignment = "BoS Head Scribe"
 
 /obj/item/card/id/ms13/bos/scribe
-	assignment = "Scribe"
+	assignment = "BoS Scribe"
 
 // Combat Test IDs //
 

--- a/mojave/items/storage/storage.dm
+++ b/mojave/items/storage/storage.dm
@@ -47,6 +47,7 @@
 	new /obj/item/stack/medical/gauze/ms13/half(src)
 	new /obj/item/stack/medical/suture/ms13/four(src)
 	new /obj/item/stack/medical/ointment/ms13/cream/half(src)
+	new /obj/item/bonesetter(src)
 
 // Lollipop jar
 

--- a/mojave/jobs/job_types/raiders/sawbone.dm
+++ b/mojave/jobs/job_types/raiders/sawbone.dm
@@ -1,5 +1,5 @@
 /datum/job/ms13/raiders/sawbone
-	title = "Sawbone"
+	title = "Raider Sawbone"
 	total_positions = 2
 	spawn_positions = 2
 	supervisors = "The Boss and the Enforcer"

--- a/mojave/machinery/terminals.dm
+++ b/mojave/machinery/terminals.dm
@@ -442,6 +442,11 @@
 		icon_state = "[base_icon_state]"
 	FXtoggle()
 
+/obj/machinery/ms13/terminal/wall/examine(mob/user)
+	. = ..()
+	if(flippable)
+		. += span_notice("You can flip [src] up and down using <b>ALT+CLICK.</b>")
+
 /obj/machinery/ms13/terminal/wall/pristine
 	icon_state = "wallterminal_new"
 	base_icon_state = "wallterminal_new"

--- a/mojave/modules/crafting/recipes/recipes.dm
+++ b/mojave/modules/crafting/recipes/recipes.dm
@@ -869,6 +869,39 @@
 	category = CAT_WEAPONS
 	crafting_interface = CRAFTING_BENCH_WEAPONS
 
+/datum/crafting_recipe/brass_knuckle
+	name = "brass knuckle"
+	result = /obj/item/ms13/knuckles
+	time = 8 SECONDS
+	tool_behaviors = list()
+	tool_paths = list(/obj/item/ms13/hammer)
+	reqs = list(/obj/item/stack/sheet/ms13/scrap_brass = 8)
+	category = CAT_WEAPONS
+	crafting_interface = CRAFTING_BENCH_GENERAL | CRAFTING_BENCH_WEAPONS
+
+/datum/crafting_recipe/steel_knuckle
+	name = "steel knuckle"
+	result = /obj/item/ms13/knuckles/weighted
+	time = 12 SECONDS
+	tool_behaviors = list()
+	tool_paths = list(/obj/item/ms13/hammer)
+	reqs = list(/obj/item/stack/sheet/ms13/scrap_steel = 7,
+				/obj/item/stack/sheet/ms13/scrap = 7)
+	category = CAT_WEAPONS
+	crafting_interface = CRAFTING_BENCH_WEAPONS
+
+/datum/crafting_recipe/spiked_knuckle
+	name = "spiked knuckle"
+	result = /obj/item/ms13/knuckles/weighted/spiked
+	time = 15 SECONDS
+	tool_behaviors = list(TOOL_WELDER)
+	tool_paths = list(/obj/item/ms13/hammer)
+	reqs = list(/obj/item/ms13/knuckles/weighted = 1,
+				/obj/item/stack/sheet/ms13/refined_steel = 3,
+				/obj/item/stack/sheet/ms13/scrap_parts = 5)
+	category = CAT_WEAPONS
+	crafting_interface = CRAFTING_BENCH_WEAPONS
+
 //ELECTRONICS CRAFTING
 
 /datum/crafting_recipe/shart_flashlight

--- a/mojave/structures/fires.dm
+++ b/mojave/structures/fires.dm
@@ -90,7 +90,7 @@
 	start_burning()
 
 /obj/structure/bonfire/ms13/fire_barrel/start_burning()
-	if(burning || !check_oxygen())
+	if(burning)
 		return
 	icon_state = burn_icon
 	burning = TRUE

--- a/mojave/structures/obstacles.dm
+++ b/mojave/structures/obstacles.dm
@@ -8,7 +8,7 @@
 
 /obj/structure/ms13/bars
 	name = "metal bars"
-	desc = "Sturdy metal bars. If only you had a saw."
+	desc = "Sturdy metal bars."
 	icon = 'mojave/icons/obstacles/tallobstacles.dmi'
 	icon_state = "bars"
 	density = TRUE
@@ -29,11 +29,24 @@
 /obj/structure/ms13/bars/attackby(obj/item/W, mob/user, params)
 	if(W.tool_behaviour == TOOL_SAW)
 		user.show_message(span_notice("You begin sawing through the bars."), MSG_VISUAL)
-		if(do_after(user, 60 SECONDS, target = src, interaction_key = DOAFTER_SOURCE_DECON)) 
+		if(do_after(user, 45 SECONDS, target = src, interaction_key = DOAFTER_SOURCE_DECON)) 
 			user.show_message(span_notice("You saw through the bars!"), MSG_VISUAL)
 			deconstruct()
 			return TRUE
-	
+
+/obj/structure/ms13/bars/welder_act(mob/living/user, obj/item/I)
+	if(!I.tool_start_check(user, amount=0))
+		return TRUE
+	if(I.use_tool(src, user, 20 SECONDS, volume=80))
+		deconstruct(disassembled = TRUE)
+		return TRUE
+
+/obj/structure/ms13/bars/examine(mob/user)
+	. = ..()
+	. += deconstruction_hints(user)
+
+/obj/structure/ms13/bars/proc/deconstruction_hints(mob/user)
+	return span_notice("You could use a <b>saw</b> or <b>welding tool</b> to cut through [src].")
 
 /obj/structure/ms13/bars/corner
 	icon_state = "barscorner"


### PR DESCRIPTION
## About The Pull Request

Adds some alcohol spawners to Town bar and some food spawners to Town mess hall. Adds some extra doctor's bags to faction bases. Fixes Raider Sawbones preferences. Shows a hint for flipping the wall terminals up and down. Deconstruction tip for metal bars, speed buff, and you can do it with a welder for a mega speed buff. Slight buff to less common drink spawners. Fix for prelit fire barrels not being... prelit. Adds bonesetters to doctor's bags. 

## Why It's Good For The Game

Adjusting and bug fixing after tests is important.