### PR TITLE
Blood Gang

### DIFF
--- a/mojave/effects/spawners/lootdrop/medicalloot.dm
+++ b/mojave/effects/spawners/lootdrop/medicalloot.dm
@@ -56,14 +56,9 @@
 
 /obj/effect/spawner/random/ms13/medical/bloodbag
 	name = "blood bag spawner"
-	spawn_loot_count = 2
-	spawn_loot_chance = 100
+	spawn_loot_count = 1
+	spawn_loot_chance = 65
 	loot = list(
-			/obj/item/reagent_containers/blood/ms13/a_plus = 15,
-			/obj/item/reagent_containers/blood/ms13/a_minus = 15,
-			/obj/item/reagent_containers/blood/ms13/b_plus = 15,
-			/obj/item/reagent_containers/blood/ms13/b_minus = 15,
-			/obj/item/reagent_containers/blood/ms13/o_plus = 15,
-			/obj/item/reagent_containers/blood/ms13/o_minus = 10,
-			/obj/item/reagent_containers/blood/ms13/radaway = 15
+			/obj/item/reagent_containers/blood/ms13/universal = 80,
+			/obj/item/reagent_containers/blood/ms13/radaway = 20
 			)

--- a/mojave/effects/spawners/lootdrop/medicalloot.dm
+++ b/mojave/effects/spawners/lootdrop/medicalloot.dm
@@ -59,6 +59,6 @@
 	spawn_loot_count = 1
 	spawn_loot_chance = 65
 	loot = list(
-			/obj/item/reagent_containers/blood/ms13/universal = 80,
+			/obj/item/reagent_containers/blood/ms13/o_minus = 80,
 			/obj/item/reagent_containers/blood/ms13/radaway = 20
 			)

--- a/mojave/items/food/fish.dm
+++ b/mojave/items/food/fish.dm
@@ -4,7 +4,7 @@
 	name = "fish"
 	desc = "You shouldn't be seeing this."
 	icon = 'mojave/icons/objects/food/fish/fish_world.dmi'
-	food_reagents = list(/datum/reagent/consumable/nutriment/protein = 4)
+	food_reagents = list(/datum/reagent/consumable/nutriment/protein = 8, /datum/reagent/consumable/nutriment/vitamin = 4)
 	foodtypes = MEAT | RAW
 	//Tells the initialize function which icon to pick
 	var/fish_type = "fish"
@@ -169,7 +169,7 @@
 	icon = 'mojave/icons/objects/food/fish/fish_world.dmi'
 	icon_state = "sockeye_cutlet"
 	bite_consumption = 4
-	food_reagents = list(/datum/reagent/consumable/nutriment/protein = 6, /datum/reagent/consumable/nutriment/vitamin = 2)
+	food_reagents = list(/datum/reagent/consumable/nutriment/protein = 3, /datum/reagent/consumable/nutriment/vitamin = 2)
 	tastes = list("fish" = 5)
 	foodtypes = MEAT
 

--- a/mojave/items/food/fish.dm
+++ b/mojave/items/food/fish.dm
@@ -4,6 +4,7 @@
 	name = "fish"
 	desc = "You shouldn't be seeing this."
 	icon = 'mojave/icons/objects/food/fish/fish_world.dmi'
+	bite_consumption = 4
 	food_reagents = list(/datum/reagent/consumable/nutriment/protein = 8, /datum/reagent/consumable/nutriment/vitamin = 4)
 	foodtypes = MEAT | RAW
 	//Tells the initialize function which icon to pick
@@ -93,8 +94,8 @@
 	icon = 'mojave/icons/objects/food/fish/fish_world.dmi'
 	icon_state = "sockeye_cutlet"
 	var/fish_cooked_type = /obj/item/food/meat/cutlet/ms13/fish
-	bite_consumption = 4
-	food_reagents = list(/datum/reagent/consumable/nutriment/protein = 4)
+	bite_consumption = 3
+	food_reagents = list(/datum/reagent/consumable/nutriment/protein = 3)
 	tastes = list("fish" = 8)
 	foodtypes = MEAT | RAW
 
@@ -168,7 +169,7 @@
 	desc = "A cooked fish fillet."
 	icon = 'mojave/icons/objects/food/fish/fish_world.dmi'
 	icon_state = "sockeye_cutlet"
-	bite_consumption = 4
+	bite_consumption = 5
 	food_reagents = list(/datum/reagent/consumable/nutriment/protein = 3, /datum/reagent/consumable/nutriment/vitamin = 2)
 	tastes = list("fish" = 5)
 	foodtypes = MEAT

--- a/mojave/items/food/fish.dm
+++ b/mojave/items/food/fish.dm
@@ -4,8 +4,8 @@
 	name = "fish"
 	desc = "You shouldn't be seeing this."
 	icon = 'mojave/icons/objects/food/fish/fish_world.dmi'
-	bite_consumption = 5
-	food_reagents = list(/datum/reagent/consumable/nutriment/protein = 10)
+	bite_consumption = 4
+	food_reagents = list(/datum/reagent/consumable/nutriment/protein = 8)
 	foodtypes = MEAT | RAW
 	//Tells the initialize function which icon to pick
 	var/fish_type = "fish"
@@ -169,8 +169,8 @@
 	desc = "A cooked fish fillet."
 	icon = 'mojave/icons/objects/food/fish/fish_world.dmi'
 	icon_state = "sockeye_cutlet"
-	bite_consumption = 4
-	food_reagents = list(/datum/reagent/consumable/nutriment/protein = 3, /datum/reagent/consumable/nutriment/vitamin = 1)
+	bite_consumption = 5
+	food_reagents = list(/datum/reagent/consumable/nutriment/protein = 4, /datum/reagent/consumable/nutriment/vitamin = 1)
 	tastes = list("fish" = 5)
 	foodtypes = MEAT
 

--- a/mojave/items/food/fish.dm
+++ b/mojave/items/food/fish.dm
@@ -4,8 +4,8 @@
 	name = "fish"
 	desc = "You shouldn't be seeing this."
 	icon = 'mojave/icons/objects/food/fish/fish_world.dmi'
-	bite_consumption = 4
-	food_reagents = list(/datum/reagent/consumable/nutriment/protein = 8, /datum/reagent/consumable/nutriment/vitamin = 4)
+	bite_consumption = 5
+	food_reagents = list(/datum/reagent/consumable/nutriment/protein = 10)
 	foodtypes = MEAT | RAW
 	//Tells the initialize function which icon to pick
 	var/fish_type = "fish"
@@ -169,8 +169,8 @@
 	desc = "A cooked fish fillet."
 	icon = 'mojave/icons/objects/food/fish/fish_world.dmi'
 	icon_state = "sockeye_cutlet"
-	bite_consumption = 5
-	food_reagents = list(/datum/reagent/consumable/nutriment/protein = 3, /datum/reagent/consumable/nutriment/vitamin = 2)
+	bite_consumption = 4
+	food_reagents = list(/datum/reagent/consumable/nutriment/protein = 3, /datum/reagent/consumable/nutriment/vitamin = 1)
 	tastes = list("fish" = 5)
 	foodtypes = MEAT
 

--- a/mojave/items/medical/IV_bags.dm
+++ b/mojave/items/medical/IV_bags.dm
@@ -26,9 +26,6 @@
 /obj/item/reagent_containers/blood/ms13/o_minus
 	blood_type = "O-"
 
-/obj/item/reagent_containers/blood/ms13/universal
-	blood_type = "U"
-
 //Misc//
 
 /obj/item/reagent_containers/blood/ms13/radaway

--- a/mojave/items/medical/IV_bags.dm
+++ b/mojave/items/medical/IV_bags.dm
@@ -26,6 +26,9 @@
 /obj/item/reagent_containers/blood/ms13/o_minus
 	blood_type = "O-"
 
+/obj/item/reagent_containers/blood/ms13/universal
+	blood_type = "U"
+
 //Misc//
 
 /obj/item/reagent_containers/blood/ms13/radaway


### PR DESCRIPTION
## About The Pull Request

The only bloodbags that spawn are now either O- or Radaway (for dealing with toxin damage), bloodbag spawners will probably need to get looked at with these changes and their spawn chances changed in mind. Also gives fish the vitamin reagent which slightly helps with regenerating blood but more noticeably helps with healing brute and burn damage by a very minor amount. Food is now a semi-valid healing method if you are seriously, seriously in a pinch.

## Why It's Good For The Game

One of the ways to address bloodloss is just making bloodbags universal, especially since we have no ways to detect bloodtypes. Food probably needed a buff as well, and here it is.