### PR TITLE
Transfers drag slowdown to base /obj instead of /obj/item

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -208,7 +208,6 @@ GLOBAL_DATUM_INIT(fire_overlay, /mutable_appearance, mutable_appearance('icons/e
 
 //MOJAVE EDIT CHANGE BEGIN
 	var/log_pickup_and_drop = FALSE //For logging in the attack logs certain items (mostly weapons) being equipped, dropped, or taken into hand
-	drag_slowdown = 2 // This is a cover-all. That way no matter what, you won't be able to cheese stuff and we won't have to run around in a weird cat and mouse game to nerf dragging some vague item.
 //MOJAVE EDIT CHANGE END
 
 	/// Used in obj/item/examine to give additional notes on what the weapon does, separate from the predetermined output variables

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -26,7 +26,7 @@
 
 	var/renamedByPlayer = FALSE //set when a player uses a pen on a renamable object
 
-	var/drag_slowdown // Amont of multiplicative slowdown applied if pulled. >1 makes you slower, <1 makes you faster.
+	var/drag_slowdown = 2 // Amont of multiplicative slowdown applied if pulled. >1 makes you slower, <1 makes you faster. // Mojave Sun edit - So that no matter what, shit can't be drag exploited | Original is "var/drag_slowdown // Amont of multiplicative slowdown applied if pulled. >1 makes you slower, <1 makes you faster."
 
 	vis_flags = VIS_INHERIT_PLANE //when this be added to vis_contents of something it inherit something.plane, important for visualisation of obj in openspace.
 


### PR DESCRIPTION
I was ignorant and forgot to change this before Koshenko merged my PR all of 2 seconds ago. SPEEDMERGE.

This is because I didn't (at the time) count on the fact that not everything exploitable is going to be an item subtype. A big recent one is  IV drips- It's better to get /everything/ in this.