### PR TITLE
Buffs medical consumable items

### DIFF
--- a/mojave/items/medical/stack_medical.dm
+++ b/mojave/items/medical/stack_medical.dm
@@ -31,7 +31,7 @@
     self_delay = 3.5 SECONDS
     other_delay = 2 SECONDS
     repeating = FALSE
-    heal_brute = 8
+    heal_brute = 10
     stop_bleeding = 0.75
     gender = NEUTER //So examine text says "This is a suture" instead of "These are some suture"
     merge_type = /obj/item/stack/medical/suture/ms13
@@ -60,7 +60,7 @@
     repeating = FALSE
     self_delay = 2.5 SECONDS
     other_delay = 1.5 SECONDS
-    heal_burn = 8
+    heal_burn = 10
     flesh_regeneration = 3.5
     sanitization = 1.25
     gender = NEUTER //So examine text says "This is a bottle of ointment" instead of "These are some bottle of ointment"
@@ -78,7 +78,7 @@
     inhand_icon_state = "aloe"
     amount = 10
     max_amount = 10
-    heal_burn = 4
+    heal_burn = 5
     flesh_regeneration = 2
     sanitization = 0.5
     gender = PLURAL
@@ -89,7 +89,7 @@
     desc = "A small container of healing cream meant for burn related injuries."
     icon_state = "burncream"
     inhand_icon_state = "burncream"
-    heal_burn = 6
+    heal_burn = 8
     flesh_regeneration = 2.75
     sanitization = 0.75
     gender = PLURAL
@@ -114,7 +114,7 @@
     absorption_rate = 0.12
     absorption_capacity = 5
     splint_factor = 0.6
-    burn_cleanliness_bonus = 0.6
+    burn_cleanliness_bonus = 0.5
     merge_type = /obj/item/stack/medical/gauze/ms13
 
 /obj/item/stack/medical/gauze/ms13/attackby(obj/item/I, mob/user, params)
@@ -141,5 +141,5 @@
     absorption_rate = 0.18
     absorption_capacity = 6.5
     splint_factor = 0.5 //Lower = better
-    burn_cleanliness_bonus = 0.4 //Lower = better
+    burn_cleanliness_bonus = 0.3 //Lower = better
     merge_type = /obj/item/stack/medical/gauze/ms13/military

--- a/mojave/items/storage/storage.dm
+++ b/mojave/items/storage/storage.dm
@@ -37,6 +37,7 @@
 	new /obj/item/stack/medical/gauze/ms13(src)
 	new /obj/item/stack/medical/suture/ms13(src)
 	new /obj/item/stack/medical/ointment/ms13/cream(src)
+	new /obj/item/reagent_containers/hypospray/medipen/ms13/stimpak(src)
 
 /obj/item/storage/firstaid/ms13/quality
 
@@ -46,6 +47,7 @@
 	new /obj/item/stack/medical/suture/ms13(src)
 	new /obj/item/stack/medical/ointment/ms13(src)
 	new /obj/item/reagent_containers/hypospray/medipen/ms13/stimpak(src)
+	new /obj/item/reagent_containers/hypospray/medipen/ms13/stimpak/super(src)
 
 /obj/item/storage/firstaid/ms13/bag
 	name = "doctors bag"

--- a/mojave/items/tools/lighting.dm
+++ b/mojave/items/tools/lighting.dm
@@ -52,7 +52,7 @@
 /obj/item/flashlight/flare/ms13/Initialize()
 	. = ..()
 	AddElement(/datum/element/inworld_sprite, 'mojave/icons/objects/tools/tools_inventory.dmi')
-	fuel = rand(900, 1200) //This is remaining fuel in seconds, so this puts every flare at between 15-20 minutes of life time.
+	fuel = rand(720, 1080) //This is remaining fuel in seconds, so this puts every flare at between 12-18 minutes of life time.
 
 /obj/item/flashlight/flare/torch/ms13
 	name = "torch"

--- a/mojave/items/tools/lighting.dm
+++ b/mojave/items/tools/lighting.dm
@@ -52,7 +52,7 @@
 /obj/item/flashlight/flare/ms13/Initialize()
 	. = ..()
 	AddElement(/datum/element/inworld_sprite, 'mojave/icons/objects/tools/tools_inventory.dmi')
-	fuel = rand(720, 1080) //This is remaining fuel in seconds, so this puts every flare at between 12-18 minutes of life time.
+	fuel = rand(900, 1200) //This is remaining fuel in seconds, so this puts every flare at between 15-20 minutes of life time.
 
 /obj/item/flashlight/flare/torch/ms13
 	name = "torch"


### PR DESCRIPTION
## About The Pull Request

Basically does what it says on the tin, buffs basically every medical consumable item. Ointment, cream, and aloe heal more burn and sutures heal more brute. Gauze also is better at keeping burn wounds clean. Also adds a single stimpack to basic first aid kits and a regular stim and super stim into the quality first aid kit. This is barely a balance concern because there are _literally_ like two quality first aid kits on Mammoth and I think both are in some kind of high tier dungeon I reckon. I considered buffing stims a tad as well but with Scar's chem rework around the corner it seemed un-needed. 

## Why It's Good For The Game

Making changes based on feedback is good. 