### PR TITLE
Modifies sound levels of the sentry bot

### DIFF
--- a/mojave/code/modules/mob/living/simple_animal/hostile/sentrybot.dm
+++ b/mojave/code/modules/mob/living/simple_animal/hostile/sentrybot.dm
@@ -112,7 +112,7 @@ GLOBAL_LIST_INIT(sentrybot_dying_sound, list(
 	mid_length = 1
 	end_sound = 'mojave/sound/ms13npc/sentrybot/treads_end.mp3'
 	vary = FALSE
-	volume = 50
+	volume = 25
 
 /mob/living/simple_animal/hostile/ms13/robot/sentrybot/Initialize()
 	. = ..()
@@ -127,7 +127,7 @@ GLOBAL_LIST_INIT(sentrybot_dying_sound, list(
 	SIGNAL_HANDLER
 	//playsound(src, 'sound/mecha/mechstep.ogg', 40, TRUE)
 	last_move_done_at = world.time
-	addtimer(CALLBACK(src, .proc/check_if_loop_should_continue, world.time), move_to_delay + 0.8 SECONDS)
+	addtimer(CALLBACK(src, .proc/check_if_loop_should_continue, world.time), move_to_delay + 0.5 SECONDS)
 	/*
 	if(drift_cooldown > world.time) //Special move cooldown + drifting shouldn't restart the tread sounds
 		return
@@ -191,7 +191,7 @@ GLOBAL_LIST_INIT(sentrybot_dying_sound, list(
 		return
 	var/random_speech = pick(glob_list_used)
 	speech_cooldown = world.time + glob_list_used[random_speech]
-	playsound(src, random_speech, 50, FALSE)
+	playsound(src, random_speech, 80, FALSE)
 
 /mob/living/simple_animal/hostile/ms13/robot/sentrybot/Destroy()
 	QDEL_NULL(rocket)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Movement treads are quieter while voice lines are louder alongside quicker end to looping treads should movement no longer happen
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
You can hear the voicelines easier without being droned out by laser fire and moving treads
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: ma44
soundadd: Sentrybot's voicelines are louder and treads are quieter
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
