### PR TITLE
Post Community Meeting Tweaks

### DIFF
--- a/mojave/code/modules/mob/living/basic/robots.dm
+++ b/mojave/code/modules/mob/living/basic/robots.dm
@@ -60,8 +60,8 @@
     attack_verb_simple = "pinch"
     attack_sound = 'mojave/sound/ms13weapons/meleesounds/pipe_hit.ogg'
     sharpness = NONE
-    wound_bonus = 8
-    bare_wound_bonus = 4
+    wound_bonus = 5
+    bare_wound_bonus = 5
     shadow_type = "shadow_large"
 
 /mob/living/basic/ms13/robot/handy/New()
@@ -85,7 +85,7 @@
     subtractible_armour_penetration = 15
     sharpness = SHARP_EDGED
     wound_bonus = 8
-    bare_wound_bonus = 12
+    bare_wound_bonus = 10
     attack_verb_continuous = "saws"
     attack_verb_simple = "saw"
     attack_sound = list('mojave/sound/ms13weapons/meleesounds/ripper_hit1.ogg', 'mojave/sound/ms13weapons/meleesounds/ripper_hit2.ogg')

--- a/mojave/code/modules/mob/living/simple_animal/hostile/sentrybot.dm
+++ b/mojave/code/modules/mob/living/simple_animal/hostile/sentrybot.dm
@@ -422,7 +422,7 @@ GLOBAL_LIST_INIT(sentrybot_dying_sound, list(
 	sharpness = SHARP_POINTY
 	wound_bonus = 10
 	bare_wound_bonus = 15
-	embedding = list("embedded_pain_multiplier" = 2, "embed_chance" = 50, "embedded_fall_chance" = 10, "ignore_throwspeed_threshold" = TRUE)
+	embedding = list("embedded_pain_multiplier" = 1, "embed_chance" = 50, "embedded_fall_chance" = 10, "ignore_throwspeed_threshold" = TRUE)
 
 //A flamethrower that's essentially a forward facing backblast of the rocket launcher
 /datum/action/cooldown/flamethrow

--- a/mojave/code/modules/mob/mob_projectiles.dm
+++ b/mojave/code/modules/mob/mob_projectiles.dm
@@ -99,13 +99,27 @@
 	impact_light_intensity = 5
 	impact_light_range = 1.25
 
+/obj/item/ammo_casing/ms13/nail/protectron
+	projectile_type = /obj/projectile/bullet/ms13/nail/protectron
+	variance = 22
+	pellets = 1
+	fire_sound = 'mojave/sound/ms13weapons/gunsounds/nailgun/nailgun_single.ogg'
+	randomspread = TRUE
+
+/obj/item/ammo_casing/ms13/nail/protectron/fire_casing(atom/target, mob/living/user, params, distro, quiet, zone_override, spread, atom/fired_from, extra_damage, extra_penetration)
+	. = ..()
+	if(. && !QDELETED(src))
+		qdel(src)
+
 /obj/projectile/bullet/ms13/nail/protectron
+	name = "nail"
 	icon_state = "nail"
 	damage = 15
-	armour_penetration = 5
-	wound_bonus = 2
-	wound_bonus = WOUND_MINIMUM_DAMAGE
-	embedding = list(embed_chance=85, fall_chance=2, jostle_chance=0, ignore_throwspeed_threshold=TRUE, pain_stam_pct=0.5, pain_mult=3, rip_time=10)
+	subtractible_armour_penetration = 5
+	wound_bonus = 5
+	bare_wound_bonus = 10
+	sharpness = SHARP_POINTY
+	embedding = list("embedded_pain_multiplier" = 2, "embed_chance" = 60, "embedded_fall_chance" = 20, "ignore_throwspeed_threshold" = TRUE)
 
 // Robobrain Projectiles //
 

--- a/mojave/code/modules/mob/robots/handies.dm
+++ b/mojave/code/modules/mob/robots/handies.dm
@@ -11,8 +11,8 @@
 	move_to_delay = 3
 	speed = 1
 	sharpness = NONE
-	wound_bonus = 5
-	bare_wound_bonus = 2
+	wound_bonus = 4
+	bare_wound_bonus = 4
 	speak_emote = list("states", "says")
 	attack_verb_continuous = "pinches"
 	attack_verb_simple = "pinch"
@@ -69,8 +69,8 @@
 	melee_damage_lower = 20
 	melee_damage_upper = 20
 	subtractible_armour_penetration = 15
-	wound_bonus = 8
-	bare_wound_bonus = 4
+	wound_bonus = 6
+	bare_wound_bonus = 6
 	minimum_distance = 2
 	retreat_distance = 3
 	loot = list(/obj/item/stack/sheet/ms13/scrap_steel/two, /obj/effect/decal/cleanable/robot_debris, /obj/item/stack/sheet/ms13/scrap_electronics/two, /obj/item/stack/sheet/ms13/scrap_parts/two, /obj/item/ms13/component/plasma_battery, /obj/item/stack/sheet/ms13/circuits)

--- a/mojave/code/modules/mob/robots/protectrons.dm
+++ b/mojave/code/modules/mob/robots/protectrons.dm
@@ -83,25 +83,30 @@
 		ranged_cooldown = 5 SECONDS
 
 /mob/living/simple_animal/hostile/ms13/robot/protectron/builder
+	name = "builder protectron"
 	desc = "A heavy duty protectron that is equipped with basic tools in order to aid construction workers. Stay clear!"
 	icon_state = "protectron_builder"
 	icon_living = "protectron_builder"
-	melee_damage_lower = 20
-	melee_damage_upper = 20
-	wound_bonus = -5
-	bare_wound_bonus = 5
-	rapid = 2
-	rapid_fire_delay = 3
-	projectiletype = /obj/projectile/bullet/ms13/nail/protectron
+	melee_damage_lower = 15
+	melee_damage_upper = 15
+	subtractible_armour_penetration = 15
+	wound_bonus = 5
+	bare_wound_bonus = 0
+	rapid = 5
+	rapid_fire_delay = 0.35 SECONDS //5 nails over 1.75 seconds
+	ranged_cooldown = 5.75 SECONDS //Then a 4 second delay
+	casingtype = /obj/item/ammo_casing/ms13/nail/protectron
 	projectilesound = 'mojave/sound/ms13weapons/gunsounds/nailgun/nailgun_single.ogg'
+	minimum_distance = 3
+	retreat_distance = 6
 
 /mob/living/simple_animal/hostile/ms13/robot/protectron/reinforced
 	name = "reinforced protectron"
 	desc = "A high security variant of a protectron. Built to last and keep up to harsh punishment, the unaging guard that doesn't require payment."
 	icon_state = "protectron_reinforced"
 	icon_living = "protectron_reinforced"
-	health = 210
-	maxHealth = 210
+	health = 200
+	maxHealth = 200
 	melee_damage_lower = 15
 	melee_damage_upper = 15
 	subtractible_armour_penetration = 5

--- a/mojave/effects/spawners/lootdrop/guarenteed/miscloot.dm
+++ b/mojave/effects/spawners/lootdrop/guarenteed/miscloot.dm
@@ -156,3 +156,15 @@
 			/obj/item/stack/sheet/ms13/refined_silver/two = 10,
 			/obj/item/stack/sheet/ms13/refined_gold/two = 10
 	)
+
+/obj/effect/spawner/random/ms13/guarenteed/crafting/refined
+	name = "refined metals spawner"
+	loot = list(
+			/obj/item/stack/sheet/ms13/refined_silver/two,
+			/obj/item/stack/sheet/ms13/refined_gold/two,
+			/obj/item/stack/sheet/ms13/refined_alu/two,
+			/obj/item/stack/sheet/ms13/refined_brass/two,
+			/obj/item/stack/sheet/ms13/refined_lead/two,
+			/obj/item/stack/sheet/ms13/refined_steel/two,
+			/obj/item/stack/sheet/ms13/refined_copper/two
+	)

--- a/mojave/effects/spawners/lootdrop/miscloot.dm
+++ b/mojave/effects/spawners/lootdrop/miscloot.dm
@@ -178,5 +178,5 @@
 			/obj/item/stack/sheet/ms13/refined_brass/two,
 			/obj/item/stack/sheet/ms13/refined_lead/two,
 			/obj/item/stack/sheet/ms13/refined_steel/two,
-			/obj/item/stack/sheet/ms13/refined_copper/two,
+			/obj/item/stack/sheet/ms13/refined_copper/two
 	)

--- a/mojave/items/medical/stack_medical.dm
+++ b/mojave/items/medical/stack_medical.dm
@@ -227,6 +227,8 @@
 	desc = "A potent healing balm pouch, containing a mixture of various chemicals. The back says something about danger and keeping it away from the eyes."
 	singular_name = "balm pouch"
 	icon_state = "balm"
+	self_delay = 2.5 SECONDS
+	other_delay = 2 SECONDS
 	amount = 8
 	max_amount = 8
 	heal_brute = 12

--- a/mojave/structures/storage/crates.dm
+++ b/mojave/structures/storage/crates.dm
@@ -170,7 +170,7 @@
 	desc = "Useful for storing blood, organs, or just about whatever you could wish for. Has some handles and rollers under it for transporation, but is very bulky."
 	icon_state = "medical"
 	anchored = FALSE
-	drag_slowdown = 0.5
+	drag_slowdown = 1
 	material_drop = /obj/item/stack/sheet/ms13/scrap
 	material_drop_amount = 2
 

--- a/mojave/structures/table.dm
+++ b/mojave/structures/table.dm
@@ -271,7 +271,7 @@
 	frame = /obj/item/stack/sheet/ms13/scrap
 	framestack = /obj/item/stack/sheet/ms13/scrap
 	framestackamount = 2
-	drag_slowdown = 0.5
+	drag_slowdown = 1
 
 ///// CRAFTING TABLES /////
 


### PR DESCRIPTION
## About The Pull Request

I wanted to throw up a PR with some misc. stuff after the community meeting before I do other things so I don't have a bunch of unatomized PRs. This basically just nerfs the handies a bit, adds a delay to the balm pouch, increases drag slowdown on medical crates and rolling tables, makes the Builder Protectron finally balanced and therefore more usable, and adds in the missing guaranteed refined metals spawner that I forgot to add in my last PR. 

## Why It's Good For The Game

The new Builder Protectron is awesome
