### PR TITLE
Mining Facility Area Touchup

### DIFF
--- a/_maps/map_files/Mammoth/Mammoth.dmm
+++ b/_maps/map_files/Mammoth/Mammoth.dmm
@@ -12090,6 +12090,7 @@
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 4
 	},
+/obj/effect/spawner/random/ms13/melee/lowrandom,
 /turf/open/floor/plating/ms13/ground/mountain,
 /area/ms13/underground/mountain)
 "hHp" = (
@@ -14112,7 +14113,6 @@
 /turf/open/floor/ms13/metal/grate/border,
 /area/ms13/underground/vault_atrium_middle)
 "iQA" = (
-/obj/effect/spawner/random/ms13/melee/tier2,
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 5
 	},
@@ -14850,7 +14850,6 @@
 "jlB" = (
 /obj/effect/decal/cleanable/blood,
 /obj/effect/decal/cleanable/blood/gibs,
-/obj/effect/spawner/random/ms13/gun/tier3,
 /turf/open/floor/plating/ms13/ground/mountain,
 /area/ms13/underground/mountain)
 "jlM" = (
@@ -21693,7 +21692,7 @@
 /turf/open/floor/ms13/tile/large/cream,
 /area/ms13/supermarket)
 "nNR" = (
-/obj/effect/spawner/random/ms13/ammo/tier3,
+/obj/effect/spawner/random/ms13/melee/highrandom,
 /turf/open/floor/plating/ms13/ground/mountain,
 /area/ms13/underground/mountain)
 "nOA" = (
@@ -22030,6 +22029,13 @@
 /obj/structure/railing/ms13/solo,
 /turf/open/floor/plating/ms13/ground/snow,
 /area/ms13/snow/lightforest)
+"obI" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 10
+	},
+/obj/effect/spawner/random/ms13/melee/highrandom,
+/turf/open/floor/plating/ms13/ground/mountain,
+/area/ms13/underground/mountain)
 "obJ" = (
 /obj/structure/fluff/ms13/mammoth_sign,
 /turf/open/floor/plating/ms13/ground/snow,
@@ -22689,6 +22695,7 @@
 /obj/machinery/light/ms13/bulb/broken{
 	dir = 1
 	},
+/obj/effect/spawner/random/ms13/ammo/lowrandom,
 /obj/effect/spawner/random/ms13/ammo/lowrandom,
 /turf/open/floor/wood/ms13/common,
 /area/ms13/underground/mountain)
@@ -27413,10 +27420,6 @@
 /area/ms13/supermarket)
 "usd" = (
 /turf/open/ms13/water/shallow,
-/area/ms13/underground/mountain)
-"usi" = (
-/obj/effect/spawner/random/ms13/gun/tier3,
-/turf/open/floor/plating/ms13/ground/mountain,
 /area/ms13/underground/mountain)
 "usC" = (
 /obj/machinery/door/unpowered/ms13/wood{
@@ -37973,7 +37976,7 @@ khQ
 khQ
 khQ
 aaD
-usi
+xmo
 xmo
 xmo
 xmo
@@ -39167,7 +39170,7 @@ vfy
 kDw
 iQA
 bzv
-iaT
+obI
 khQ
 khQ
 khQ

--- a/_maps/map_files/Mammoth/Mammoth.dmm
+++ b/_maps/map_files/Mammoth/Mammoth.dmm
@@ -233,6 +233,7 @@
 "afJ" = (
 /obj/structure/closet/ms13/metal,
 /obj/structure/ms13/storage/vent,
+/obj/effect/spawner/random/ms13/clothing/under,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "agy" = (
@@ -432,10 +433,6 @@
 /obj/structure/bed/ms13/mattress/filthy,
 /turf/open/floor/wood/ms13/mosaic,
 /area/ms13/town)
-"amZ" = (
-/mob/living/simple_animal/hostile/ms13/robot/eyebot,
-/turf/open/floor/plating/ms13/ground/road,
-/area/ms13)
 "ana" = (
 /obj/structure/filingcabinet/ms13/short{
 	dir = 8
@@ -1609,6 +1606,13 @@
 /obj/effect/spawner/random/ms13/medical/surgical,
 /turf/open/floor/ms13/tile/large/white,
 /area/ms13/town)
+"bfh" = (
+/obj/effect/decal/cleanable/blood/old{
+	pixel_x = -9
+	},
+/obj/structure/bed/ms13/sleepingbag/green,
+/turf/open/floor/plating/ms13/ground/mountain,
+/area/ms13/underground/mountain)
 "bfj" = (
 /obj/structure/table/ms13/no_smooth/large/wood/desk{
 	dir = 1
@@ -2078,6 +2082,11 @@
 	},
 /turf/open/floor/wood/ms13/common,
 /area/ms13/town)
+"bzv" = (
+/mob/living/basic/ms13/hostile_animal/yaoguai,
+/obj/effect/decal/cleanable/blood/tracks,
+/turf/open/floor/plating/ms13/ground/mountain,
+/area/ms13/underground/mountain)
 "bzF" = (
 /obj/item/chair/ms13/metal/office/blue,
 /turf/open/floor/wood/ms13/wide,
@@ -3486,6 +3495,13 @@
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/ms13/concrete,
 /area/ms13/town)
+"cxI" = (
+/obj/structure/ms13/storage/shelf{
+	dir = 4
+	},
+/obj/effect/spawner/random/ms13/crafting/refined,
+/turf/open/floor/ms13/concrete/industrial,
+/area/ms13/town)
 "cxO" = (
 /obj/effect/spawner/random/ms13/medical/bloodbag,
 /obj/structure/table/ms13/metal/heavy,
@@ -4211,6 +4227,12 @@
 	},
 /turf/open/floor/wood/ms13/common,
 /area/ms13/tribal_abandoned)
+"cXS" = (
+/obj/effect/decal/cleanable/blood{
+	icon_state = "floor7"
+	},
+/turf/open/floor/plating/ms13/ground/mountain,
+/area/ms13/underground/mountain)
 "cYd" = (
 /obj/structure/fluff/ms13/barrel/single/toxic/four,
 /turf/open/floor/plating/ms13/ground/road,
@@ -4410,8 +4432,8 @@
 /turf/open/floor/wood/ms13/common,
 /area/ms13/town)
 "dfp" = (
-/obj/effect/mob_spawn/corpse/human/charredskeleton,
 /obj/effect/decal/cleanable/blood/old,
+/obj/effect/mob_spawn/corpse/human/ms13/wastelander,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "dfH" = (
@@ -7497,6 +7519,10 @@
 /obj/structure/ms13/rug/rubber,
 /turf/open/floor/ms13/tile/large/white,
 /area/ms13/underground/vault_atrium_middle)
+"fcC" = (
+/obj/effect/spawner/random/ms13/guarenteed/tools/tool,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/town)
 "fcN" = (
 /obj/structure/closet/ms13/fridge,
 /turf/open/floor/ms13/tile/long,
@@ -7607,6 +7633,7 @@
 /area/ms13/town)
 "fgZ" = (
 /obj/structure/table/ms13/metal/grate,
+/obj/effect/spawner/random/ms13/tools/tool,
 /obj/effect/spawner/random/ms13/tools/tool,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
@@ -7793,6 +7820,9 @@
 /area/ms13/town)
 "flN" = (
 /obj/structure/closet/crate/ms13/woodcrate/compact,
+/obj/effect/spawner/random/ms13/crafting/household,
+/obj/effect/spawner/random/ms13/crafting/household,
+/obj/effect/spawner/random/ms13/tools/tool,
 /turf/open/floor/ms13/tile/large/cream,
 /area/ms13/town)
 "fmd" = (
@@ -7921,6 +7951,10 @@
 /obj/structure/table/ms13/wood/bar,
 /obj/effect/spawner/random/ms13/gun/tier1,
 /turf/open/floor/wood/ms13/carpet,
+/area/ms13/town)
+"fpl" = (
+/mob/living/simple_animal/hostile/ms13/robot/protectron/builder,
+/turf/open/floor/ms13/concrete/industrial/walkway,
 /area/ms13/town)
 "fpN" = (
 /obj/effect/landmark/start/ms13/doctor,
@@ -8582,6 +8616,12 @@
 /obj/structure/filingcabinet/ms13,
 /turf/open/floor/wood/ms13/common,
 /area/ms13/town)
+"fKE" = (
+/obj/effect/decal/cleanable/blood{
+	icon_state = "floor3"
+	},
+/turf/open/floor/plating/ms13/ground/mountain,
+/area/ms13/underground/mountain)
 "fKQ" = (
 /turf/open/floor/plating/ms13/ground/sidewalk,
 /area/ms13/underground/vault_outer)
@@ -8734,6 +8774,10 @@
 	dir = 1
 	},
 /turf/open/floor/ms13/tile/brown/big,
+/area/ms13/town)
+"fPW" = (
+/mob/living/simple_animal/hostile/ms13/robot/protectron/builder,
+/turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "fQo" = (
 /obj/structure/table/ms13/metal,
@@ -9395,6 +9439,13 @@
 /obj/structure/table/ms13/no_smooth/counter/metal,
 /turf/open/floor/ms13/tile/large/white,
 /area/ms13/town)
+"ggf" = (
+/obj/structure/closet/ms13/metal,
+/obj/structure/ms13/storage/vent,
+/obj/effect/spawner/random/ms13/ammo/tier1,
+/obj/effect/spawner/random/ms13/gun/tier1,
+/turf/open/floor/ms13/concrete/industrial,
+/area/ms13/town)
 "ggh" = (
 /obj/structure/table/ms13/wood,
 /obj/machinery/ms13/terminal/wasteland{
@@ -9438,6 +9489,7 @@
 /obj/structure/table/ms13/no_smooth/counter/metal{
 	dir = 1
 	},
+/obj/effect/spawner/random/ms13/melee/lowrandom,
 /turf/open/floor/ms13/tile/large/cafeteria,
 /area/ms13/town)
 "ghY" = (
@@ -9559,6 +9611,15 @@
 	},
 /obj/structure/ms13/storage/trashcan,
 /turf/open/floor/wood/ms13/common,
+/area/ms13/town)
+"gll" = (
+/obj/structure/closet/crate/ms13/woodcrate,
+/obj/machinery/light/ms13{
+	dir = 4
+	},
+/obj/effect/spawner/random/ms13/crafting/precious,
+/obj/effect/spawner/random/ms13/crafting/refined,
+/turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "glq" = (
 /obj/structure/chair/ms13/metal{
@@ -10488,6 +10549,11 @@
 /obj/structure/bed/ms13/mattress/stained,
 /turf/open/floor/ms13/tile/long,
 /area/ms13/underground/vault_atrium_middle)
+"gLc" = (
+/obj/structure/closet/crate/ms13/woodcrate,
+/obj/effect/spawner/random/ms13/crafting/refined,
+/turf/open/floor/ms13/concrete/industrial,
+/area/ms13/town)
 "gLd" = (
 /obj/structure/table/ms13/metal/heavy,
 /obj/machinery/ms13/terminal{
@@ -10819,6 +10885,12 @@
 /obj/effect/spawner/random/ms13/tools/radio,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
+"gTN" = (
+/obj/structure/closet/ms13/metal,
+/obj/effect/spawner/random/ms13/clothing/under,
+/obj/item/pickaxe/ms13,
+/turf/open/floor/ms13/concrete/industrial,
+/area/ms13/town)
 "gTQ" = (
 /obj/structure/ms13/rug/rubber{
 	dir = 4
@@ -11131,7 +11203,7 @@
 /area/ms13/underground/bos)
 "hcY" = (
 /obj/structure/closet/crate/ms13/woodcrate,
-/obj/effect/spawner/random/ms13/crafting/precious,
+/obj/effect/spawner/random/ms13/crafting/refined,
 /turf/open/floor/ms13/concrete/industrial/walkway{
 	dir = 1
 	},
@@ -11623,6 +11695,7 @@
 "htU" = (
 /obj/structure/closet/ms13/wall/firstaid,
 /obj/effect/spawner/random/ms13/medical/highrandom,
+/obj/effect/spawner/random/ms13/medical/tier1,
 /turf/open/floor/ms13/tile/blue,
 /area/ms13/town)
 "huc" = (
@@ -12013,6 +12086,12 @@
 	},
 /turf/open/floor/plating,
 /area/ms13/town)
+"hHl" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/turf/open/floor/plating/ms13/ground/mountain,
+/area/ms13/underground/mountain)
 "hHp" = (
 /obj/machinery/door/unpowered/ms13/seethrough/metal{
 	dir = 4
@@ -12722,6 +12801,12 @@
 /obj/machinery/light/ms13/bulb,
 /turf/open/floor/wood/ms13/common,
 /area/ms13/town)
+"iaT" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 10
+	},
+/turf/open/floor/plating/ms13/ground/mountain,
+/area/ms13/underground/mountain)
 "iaZ" = (
 /obj/machinery/ms13/terminal/wasteland{
 	dir = 8;
@@ -12996,8 +13081,9 @@
 "ihp" = (
 /obj/structure/closet/crate/ms13/woodcrate/compact,
 /obj/effect/spawner/random/ms13/crafting/highrandom,
-/obj/effect/spawner/random/ms13/crafting/highrandom,
 /obj/machinery/light/ms13/bulb,
+/obj/effect/spawner/random/ms13/crafting/lowrandom,
+/obj/effect/spawner/random/ms13/crafting/lowrandom,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "ihs" = (
@@ -14025,6 +14111,13 @@
 	},
 /turf/open/floor/ms13/metal/grate/border,
 /area/ms13/underground/vault_atrium_middle)
+"iQA" = (
+/obj/effect/spawner/random/ms13/melee/tier2,
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 5
+	},
+/turf/open/floor/plating/ms13/ground/mountain,
+/area/ms13/underground/mountain)
 "iQX" = (
 /obj/effect/spawner/random/ms13/crafting/household,
 /obj/structure/ms13/storage/large/shelf,
@@ -14228,6 +14321,7 @@
 /obj/structure/ms13/storage/large/shelf{
 	dir = 4
 	},
+/obj/effect/spawner/random/ms13/medical/lowrandom,
 /obj/effect/spawner/random/ms13/medical/lowrandom,
 /turf/open/floor/ms13/tile/blue,
 /area/ms13/town)
@@ -14753,6 +14847,12 @@
 	},
 /turf/open/floor/plating/ms13/ground/mountain,
 /area/ms13/town)
+"jlB" = (
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/blood/gibs,
+/obj/effect/spawner/random/ms13/gun/tier3,
+/turf/open/floor/plating/ms13/ground/mountain,
+/area/ms13/underground/mountain)
 "jlM" = (
 /obj/machinery/door/unpowered/ms13/metal{
 	dir = 1
@@ -14977,6 +15077,7 @@
 /obj/structure/closet/crate/ms13/woodcrate,
 /obj/effect/spawner/random/ms13/crafting/precious,
 /obj/structure/ms13/storage/vent,
+/obj/effect/spawner/random/ms13/crafting/refined,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "juq" = (
@@ -15499,7 +15600,6 @@
 /obj/structure/closet/ms13/metal,
 /obj/item/clothing/under/ms13/wasteland/machinist,
 /obj/structure/ms13/wall_decor/clock,
-/obj/item/pickaxe/ms13,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "jKr" = (
@@ -15664,6 +15764,10 @@
 	dir = 8
 	},
 /turf/open/floor/wood/ms13/common,
+/area/ms13/town)
+"jQv" = (
+/mob/living/basic/ms13/ghoul/radioactive,
+/turf/open/floor/ms13/metal/stayclear,
 /area/ms13/town)
 "jQz" = (
 /obj/machinery/light/ms13/bulb{
@@ -16283,6 +16387,7 @@
 	dir = 1
 	},
 /obj/effect/spawner/random/ms13/melee/tier3,
+/obj/effect/spawner/random/ms13/gun/lowrandom,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "kiw" = (
@@ -16398,6 +16503,13 @@
 "klm" = (
 /obj/structure/table/ms13/low_wall/brick/alt,
 /turf/open/floor/plating,
+/area/ms13/town)
+"kly" = (
+/obj/structure/table/ms13/no_smooth/counter/wood,
+/obj/item/paper_bin/ms13{
+	pixel_y = 6
+	},
+/turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "klK" = (
 /obj/structure/ms13/rug/mat/rubber,
@@ -16584,14 +16696,13 @@
 "krG" = (
 /obj/structure/table/ms13/metal,
 /obj/effect/spawner/random/ms13/crafting/household,
-/obj/effect/spawner/random/ms13/crafting/household,
-/obj/effect/spawner/random/ms13/crafting/lowrandom,
 /obj/effect/spawner/random/ms13/crafting/lowrandom,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "krJ" = (
 /obj/structure/table/ms13/metal,
-/obj/effect/spawner/random/ms13/seeds/spores,
+/obj/effect/spawner/random/ms13/crafting/lowrandom,
+/obj/effect/spawner/random/ms13/crafting/household,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "krS" = (
@@ -16635,6 +16746,14 @@
 /obj/structure/table/ms13/metal,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/underground/tunnel/maintenance)
+"ktp" = (
+/obj/structure/ms13/storage/shelf{
+	dir = 1
+	},
+/obj/effect/spawner/random/ms13/food/packaged,
+/obj/effect/spawner/random/ms13/food/packaged,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/town)
 "ktw" = (
 /obj/machinery/door/unpowered/ms13/metal{
 	dir = 1
@@ -16645,6 +16764,7 @@
 /obj/structure/table/ms13/no_smooth/counter/metal{
 	dir = 8
 	},
+/obj/effect/spawner/random/ms13/medical/bloodbag,
 /obj/effect/spawner/random/ms13/medical/bloodbag,
 /obj/effect/spawner/random/ms13/medical/bloodbag,
 /turf/open/floor/ms13/tile/blue,
@@ -16907,6 +17027,10 @@
 /obj/effect/spawner/random/ms13/medical/highrandom,
 /turf/open/floor/ms13/tile,
 /area/ms13/town)
+"kDw" = (
+/obj/effect/spawner/random/ms13/guarenteed/medical/herbal,
+/turf/open/floor/plating/ms13/ground/mountain,
+/area/ms13/underground/mountain)
 "kDz" = (
 /obj/structure/stairs/east,
 /obj/structure/railing/ms13/solo,
@@ -17100,18 +17224,10 @@
 	},
 /turf/open/floor/plating/ms13/ground/mountain,
 /area/ms13/underground/vault_atrium_middle)
-"kJz" = (
-/obj/structure/closet/ms13/metal,
-/obj/item/clothing/under/ms13/wasteland/machinist,
-/obj/effect/spawner/random/ms13/clothing/under,
-/turf/open/floor/ms13/concrete/industrial,
-/area/ms13/town)
 "kJF" = (
 /obj/structure/table/ms13/no_smooth/counter/wood,
 /obj/structure/ms13/wall_decor/clock,
-/obj/item/paper_bin/ms13{
-	pixel_y = 6
-	},
+/obj/effect/spawner/random/ms13/food/junkfood_boxed,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "kKj" = (
@@ -17366,10 +17482,6 @@
 	},
 /turf/open/floor/plating/ms13/ground/mountain,
 /area/ms13/town)
-"kTE" = (
-/mob/living/basic/ms13/hostile_animal/yaoguai,
-/turf/open/floor/plating/ms13/ground/mountain,
-/area/ms13/underground/mountain)
 "kTJ" = (
 /obj/structure/table/ms13/metal,
 /obj/structure/safe/ms13/wall,
@@ -17691,6 +17803,7 @@
 /obj/machinery/light/ms13{
 	dir = 4
 	},
+/obj/effect/spawner/random/ms13/melee/tier1,
 /turf/open/floor/wood/ms13/carpet,
 /area/ms13/town)
 "ldv" = (
@@ -17761,6 +17874,7 @@
 /obj/structure/ms13/storage/large/shelf{
 	dir = 4
 	},
+/obj/effect/spawner/random/ms13/tools/tool,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "lgy" = (
@@ -17775,8 +17889,9 @@
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "lgK" = (
-/obj/effect/spawner/random/ms13/tools/lights,
 /obj/structure/table/ms13/metal/grate,
+/obj/effect/spawner/random/ms13/crafting/lowrandom,
+/obj/effect/spawner/random/ms13/crafting/electrical,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "lhg" = (
@@ -17785,6 +17900,7 @@
 	pixel_x = -12
 	},
 /obj/structure/ms13/skeleton,
+/obj/effect/spawner/random/ms13/medical/lowrandom,
 /turf/open/floor/ms13/tile/brown,
 /area/ms13/town)
 "lhk" = (
@@ -17993,6 +18109,7 @@
 "lpT" = (
 /obj/effect/spawner/random/ms13/tools/radio,
 /obj/structure/table/ms13/metal/grate,
+/obj/effect/spawner/random/ms13/tools/lights,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "lpX" = (
@@ -19042,6 +19159,13 @@
 	},
 /turf/open/floor/plating/ms13/ground/road,
 /area/ms13)
+"mcS" = (
+/obj/structure/closet/crate/ms13/woodcrate,
+/obj/effect/spawner/random/ms13/crafting/refined,
+/turf/open/floor/ms13/concrete/industrial/walkway/corner{
+	dir = 4
+	},
+/area/ms13/town)
 "mcT" = (
 /obj/machinery/door/unpowered/ms13/wood{
 	dir = 4
@@ -19059,6 +19183,10 @@
 /obj/item/clothing/mask/gas/ms13/modern,
 /turf/open/floor/ms13/concrete,
 /area/ms13/underground/tunnel/maintenance)
+"mdt" = (
+/obj/effect/spawner/random/ms13/guarenteed/clothing/backpack/high,
+/turf/open/floor/plating/ms13/ground/mountain,
+/area/ms13/underground/mountain)
 "mdy" = (
 /obj/structure/chair/ms13/metal,
 /obj/item/cigbutt,
@@ -19603,12 +19731,6 @@
 /obj/effect/spawner/random/ms13/crafting/lowrandom,
 /turf/open/floor/ms13/tile/full/navy,
 /area/ms13/town)
-"myD" = (
-/obj/machinery/door/unpowered/ms13/seethrough/metal{
-	dir = 1
-	},
-/turf/open/floor/ms13/concrete/industrial,
-/area/ms13/town)
 "myS" = (
 /obj/structure/chair/office/ms13/blue{
 	dir = 4
@@ -19726,7 +19848,6 @@
 "mDB" = (
 /obj/structure/flora/grass/jungle/b,
 /obj/effect/decal/cleanable/blood/drip,
-/obj/effect/spawner/random/ms13/guarenteed/medical/herbal,
 /turf/open/floor/plating/ms13/ground/mountain,
 /area/ms13/underground/mountain)
 "mDY" = (
@@ -19834,8 +19955,9 @@
 /turf/open/floor/plating/ms13/ground/road,
 /area/ms13)
 "mHA" = (
-/obj/machinery/door/unpowered/ms13/seethrough/mirrored/metal{
-	dir = 1
+/obj/machinery/door/unpowered/ms13/metal{
+	dir = 1;
+	icon_state = "metal_mirrored_closed"
 	},
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
@@ -19907,6 +20029,7 @@
 /area/ms13/town)
 "mLg" = (
 /obj/structure/closet/crate/ms13/woodcrate,
+/obj/effect/spawner/random/ms13/crafting/refined,
 /turf/open/floor/ms13/concrete/industrial/walkway,
 /area/ms13/town)
 "mLk" = (
@@ -20458,6 +20581,7 @@
 "nea" = (
 /obj/effect/spawner/random/ms13/food/packaged,
 /obj/structure/ms13/storage/shelf,
+/obj/effect/spawner/random/ms13/food/packaged,
 /turf/open/floor/ms13/tile/large/cafeteria,
 /area/ms13/town)
 "neG" = (
@@ -20576,6 +20700,12 @@
 	dir = 4
 	},
 /turf/open/floor/ms13/concrete,
+/area/ms13/town)
+"nhW" = (
+/obj/structure/closet/crate/ms13/woodcrate/compact,
+/obj/effect/spawner/random/ms13/crafting/refined,
+/obj/effect/spawner/random/ms13/crafting/refined,
+/turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "nic" = (
 /obj/structure/ms13/storage/shelf{
@@ -20742,6 +20872,13 @@
 	dir = 4
 	},
 /turf/open/floor/ms13/tile/full/navy,
+/area/ms13/town)
+"nnw" = (
+/obj/structure/closet/crate/ms13/woodcrate/compact,
+/obj/effect/spawner/random/ms13/tools/tool,
+/obj/effect/spawner/random/ms13/tools/tool,
+/obj/effect/spawner/random/ms13/tools/lights,
+/turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "nnF" = (
 /obj/effect/spawner/random/ms13/guarenteed/ammo/lowrandom,
@@ -21039,6 +21176,13 @@
 	dir = 4
 	},
 /area/ms13/ncr)
+"nwq" = (
+/obj/structure/ms13/storage/shelf{
+	dir = 1
+	},
+/obj/effect/spawner/random/ms13/medical/surgical,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/town)
 "nwv" = (
 /obj/machinery/light/ms13,
 /obj/item/chair/ms13/metal/unfinished,
@@ -21495,6 +21639,7 @@
 "nMr" = (
 /obj/structure/closet/crate/ms13/vault_tec/long,
 /obj/effect/spawner/random/ms13/armor/highrandom,
+/obj/effect/spawner/random/ms13/armor/headgear,
 /turf/open/floor/plating/ms13/ground/mountain,
 /area/ms13/underground/mountain)
 "nMG" = (
@@ -22246,6 +22391,13 @@
 	},
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
+"oml" = (
+/obj/structure/closet/crate/ms13/woodcrate/compact,
+/obj/effect/spawner/random/ms13/food/packaged,
+/obj/effect/spawner/random/ms13/food/packaged,
+/obj/effect/spawner/random/ms13/food/packaged,
+/turf/open/floor/ms13/tile/large/cream,
+/area/ms13/town)
 "omE" = (
 /obj/structure/table/ms13/wood,
 /turf/open/floor/wood/ms13/carpet/shaggy/green,
@@ -22668,6 +22820,8 @@
 "oxP" = (
 /obj/structure/closet/crate/ms13/woodcrate/compact,
 /obj/effect/spawner/random/ms13/crafting/highrandom,
+/obj/effect/spawner/random/ms13/crafting/lowrandom,
+/obj/effect/spawner/random/ms13/crafting/lowrandom,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "oye" = (
@@ -22681,10 +22835,6 @@
 	},
 /turf/open/floor/ms13/tile/blue,
 /area/ms13/town)
-"oyH" = (
-/obj/item/ms13/animalitem/slepnir/hooves,
-/turf/open/floor/plating/ms13/ground/mountain,
-/area/ms13/underground/mountain)
 "oyJ" = (
 /obj/structure/chair/ms13/metal/broken,
 /turf/open/floor/wood/ms13/wide,
@@ -22875,6 +23025,13 @@
 /obj/effect/spawner/random/ms13/gun/tier1,
 /turf/open/floor/ms13/tile/full/green,
 /area/ms13/town)
+"oFQ" = (
+/obj/structure/ms13/storage/shelf{
+	dir = 4
+	},
+/obj/effect/spawner/random/ms13/crafting/household,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/town)
 "oGx" = (
 /obj/structure/table/ms13/metal,
 /obj/machinery/light/ms13/bulb/broken{
@@ -22908,6 +23065,10 @@
 /obj/item/storage/bag/tray,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/ncr)
+"oHx" = (
+/obj/effect/spawner/random/ms13/medical/herbal,
+/turf/open/floor/plating/ms13/ground/snow,
+/area/ms13/snow/lightforest)
 "oHQ" = (
 /obj/effect/decal/cleanable/blood/footprints{
 	dir = 8;
@@ -23165,6 +23326,13 @@
 	},
 /turf/open/floor/ms13/tile/brown,
 /area/ms13/supermarket)
+"oWn" = (
+/obj/structure/ms13/storage/large/shelf{
+	dir = 4
+	},
+/obj/effect/spawner/random/ms13/tools/lights,
+/turf/open/floor/ms13/concrete/industrial,
+/area/ms13/town)
 "oXj" = (
 /obj/structure/ms13/storage/trashcan,
 /turf/open/floor/wood/ms13/carpet/blue,
@@ -24418,6 +24586,12 @@
 /obj/machinery/door/unpowered/ms13/metal/mirrored,
 /turf/open/floor/wood/ms13/mosaic,
 /area/ms13/town)
+"qzk" = (
+/obj/effect/decal/cleanable/blood{
+	icon_state = "floor4"
+	},
+/turf/open/floor/plating/ms13/ground/mountain,
+/area/ms13/underground/mountain)
 "qzn" = (
 /obj/machinery/ms13/substation/discharge,
 /turf/open/floor/ms13/concrete/cable/node{
@@ -25181,6 +25355,13 @@
 /obj/effect/landmark/start/ms13/settler,
 /turf/open/floor/ms13/tile/navy,
 /area/ms13/underground/vault_atrium_middle)
+"rDw" = (
+/obj/structure/ms13/storage/large/shelf{
+	dir = 4
+	},
+/obj/effect/spawner/random/ms13/tools/tool,
+/turf/open/floor/ms13/tile/large/cream,
+/area/ms13/town)
 "rDD" = (
 /obj/structure/table/ms13/no_smooth/metal,
 /obj/effect/spawner/random/ms13/guarenteed/drink/alcohol,
@@ -25190,6 +25371,7 @@
 /obj/structure/table/ms13/no_smooth/counter/wood{
 	dir = 4
 	},
+/obj/effect/spawner/random/ms13/food/packaged,
 /turf/open/floor/ms13/tile/brown,
 /area/ms13/town)
 "rDP" = (
@@ -26797,6 +26979,11 @@
 /obj/effect/spawner/random/ms13/medical/lowrandom,
 /turf/open/floor/ms13/tile/long,
 /area/ms13/town)
+"tHO" = (
+/obj/effect/turf_decal/ms13/road/horizontalline,
+/mob/living/simple_animal/hostile/retaliate/ms13/robot/eyebot,
+/turf/open/floor/plating/ms13/ground/road,
+/area/ms13/underground/tunnel)
 "tIk" = (
 /obj/machinery/shower{
 	dir = 4
@@ -28238,6 +28425,11 @@
 /obj/effect/spawner/random/ms13/armor/tier1,
 /turf/open/floor/ms13/tile/blue/long,
 /area/ms13/town)
+"vUN" = (
+/obj/structure/closet/crate/ms13/woodcrate/compact,
+/obj/effect/spawner/random/ms13/crafting/refined,
+/turf/open/floor/ms13/concrete/industrial,
+/area/ms13/town)
 "vVp" = (
 /obj/structure/table/ms13/wood,
 /obj/machinery/ms13/terminal/wasteland{
@@ -28757,6 +28949,10 @@
 	dir = 1
 	},
 /turf/open/floor/wood/ms13/common,
+/area/ms13/town)
+"wLS" = (
+/obj/effect/spawner/random/ms13/crafting/refined,
+/turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "wMk" = (
 /obj/effect/spawner/random/ms13/gun/tier1,
@@ -29426,6 +29622,11 @@
 	},
 /turf/open/floor/wood/ms13/mosaic,
 /area/ms13/town)
+"xEi" = (
+/obj/effect/mob_spawn/corpse/human/ms13/wastelander,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/plating/ms13/ground/mountain,
+/area/ms13/underground/mountain)
 "xES" = (
 /obj/structure/table/ms13/wood,
 /obj/structure/ms13/rug/red,
@@ -29531,6 +29732,10 @@
 /area/ms13/underground/vault_atrium_middle)
 "xNi" = (
 /turf/open/openspace/ms13,
+/area/ms13/town)
+"xNt" = (
+/obj/effect/mob_spawn/corpse/human/ms13/wastelander,
+/turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "xNQ" = (
 /obj/structure/chair/office/ms13/green{
@@ -29740,9 +29945,7 @@
 /turf/open/floor/ms13/tile/large/white,
 /area/ms13/town)
 "xZQ" = (
-/obj/effect/decal/cleanable/blood/gibs,
 /obj/effect/decal/cleanable/blood,
-/obj/effect/spawner/random/ms13/gun/tier3,
 /turf/open/floor/plating/ms13/ground/mountain,
 /area/ms13/underground/mountain)
 "yar" = (
@@ -31128,7 +31331,7 @@ khQ
 khQ
 khQ
 ykZ
-nAP
+ktp
 axO
 axO
 oYk
@@ -31451,7 +31654,7 @@ xmo
 xmo
 xmo
 xmo
-nNn
+xmo
 xmo
 khQ
 khQ
@@ -31654,7 +31857,7 @@ khQ
 ykZ
 koy
 axO
-axO
+xNt
 vEh
 dgQ
 xmo
@@ -32329,7 +32532,7 @@ nAP
 axO
 axO
 nDs
-axO
+nEg
 ihp
 ykZ
 khQ
@@ -32581,7 +32784,7 @@ khQ
 khQ
 xmo
 xmo
-wtg
+kSf
 xmo
 khQ
 khQ
@@ -32589,7 +32792,7 @@ wtg
 ylG
 ylG
 ylG
-kwJ
+ylG
 ylG
 ylG
 wtg
@@ -32888,7 +33091,7 @@ wtg
 wtg
 wtg
 wtg
-ylG
+kwJ
 ylG
 ylG
 ylG
@@ -33185,7 +33388,7 @@ khQ
 khQ
 khQ
 wtg
-kSf
+wtg
 wtg
 ylG
 ylG
@@ -33463,7 +33666,7 @@ xmo
 pyY
 keL
 xmo
-xmo
+uMx
 ykZ
 ykZ
 ykZ
@@ -34112,7 +34315,7 @@ wtg
 pdE
 lNS
 mzI
-fSQ
+oWn
 ezv
 xmo
 xmo
@@ -34371,7 +34574,7 @@ khQ
 khQ
 khQ
 ykZ
-axO
+fcC
 vEh
 ewx
 ykZ
@@ -34713,11 +34916,11 @@ xZD
 xZD
 xZD
 xZD
-myD
+oEJ
 red
 red
 red
-red
+fPW
 xmo
 xmo
 xmo
@@ -35306,10 +35509,10 @@ pwP
 mAT
 red
 mjq
-kJz
+hUC
 xcO
 sqn
-kJz
+hUC
 pwP
 ylG
 ylG
@@ -35364,7 +35567,7 @@ khQ
 khQ
 khQ
 khQ
-nNn
+xmo
 xmo
 khQ
 khQ
@@ -35647,7 +35850,7 @@ jTH
 khQ
 khQ
 ykZ
-nAP
+nwq
 bCT
 axO
 nBo
@@ -35895,7 +36098,7 @@ ylG
 ylG
 jIO
 cVP
-fqj
+jQv
 red
 red
 red
@@ -36204,7 +36407,7 @@ lgK
 jIO
 wtg
 pwP
-dgH
+gTN
 red
 red
 red
@@ -36517,7 +36720,7 @@ red
 red
 pSt
 sIA
-sIA
+jKr
 sIA
 kar
 lpX
@@ -36538,7 +36741,7 @@ khQ
 xmo
 xmo
 xmo
-xmo
+qzk
 xmo
 khQ
 khQ
@@ -36808,7 +37011,7 @@ jIO
 jIO
 wtg
 pwP
-dgH
+xcO
 red
 red
 red
@@ -36841,8 +37044,8 @@ khQ
 xmo
 xmo
 xmo
-xmo
-xmo
+cXS
+qzk
 xmo
 khQ
 khQ
@@ -36862,7 +37065,7 @@ nBt
 nFJ
 ykZ
 ykZ
-xmo
+mdt
 nNn
 xmo
 xmo
@@ -37145,10 +37348,10 @@ khQ
 khQ
 xmo
 xmo
+fKE
 xmo
 xmo
 xmo
-rAX
 khQ
 khQ
 khQ
@@ -37397,7 +37600,7 @@ khQ
 khQ
 khQ
 ylG
-kwJ
+ylG
 xZD
 xZD
 xZD
@@ -37451,7 +37654,7 @@ xmo
 xmo
 xZQ
 xmo
-tmE
+xmo
 khQ
 khQ
 khQ
@@ -37472,7 +37675,7 @@ xmo
 xmo
 xmo
 xmo
-nNn
+xmo
 xmo
 xmo
 xmo
@@ -37749,12 +37952,12 @@ khQ
 khQ
 khQ
 khQ
-rAX
-kCq
-gZd
+xmo
+xmo
+xmo
 mDB
 xmo
-khQ
+xmo
 khQ
 khQ
 khQ
@@ -38006,7 +38209,7 @@ jcS
 cbe
 cbe
 jIO
-ePT
+kly
 joL
 lHk
 mtT
@@ -38019,9 +38222,9 @@ xZD
 xZD
 xZD
 xZD
-xZD
-xZD
 lMB
+xZD
+xZD
 xZD
 xZD
 xZD
@@ -38051,14 +38254,14 @@ khQ
 khQ
 khQ
 khQ
-vfy
+kCi
 xmo
-kTE
+xmo
 vdX
 xmo
-khQ
-khQ
-khQ
+xmo
+tmE
+rAX
 khQ
 khQ
 khQ
@@ -38357,10 +38560,10 @@ khQ
 pyY
 xmo
 xmo
-khQ
-khQ
-khQ
-khQ
+bfh
+iaT
+xmo
+xmo
 khQ
 khQ
 khQ
@@ -38397,7 +38600,7 @@ xmo
 xmo
 kCi
 xmo
-xmo
+gZd
 oDO
 khQ
 khQ
@@ -38620,7 +38823,7 @@ jIO
 xZD
 xZD
 ykT
-amZ
+ykT
 ykT
 ykT
 ykT
@@ -38657,12 +38860,12 @@ khQ
 khQ
 khQ
 khQ
-khQ
-khQ
-khQ
-khQ
-khQ
-khQ
+xmo
+gZd
+kCq
+hHl
+jlB
+rAX
 khQ
 khQ
 khQ
@@ -38940,12 +39143,12 @@ xZD
 xZD
 xZD
 xZD
-myD
+oEJ
 red
 red
-feZ
 red
 red
+fPW
 red
 red
 red
@@ -38960,11 +39163,11 @@ khQ
 khQ
 khQ
 khQ
-khQ
-khQ
-khQ
-khQ
-khQ
+vfy
+kDw
+iQA
+bzv
+iaT
 khQ
 khQ
 khQ
@@ -39000,7 +39203,7 @@ khQ
 khQ
 khQ
 xmo
-oyH
+xmo
 tmE
 kCi
 khQ
@@ -39247,9 +39450,9 @@ uFa
 eFc
 fSc
 fSc
-mLg
 fSc
-eSN
+fSc
+mcS
 red
 xPT
 xPT
@@ -39263,10 +39466,10 @@ khQ
 khQ
 khQ
 khQ
-khQ
-khQ
-khQ
-khQ
+xmo
+xmo
+xmo
+xEi
 khQ
 khQ
 khQ
@@ -39524,7 +39727,7 @@ axO
 kFo
 gad
 xZD
-xZD
+lMB
 ykT
 ykT
 ykT
@@ -39555,7 +39758,7 @@ eFn
 red
 uel
 oYL
-iHE
+nhW
 red
 rXU
 xPT
@@ -39858,8 +40061,8 @@ red
 spE
 red
 red
-red
-hnA
+feZ
+vUN
 xPT
 khQ
 khQ
@@ -40128,7 +40331,7 @@ oJO
 jYy
 jIO
 xZD
-xZD
+wPy
 xBj
 xBj
 ykT
@@ -40759,11 +40962,11 @@ vsM
 vsM
 vsM
 vsM
-hcY
+eFn
 red
 spE
 red
-jSD
+gLc
 red
 rXU
 xPT
@@ -41023,7 +41226,7 @@ khQ
 ylG
 ylG
 jIO
-kQH
+oFQ
 axO
 jIO
 kZM
@@ -41060,7 +41263,7 @@ eFt
 fSc
 mLg
 fSc
-fSc
+fpl
 eVD
 red
 xPT
@@ -41357,17 +41560,17 @@ xZD
 xZD
 xZD
 xPT
-eJF
+kkN
 red
 red
-fSQ
+red
 red
 red
 iHE
-fSQ
-ezv
 red
-eEa
+ezv
+wLS
+cxI
 xPT
 khQ
 khQ
@@ -41650,7 +41853,7 @@ ykT
 ykT
 ykT
 ykT
-xZD
+wPy
 xZD
 ylG
 ylG
@@ -41659,11 +41862,11 @@ xZD
 xZD
 unm
 xPT
-eJF
 red
-hnA
 red
-feZ
+nnw
+red
+red
 red
 red
 red
@@ -42267,8 +42470,8 @@ xPT
 lNS
 red
 fSQ
-cWB
-hnA
+gll
+iHE
 red
 fSQ
 ezv
@@ -43465,7 +43668,7 @@ vxv
 ryV
 gdT
 rxW
-iSK
+vvF
 ryV
 gdT
 rxW
@@ -43741,7 +43944,7 @@ tqN
 ylG
 ylG
 ylG
-ylG
+oHx
 rxh
 ylG
 ylG
@@ -44044,14 +44247,14 @@ ylG
 ylG
 ylG
 ylG
-ylG
+ian
 ylG
 ylG
 ylG
 ylG
 xPT
 red
-fSQ
+oWn
 red
 red
 gwU
@@ -44346,7 +44549,7 @@ ylG
 ylG
 ylG
 ylG
-ian
+ylG
 ylG
 ylG
 ylG
@@ -44374,7 +44577,7 @@ pwP
 hzB
 vvF
 vvF
-vvF
+iSK
 iVf
 vvF
 vvF
@@ -44654,7 +44857,7 @@ ylG
 ylG
 ylG
 xPT
-afJ
+ggf
 red
 eKM
 red
@@ -45579,9 +45782,9 @@ ykT
 ykT
 mGN
 dVn
-flN
+oml
 dVn
-jzv
+rDw
 pwP
 mIW
 dVn
@@ -46184,7 +46387,7 @@ ykT
 vxG
 dVn
 dVn
-dVn
+csf
 flN
 pwP
 cva
@@ -49496,7 +49699,7 @@ jNx
 aKG
 umf
 umf
-dAo
+tHO
 umf
 umf
 aKG

--- a/_maps/map_files/Mammoth/Mammoth_above.dmm
+++ b/_maps/map_files/Mammoth/Mammoth_above.dmm
@@ -18622,6 +18622,11 @@
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
+"pJu" = (
+/obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/mountain,
+/obj/effect/spawner/random/ms13/melee/tier3,
+/turf/open/floor/plating/ms13/ground/mountain,
+/area/ms13/underground/mountain)
 "pLi" = (
 /turf/closed/wall/ms13/scrap/red,
 /area/ms13)
@@ -19093,11 +19098,6 @@
 	},
 /turf/open/floor/plating/ms13/roof,
 /area/ms13)
-"rlZ" = (
-/obj/effect/spawner/random/ms13/gun/tier3,
-/obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/mountain,
-/turf/open/floor/plating/ms13/ground/mountain,
-/area/ms13/underground/mountain)
 "rmn" = (
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /obj/effect/landmark/start/ms13/wastelander,
@@ -28282,7 +28282,7 @@ aPY
 aPY
 aPY
 qOC
-rlZ
+nMB
 kLT
 nMB
 nMB
@@ -28583,7 +28583,7 @@ aPY
 aPY
 fMw
 xYr
-nMB
+pJu
 cCU
 nMB
 fMw

--- a/_maps/map_files/Mammoth/Mammoth_above.dmm
+++ b/_maps/map_files/Mammoth/Mammoth_above.dmm
@@ -1616,10 +1616,8 @@
 /area/ms13/underground/tunnel/maintenance)
 "afR" = (
 /obj/structure/table/ms13/metal/grate,
-/obj/item/reagent_containers/food/drinks/mug/ms13{
-	pixel_y = 8
-	},
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
+/obj/effect/spawner/random/ms13/food/junkfood_boxed,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "afS" = (
@@ -1717,7 +1715,7 @@
 "agi" = (
 /obj/structure/table/ms13/metal/grate,
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
-/obj/effect/spawner/random/ms13/crafting/lowrandom,
+/obj/effect/spawner/random/ms13/crafting/highrandom,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "agj" = (
@@ -1941,9 +1939,6 @@
 "ahc" = (
 /obj/structure/table/ms13/wood,
 /obj/item/paper_bin/ms13{
-	pixel_y = 6
-	},
-/obj/item/pen/fountain{
 	pixel_y = 6
 	},
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
@@ -2656,12 +2651,6 @@
 	},
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /turf/open/floor/wood/ms13/common,
-/area/ms13/town)
-"ajN" = (
-/obj/structure/lattice/catwalk/ms13,
-/mob/living/simple_animal/hostile/ms13/robot/protectron,
-/obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
-/turf/open/openspace/ms13,
 /area/ms13/town)
 "ajP" = (
 /obj/machinery/light/ms13{
@@ -5384,11 +5373,6 @@
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
-"auG" = (
-/mob/living/simple_animal/hostile/ms13/robot/protectron,
-/obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
-/turf/open/floor/ms13/concrete/industrial,
-/area/ms13/town)
 "auH" = (
 /obj/structure/closet/crate/ms13/footlocker{
 	dir = 8
@@ -5419,9 +5403,6 @@
 	},
 /obj/machinery/ms13/coffee{
 	pixel_y = 7
-	},
-/obj/item/reagent_containers/food/drinks/mug/ms13{
-	pixel_y = -8
 	},
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /turf/open/floor/wood/ms13/mosaic,
@@ -5631,10 +5612,8 @@
 /obj/structure/table/ms13/no_smooth/counter/wood/crafted{
 	dir = 4
 	},
-/obj/item/reagent_containers/food/drinks/mug/ms13{
-	pixel_y = 8
-	},
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/mountain,
+/obj/effect/spawner/random/ms13/drink/soda,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "avE" = (
@@ -5861,6 +5840,7 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
+/obj/item/radio/ms13/ham/receiver/radioking/wood,
 /turf/open/floor/wood/ms13/mosaic,
 /area/ms13/town)
 "awv" = (
@@ -6463,9 +6443,7 @@
 "ayW" = (
 /obj/structure/table/ms13/wood,
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
-/obj/item/reagent_containers/food/drinks/mug/ms13{
-	pixel_y = 8
-	},
+/obj/effect/spawner/random/ms13/crafting/household,
 /turf/open/floor/wood/ms13/carpet,
 /area/ms13/town)
 "ayX" = (
@@ -7800,8 +7778,8 @@
 /obj/structure/table/ms13/no_smooth/counter/wood{
 	dir = 8
 	},
-/obj/item/radio/ms13/ham/receiver/radioking/wood,
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
+/obj/effect/spawner/random/ms13/crafting/electrical,
 /turf/open/floor/wood/ms13/mosaic,
 /area/ms13/town)
 "aDX" = (
@@ -8261,8 +8239,8 @@
 /obj/structure/safe/ms13/advanced,
 /obj/effect/spawner/random/ms13/guarenteed/crafting/precious,
 /obj/effect/spawner/random/ms13/guarenteed/crafting/precious,
-/obj/effect/spawner/random/ms13/guarenteed/crafting/precious,
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
+/obj/effect/spawner/random/ms13/crafting/precious,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "aFV" = (
@@ -9813,14 +9791,6 @@
 	dir = 1
 	},
 /area/ms13/underground/tunnel/maintenance)
-"aMe" = (
-/obj/structure/closet/ms13/metal,
-/obj/item/clothing/under/ms13/wasteland/machinist,
-/obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
-/obj/item/pickaxe/ms13,
-/obj/effect/spawner/random/ms13/clothing/under,
-/turf/open/floor/ms13/concrete/industrial,
-/area/ms13/town)
 "aMf" = (
 /obj/structure/sink/kitchen{
 	dir = 8;
@@ -11718,6 +11688,7 @@
 "aTE" = (
 /obj/structure/closet/ms13/wall/firstaid,
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
+/obj/effect/spawner/random/ms13/medical/tier1,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "aTG" = (
@@ -13714,7 +13685,7 @@
 "bZX" = (
 /obj/structure/table/ms13/wood/constructed,
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/mountain,
-/obj/effect/spawner/random/ms13/seeds/spores,
+/obj/effect/spawner/random/ms13/tools/radio,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "cag" = (
@@ -13784,6 +13755,14 @@
 	},
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
+"cki" = (
+/obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/mountain,
+/obj/structure/ms13/storage/shelf{
+	dir = 1
+	},
+/obj/effect/spawner/random/ms13/tools/tool,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/town)
 "ckK" = (
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /obj/machinery/light/ms13/bulb{
@@ -13803,6 +13782,12 @@
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /turf/open/floor/wood/ms13/mosaic,
 /area/ms13/town)
+"col" = (
+/obj/structure/table/ms13/no_smooth/counter/metal,
+/obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
+/obj/effect/spawner/random/ms13/medical/lowrandom,
+/turf/open/floor/ms13/concrete/industrial,
+/area/ms13/town)
 "con" = (
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /obj/structure/ms13/storage/trashcan,
@@ -13813,6 +13798,14 @@
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /obj/effect/spawner/random/ms13/drink/alcohol_beer,
 /turf/open/floor/wood/ms13/common,
+/area/ms13/town)
+"cpt" = (
+/obj/structure/ms13/storage/large/shelf{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/mountain,
+/obj/effect/spawner/random/ms13/medical/lowrandom,
+/turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "cpz" = (
 /obj/structure/table/ms13/wood,
@@ -13888,6 +13881,14 @@
 /obj/effect/spawner/random/ms13/clothing/hat,
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /turf/open/floor/wood/ms13/common,
+/area/ms13/town)
+"cAM" = (
+/obj/structure/ms13/storage/large/shelf{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/mountain,
+/obj/effect/spawner/random/ms13/food/packaged,
+/turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "cAO" = (
 /obj/structure/railing/ms13/solo{
@@ -14118,8 +14119,8 @@
 "dkM" = (
 /obj/structure/closet/crate/ms13/vault_tec/long,
 /obj/effect/spawner/random/ms13/clothing/under,
-/obj/effect/spawner/random/ms13/clothing/shoe,
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
+/obj/effect/spawner/random/ms13/armor/lowrandom,
 /turf/open/floor/plating/ms13/roof,
 /area/ms13/town)
 "dmk" = (
@@ -14615,10 +14616,6 @@
 /obj/structure/table/ms13/no_smooth/counter/wood/crafted{
 	dir = 4
 	},
-/obj/item/reagent_containers/food/drinks/mug/ms13{
-	pixel_x = -4;
-	pixel_y = 5
-	},
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/mountain,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
@@ -14756,6 +14753,11 @@
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /obj/machinery/ms13/substation/discharge/rusty,
 /turf/open/floor/ms13/concrete/cable/node,
+/area/ms13/town)
+"fgz" = (
+/obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
+/mob/living/simple_animal/hostile/ms13/robot/protectron/builder,
+/turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "fgG" = (
 /obj/effect/spawner/random/ms13/guarenteed/crafting/lowrandom,
@@ -15465,6 +15467,15 @@
 /obj/item/ammo_casing/ms13/spent,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
+"gZh" = (
+/obj/structure/lattice/catwalk/ms13,
+/obj/structure/railing/ms13/solo/industrial{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
+/mob/living/simple_animal/hostile/ms13/robot/protectron,
+/turf/open/openspace/ms13,
+/area/ms13/town)
 "hcg" = (
 /turf/closed/wall/ms13/scrap/white,
 /area/ms13)
@@ -15771,7 +15782,7 @@
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "hUB" = (
-/obj/effect/spawner/random/ms13/gun/lowrandom,
+/obj/effect/spawner/random/ms13/gun/lowunique,
 /turf/open/floor/plating/ms13/ground/mountain,
 /area/ms13/underground/mountain)
 "hVh" = (
@@ -16296,8 +16307,8 @@
 /area/ms13)
 "jsS" = (
 /obj/structure/table/ms13/wood/constructed,
-/obj/effect/spawner/random/ms13/crafting/electrical,
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/mountain,
+/obj/effect/spawner/random/ms13/guarenteed/crafting/electrical,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "jtg" = (
@@ -16373,6 +16384,11 @@
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /turf/open/openspace/ms13,
 /area/ms13/supermarket)
+"jAZ" = (
+/obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
+/obj/structure/table/ms13/crafting/armorbench,
+/turf/open/floor/ms13/concrete/industrial,
+/area/ms13/town)
 "jBe" = (
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /obj/machinery/door/unpowered/ms13/wood{
@@ -16405,6 +16421,14 @@
 "jGD" = (
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
+/turf/open/floor/ms13/concrete/industrial,
+/area/ms13/town)
+"jGV" = (
+/obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
+/obj/structure/ms13/storage/shelf{
+	dir = 1
+	},
+/obj/effect/spawner/random/ms13/crafting/lowrandom,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "jHR" = (
@@ -16924,6 +16948,12 @@
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /turf/open/floor/ms13/tile/brown,
 /area/ms13/town)
+"kZd" = (
+/obj/structure/table/ms13/wood/constructed,
+/obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/mountain,
+/obj/effect/spawner/random/ms13/medical/herbal,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/town)
 "kZU" = (
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /obj/machinery/light/ms13{
@@ -16991,9 +17021,9 @@
 /area/ms13/town)
 "lki" = (
 /obj/structure/ms13/rug/mat/rubber/single,
-/obj/effect/spawner/random/ms13/ammo/tier1,
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /obj/structure/table/ms13/metal/grate,
+/obj/effect/spawner/random/ms13/ammo/lowrandom,
 /turf/open/floor/plating/ms13/roof,
 /area/ms13/town)
 "lkQ" = (
@@ -17207,6 +17237,7 @@
 /obj/structure/ms13/storage/shelf{
 	dir = 1
 	},
+/obj/effect/spawner/random/ms13/melee/lowrandom,
 /turf/open/floor/plating/ms13/roof,
 /area/ms13/town)
 "lSk" = (
@@ -17228,6 +17259,14 @@
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /turf/open/openspace/ms13,
 /area/ms13)
+"lTx" = (
+/obj/structure/ms13/storage/large/shelf{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
+/obj/effect/spawner/random/ms13/tools/tool,
+/turf/open/floor/ms13/concrete/industrial,
+/area/ms13/town)
 "lUd" = (
 /obj/structure/chair/ms13/metal{
 	dir = 8
@@ -17319,6 +17358,12 @@
 	},
 /obj/item/ms13/fluff/chems,
 /turf/open/floor/ms13/tile/large/white,
+/area/ms13/town)
+"meo" = (
+/obj/structure/table/ms13/wood/constructed,
+/obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/mountain,
+/obj/effect/spawner/random/ms13/crafting/household,
+/turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "mhv" = (
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
@@ -17610,6 +17655,14 @@
 /obj/effect/spawner/random/ms13/medical/lowrandom,
 /turf/open/floor/ms13/tile/brown,
 /area/ms13/town)
+"nhy" = (
+/obj/structure/ms13/storage/large/shelf{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/mountain,
+/obj/effect/spawner/random/ms13/crafting/lowrandom,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/town)
 "nhB" = (
 /obj/structure/ms13/rug/fancy,
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
@@ -17878,6 +17931,14 @@
 /obj/structure/chair/ms13/metal,
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /turf/open/floor/plating/ms13/roof,
+/area/ms13/town)
+"nQN" = (
+/obj/structure/ms13/storage/shelf{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
+/obj/effect/spawner/random/ms13/crafting/highrandom,
+/turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "nTC" = (
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
@@ -18727,6 +18788,12 @@
 /obj/machinery/light/ms13,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
+"qoW" = (
+/obj/structure/table/ms13/no_smooth/counter/metal,
+/obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
+/obj/effect/spawner/random/ms13/melee/lowrandom,
+/turf/open/floor/ms13/concrete/industrial,
+/area/ms13/town)
 "qpB" = (
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /mob/living/basic/ms13/ghoul,
@@ -18735,6 +18802,7 @@
 "qrw" = (
 /obj/structure/ms13/rug/red,
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
+/obj/effect/spawner/random/ms13/clothing/shoe,
 /turf/open/floor/plating/ms13/roof,
 /area/ms13/town)
 "qrV" = (
@@ -18953,6 +19021,12 @@
 	dir = 4
 	},
 /turf/open/floor/ms13/tile/large/checkered,
+/area/ms13/town)
+"qYR" = (
+/obj/structure/table/ms13/metal/grate,
+/obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
+/obj/effect/spawner/random/ms13/tools/hardware,
+/turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "rad" = (
 /obj/structure/ms13/skeleton,
@@ -19491,6 +19565,7 @@
 	dir = 8
 	},
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/mountain,
+/obj/effect/spawner/random/ms13/drink/alcohol_beer,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "sPC" = (
@@ -19816,6 +19891,7 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
+/obj/effect/spawner/random/ms13/crafting/lowrandom,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "tRF" = (
@@ -20404,6 +20480,11 @@
 /obj/effect/spawner/random/ms13/tools/radio,
 /turf/open/floor/wood/ms13/mosaic,
 /area/ms13/town)
+"vAh" = (
+/obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
+/mob/living/basic/ms13/ghoul,
+/turf/open/floor/ms13/concrete/industrial,
+/area/ms13/town)
 "vCd" = (
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /obj/machinery/door/poddoor/shutters/ms13/horizontal/indestructible/red/right,
@@ -20579,8 +20660,9 @@
 /turf/open/floor/ms13/tile/large/cream,
 /area/ms13/town)
 "wli" = (
-/obj/effect/spawner/random/ms13/food/produce_random,
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/mountain,
+/obj/effect/spawner/random/ms13/food/packaged,
+/obj/effect/spawner/random/ms13/food/packaged,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "wlv" = (
@@ -20655,8 +20737,8 @@
 /obj/structure/table/ms13/no_smooth/counter/metal{
 	dir = 8
 	},
-/obj/effect/spawner/random/ms13/crafting/highrandom,
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
+/obj/effect/spawner/random/ms13/crafting/lowrandom,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "wtT" = (
@@ -21034,7 +21116,6 @@
 /area/ms13/town)
 "xzj" = (
 /obj/effect/spawner/random/ms13/medical/lowrandom,
-/obj/effect/spawner/random/ms13/medical/lowrandom,
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/mountain,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
@@ -21120,6 +21201,7 @@
 /obj/effect/spawner/random/ms13/food/produce_random,
 /obj/effect/spawner/random/ms13/food/produce_random,
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/mountain,
+/obj/effect/spawner/random/ms13/food/produce_random,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "xLy" = (
@@ -22158,7 +22240,7 @@ aPY
 aPY
 yka
 wXj
-aQM
+cAM
 unC
 jPd
 yka
@@ -22752,9 +22834,9 @@ aPY
 aPY
 yka
 yka
-xlG
+meo
 wXj
-aQM
+nhy
 yka
 yka
 aPY
@@ -24283,7 +24365,7 @@ yka
 uDY
 wXj
 wli
-aQM
+cAM
 yka
 aPY
 aPY
@@ -24885,7 +24967,7 @@ ltX
 nMB
 yka
 yka
-dEk
+cki
 wXj
 yka
 yka
@@ -25791,10 +25873,10 @@ nMB
 nMB
 gMl
 yka
-xlG
+kZd
 wXj
-wli
-aQM
+wXj
+wXj
 yka
 aPY
 aPY
@@ -27238,7 +27320,7 @@ aYa
 aYa
 aYa
 aXI
-aYz
+qoW
 aYa
 aYa
 ayr
@@ -27535,7 +27617,7 @@ abJ
 abJ
 aLH
 aXI
-aMe
+aQX
 aYa
 aYa
 aYa
@@ -27839,7 +27921,7 @@ aLH
 aXI
 aMK
 aYa
-aYa
+vAh
 aYa
 aYa
 aYa
@@ -27849,7 +27931,7 @@ aYa
 aQg
 aYa
 aYa
-aYa
+aNM
 aYa
 aMJ
 aLH
@@ -28149,7 +28231,7 @@ aYa
 aYa
 aYa
 aXI
-lKO
+jAZ
 aYa
 aYa
 aYa
@@ -28491,7 +28573,7 @@ yka
 yka
 yka
 xzj
-aQM
+cpt
 yka
 yka
 yka
@@ -29074,7 +29156,7 @@ aAF
 aAF
 aYA
 aYa
-afz
+lTx
 aYA
 aPY
 aPY
@@ -29369,7 +29451,7 @@ aPY
 aYA
 alG
 aYa
-ayr
+nQN
 aYA
 aYz
 akm
@@ -29407,7 +29489,7 @@ aPY
 aPY
 fMw
 xYr
-cCU
+nMB
 nMB
 nMB
 fMw
@@ -29669,11 +29751,11 @@ aLH
 abJ
 abJ
 aAF
-adq
+hnm
 aYa
 aZj
 aYA
-aYz
+col
 aYa
 aYa
 aYa
@@ -30879,7 +30961,7 @@ aYA
 rKt
 aft
 aft
-ajN
+aft
 aBM
 aft
 aft
@@ -31790,8 +31872,8 @@ aYA
 arq
 hyL
 aft
-auG
 aYa
+fgz
 aYa
 aYA
 aYA
@@ -32359,7 +32441,7 @@ aZO
 aqY
 arP
 ahd
-auk
+aIy
 aCj
 aCj
 aCj
@@ -32390,7 +32472,7 @@ qzE
 aft
 aoD
 aoD
-aoD
+gZh
 aoD
 aft
 aft
@@ -32697,7 +32779,7 @@ aft
 aft
 aft
 aYA
-bcf
+jGV
 aMu
 aYA
 aKQ
@@ -33301,7 +33383,7 @@ aQX
 aYa
 aYa
 agi
-aGr
+qYR
 iYJ
 aYA
 aPY

--- a/_maps/map_files/Mammoth/Mammoth_below.dmm
+++ b/_maps/map_files/Mammoth/Mammoth_below.dmm
@@ -12555,8 +12555,8 @@
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/underground/army_bunker)
 "bFy" = (
-/obj/effect/mob_spawn/corpse/human/charredskeleton,
 /obj/effect/decal/cleanable/blood/splatter,
+/obj/effect/mob_spawn/corpse/human/ms13/wastelander,
 /turf/open/floor/ms13/sewer,
 /area/ms13/underground/sewer)
 "bFO" = (
@@ -12686,6 +12686,13 @@
 	pixel_y = 6
 	},
 /turf/open/floor/ms13/concrete,
+/area/ms13/underground/underground_town)
+"cgs" = (
+/obj/structure/closet/crate/ms13/woodcrate/compact,
+/obj/effect/spawner/random/ms13/food/packaged,
+/obj/effect/spawner/random/ms13/food/packaged,
+/obj/effect/spawner/random/ms13/food/packaged,
+/turf/open/floor/wood/ms13/wide,
 /area/ms13/underground/underground_town)
 "cgH" = (
 /obj/structure/chair/comfy/ms13/ergo{
@@ -13064,6 +13071,13 @@
 /obj/effect/spawner/random/ms13/medical/lowrandom,
 /turf/open/floor/ms13/tile/fancy,
 /area/ms13/town)
+"drL" = (
+/obj/structure/ms13/storage/shelf{
+	dir = 1
+	},
+/obj/effect/spawner/random/ms13/tools/hardware,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/underground/underground_town)
 "drV" = (
 /obj/structure/ms13/bars/rusty,
 /turf/open/floor/wood/ms13/wide,
@@ -13089,8 +13103,8 @@
 /area/ms13/underground/underground_town)
 "dCb" = (
 /obj/structure/closet/crate/ms13/army,
-/obj/effect/spawner/random/ms13/ammo/tier1,
-/obj/effect/spawner/random/ms13/ammo/tier2,
+/obj/effect/spawner/random/ms13/ammo/tier3,
+/obj/effect/spawner/random/ms13/ammo/highrandom,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/underground/underground_town)
 "dCI" = (
@@ -13273,6 +13287,11 @@
 /obj/effect/spawner/random/ms13/crafting/lowrandom,
 /turf/open/floor/ms13/metal,
 /area/ms13/underground/military_crypt)
+"eeU" = (
+/obj/structure/table/ms13/metal/grate,
+/obj/effect/spawner/random/ms13/tools/tool,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/underground/underground_town)
 "efw" = (
 /obj/structure/table/ms13/metal/heavy,
 /obj/effect/spawner/random/ms13/tools/lights,
@@ -13289,6 +13308,11 @@
 	},
 /turf/open/floor/ms13/concrete/industrial/alt,
 /area/ms13/town)
+"eiN" = (
+/obj/structure/table/ms13/no_smooth/counter/wood/crafted,
+/obj/effect/spawner/random/ms13/tools/hardware,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/underground/underground_town)
 "ejJ" = (
 /obj/structure/ms13/skeleton,
 /obj/item/clothing/head/helmet/ms13/police{
@@ -13562,10 +13586,6 @@
 	},
 /turf/open/floor/ms13/concrete,
 /area/ms13/town)
-"fwP" = (
-/obj/effect/spawner/random/ms13/crafting/precious,
-/turf/open/floor/wood/ms13/wide,
-/area/ms13/underground/underground_town)
 "fxo" = (
 /obj/structure/table/ms13/crafting/weaponbench,
 /turf/open/floor/ms13/concrete,
@@ -13576,7 +13596,7 @@
 /area/ms13/underground/underground_town)
 "fBS" = (
 /obj/structure/closet/crate/ms13/woodcrate,
-/obj/effect/spawner/random/ms13/guarenteed/crafting/precious,
+/obj/effect/spawner/random/ms13/crafting/refined,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/underground/underground_town)
 "fCf" = (
@@ -13587,6 +13607,8 @@
 "fEd" = (
 /obj/structure/ms13/rug/mat/rubber/single,
 /obj/structure/table/rolling/ms13,
+/obj/effect/spawner/random/ms13/medical/surgical,
+/obj/effect/spawner/random/ms13/medical/surgical,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/underground/underground_town)
 "fFi" = (
@@ -13640,11 +13662,6 @@
 /obj/effect/spawner/random/ms13/clothing/under,
 /turf/open/floor/wood/ms13/carpet/blue,
 /area/ms13/town)
-"fQW" = (
-/obj/structure/table/ms13/metal/grate,
-/obj/effect/spawner/random/ms13/ammo/tier3,
-/turf/open/floor/wood/ms13/wide,
-/area/ms13/underground/underground_town)
 "fRu" = (
 /obj/machinery/light/ms13,
 /turf/open/floor/ms13/concrete/bricks,
@@ -13813,6 +13830,13 @@
 /obj/structure/bed/ms13/mattress/dirty,
 /turf/open/floor/ms13/concrete,
 /area/ms13/underground/underground_town)
+"gwh" = (
+/obj/structure/ms13/storage/large/shelf{
+	dir = 1
+	},
+/obj/effect/spawner/random/ms13/tools/hardware,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/underground/underground_town)
 "gwj" = (
 /obj/structure/table/ms13/no_smooth/counter/wood{
 	dir = 1
@@ -13893,22 +13917,10 @@
 	},
 /turf/open/floor/ms13/sewer,
 /area/ms13/underground/underground_town)
-"gGb" = (
-/obj/structure/table/ms13/metal/grate,
-/obj/effect/spawner/random/ms13/medical/lowrandom,
-/obj/effect/spawner/random/ms13/medical/lowrandom,
-/turf/open/floor/wood/ms13/wide,
-/area/ms13/underground/underground_town)
 "gGs" = (
 /mob/living/basic/ms13/hostile_animal/molerat,
 /turf/open/floor/ms13/sewer,
 /area/ms13/underground/sewer)
-"gHg" = (
-/obj/item/reagent_containers/blood/ms13/radaway{
-	pixel_x = -6
-	},
-/turf/closed/wall/ms13/wood,
-/area/ms13/underground/underground_town)
 "gHY" = (
 /obj/machinery/light/ms13{
 	dir = 4
@@ -13944,6 +13956,12 @@
 /obj/effect/turf_decal/ms13/graffiti/camp_north,
 /turf/open/floor/ms13/sewer,
 /area/ms13/underground/sewer)
+"gQq" = (
+/obj/structure/ms13/storage/shelf,
+/obj/effect/spawner/random/ms13/food/packaged,
+/obj/effect/spawner/random/ms13/food/packaged,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/underground/underground_town)
 "gQG" = (
 /obj/machinery/button/ms13{
 	dir = 4;
@@ -14050,6 +14068,13 @@
 	},
 /turf/open/floor/ms13/sewer,
 /area/ms13/underground/sewer)
+"hxx" = (
+/obj/structure/ms13/storage/shelf{
+	dir = 1
+	},
+/obj/effect/spawner/random/ms13/tools/radio,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/underground/underground_town)
 "hyh" = (
 /obj/machinery/door/poddoor/shutters/ms13/horizontal/red/right/pre_open,
 /turf/open/floor/ms13/metal/walkway,
@@ -14105,6 +14130,7 @@
 /obj/structure/ms13/storage/shelf{
 	dir = 1
 	},
+/obj/effect/spawner/random/ms13/medical/lowrandom,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/underground/underground_town)
 "hFl" = (
@@ -14163,6 +14189,8 @@
 "hNk" = (
 /obj/structure/closet/crate/ms13/medical,
 /obj/effect/spawner/random/ms13/medical/bloodbag,
+/obj/effect/spawner/random/ms13/medical/bloodbag,
+/obj/effect/spawner/random/ms13/medical/bloodbag,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/underground/underground_town)
 "hNG" = (
@@ -14177,6 +14205,13 @@
 /obj/effect/decal/cleanable/blood/splatter,
 /obj/effect/spawner/random/ms13/gun/tier1,
 /turf/open/floor/ms13/concrete,
+/area/ms13/underground/underground_town)
+"hRu" = (
+/obj/structure/table/ms13/no_smooth/counter/wood/crafted{
+	dir = 1
+	},
+/obj/effect/spawner/random/ms13/medical/herbal,
+/turf/open/floor/wood/ms13/wide,
 /area/ms13/underground/underground_town)
 "hSa" = (
 /obj/structure/table/ms13/no_smooth/counter/wood/crafted,
@@ -14209,7 +14244,7 @@
 /area/ms13/town)
 "hZc" = (
 /obj/structure/table/ms13/metal/grate,
-/obj/item/reagent_containers/blood/ms13/radaway,
+/obj/effect/spawner/random/ms13/medical/bloodbag,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/underground/underground_town)
 "hZR" = (
@@ -14243,6 +14278,12 @@
 	},
 /turf/open/floor/ms13/tile/large/cream,
 /area/ms13/underground/sewer)
+"idz" = (
+/obj/structure/closet/crate/ms13/woodcrate,
+/obj/effect/spawner/random/ms13/crafting/precious,
+/obj/effect/spawner/random/ms13/crafting/refined,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/underground/underground_town)
 "iff" = (
 /obj/structure/bed/ms13/bedframe/wood,
 /obj/structure/bed/ms13/mattress/filthy,
@@ -14486,6 +14527,11 @@
 /obj/effect/spawner/random/ms13/guarenteed/crafting/electrical,
 /turf/open/floor/ms13/metal/grate,
 /area/ms13/town)
+"jdz" = (
+/obj/structure/table/ms13/wood/constructed,
+/obj/effect/spawner/random/ms13/clothing/hat,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/underground/underground_town)
 "jen" = (
 /obj/structure/fluff/ms13/trash/papers{
 	dir = 1
@@ -14500,6 +14546,16 @@
 "jiu" = (
 /turf/open/floor/ms13/tile/navy,
 /area/ms13/town)
+"jml" = (
+/obj/structure/table/ms13/wood/constructed,
+/obj/effect/spawner/random/ms13/melee/lowrandom,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/underground/underground_town)
+"jph" = (
+/obj/structure/table/ms13/metal/grate,
+/obj/effect/spawner/random/ms13/medical/surgical,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/underground/underground_town)
 "jpK" = (
 /obj/structure/ms13/skeleton,
 /obj/effect/decal/cleanable/blood/splatter,
@@ -14756,6 +14812,13 @@
 /obj/structure/bed/ms13/sleepingbag/red,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/underground/underground_town)
+"kzA" = (
+/obj/structure/ms13/storage/large/shelf{
+	dir = 4
+	},
+/obj/effect/spawner/random/ms13/tools/tool,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/underground/underground_town)
 "kAx" = (
 /obj/machinery/ms13/terminal,
 /obj/structure/table/ms13/no_smooth/large/metal/desk,
@@ -14806,6 +14869,13 @@
 /obj/structure/table/ms13/metal/grate,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/underground/sewer)
+"kMt" = (
+/obj/structure/ms13/storage/shelf{
+	dir = 4
+	},
+/obj/effect/spawner/random/ms13/medical/tier1,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/underground/underground_town)
 "kMF" = (
 /obj/machinery/light/ms13/bulb,
 /turf/open/floor/ms13/concrete,
@@ -15148,13 +15218,6 @@
 /obj/effect/spawner/random/ms13/ammo/lowrandom,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/underground/army_bunker)
-"lSB" = (
-/obj/item/reagent_containers/food/drinks/mug/ms13{
-	pixel_x = -4;
-	pixel_y = 5
-	},
-/turf/open/floor/wood/ms13/wide,
-/area/ms13/underground/underground_town)
 "lUR" = (
 /obj/structure/ms13/skeleton,
 /obj/effect/decal/cleanable/blood/old{
@@ -15169,10 +15232,6 @@
 "lVH" = (
 /obj/structure/chair/ms13/metal/stool,
 /turf/open/floor/ms13/concrete/bricks,
-/area/ms13/underground/underground_town)
-"lVO" = (
-/obj/effect/spawner/random/ms13/ammo/tier1,
-/turf/open/floor/wood/ms13/wide,
 /area/ms13/underground/underground_town)
 "lXe" = (
 /obj/machinery/light/ms13/bulb/industrial{
@@ -15212,6 +15271,13 @@
 /obj/structure/closet/crate/ms13/woodcrate,
 /obj/effect/spawner/random/ms13/crafting/precious,
 /turf/open/floor/ms13/concrete/bricks,
+/area/ms13/underground/underground_town)
+"meJ" = (
+/obj/structure/ms13/storage/large/shelf{
+	dir = 4
+	},
+/obj/effect/spawner/random/ms13/ammo/lowrandom,
+/turf/open/floor/wood/ms13/wide,
 /area/ms13/underground/underground_town)
 "mgl" = (
 /obj/structure/ms13/rug/fancy{
@@ -15289,6 +15355,7 @@
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "myV" = (
+/obj/effect/spawner/random/ms13/crafting/highrandom,
 /obj/effect/spawner/random/ms13/crafting/highrandom,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/underground/underground_town)
@@ -15400,12 +15467,11 @@
 /area/ms13/underground/underground_town)
 "mWQ" = (
 /obj/structure/table/ms13/wood/constructed,
-/obj/effect/spawner/random/ms13/gun/tier1,
-/obj/effect/spawner/random/ms13/ammo/tier2,
+/obj/effect/spawner/random/ms13/gun/lowrandom,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/underground/underground_town)
 "mYl" = (
-/obj/effect/spawner/random/ms13/ammo/tier2,
+/obj/effect/spawner/random/ms13/ammo/lowrandom,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/underground/underground_town)
 "mYR" = (
@@ -15425,7 +15491,7 @@
 /area/ms13/underground/sewer)
 "nal" = (
 /obj/structure/table/ms13/no_smooth/counter/wood/crafted,
-/obj/item/storage/firstaid/ms13{
+/obj/item/storage/firstaid/ms13/regular{
 	pixel_y = 8
 	},
 /turf/open/floor/wood/ms13/wide,
@@ -15609,6 +15675,10 @@
 /obj/structure/bed/ms13/mattress/yellowed,
 /turf/open/floor/wood/ms13/carpet/blue,
 /area/ms13/town)
+"nLb" = (
+/obj/effect/spawner/random/ms13/melee/unique,
+/turf/open/floor/plating/ms13/ground/mountain,
+/area/ms13/underground/mountain)
 "nMm" = (
 /obj/machinery/door/unpowered/ms13/metal/mirrored{
 	dir = 1
@@ -15628,8 +15698,7 @@
 /area/ms13/underground/underground_town)
 "nOD" = (
 /obj/structure/table/ms13/no_smooth/counter/wood/crafted,
-/obj/effect/spawner/random/ms13/gun/tier1,
-/obj/effect/spawner/random/ms13/ammo/tier3,
+/obj/effect/spawner/random/ms13/gun/lowrandom,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/underground/underground_town)
 "nQd" = (
@@ -15713,6 +15782,7 @@
 /obj/structure/ms13/storage/shelf{
 	dir = 1
 	},
+/obj/effect/spawner/random/ms13/crafting/lowrandom,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/underground/underground_town)
 "oeW" = (
@@ -15786,6 +15856,8 @@
 /area/ms13/underground/army_bunker)
 "ooH" = (
 /obj/structure/closet/crate/ms13/woodcrate/compact,
+/obj/effect/spawner/random/ms13/food/produce_mushrooms,
+/obj/effect/spawner/random/ms13/food/produce_mushrooms,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/underground/underground_town)
 "opq" = (
@@ -15806,10 +15878,7 @@
 /turf/open/floor/ms13/tile/long,
 /area/ms13/town)
 "oqP" = (
-/obj/item/pickaxe/ms13{
-	pixel_x = 7;
-	pixel_y = -2
-	},
+/obj/effect/spawner/random/ms13/tools/tool,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/underground/underground_town)
 "oro" = (
@@ -15822,6 +15891,11 @@
 /obj/structure/ms13/skeleton,
 /obj/effect/decal/cleanable/blood/splatter,
 /obj/effect/spawner/random/ms13/melee/lowrandom,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/underground/underground_town)
+"owY" = (
+/obj/structure/table/ms13/wood/constructed,
+/obj/effect/spawner/random/ms13/ammo/tier1,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/underground/underground_town)
 "oyV" = (
@@ -16075,6 +16149,11 @@
 	},
 /turf/open/floor/ms13/metal,
 /area/ms13/underground/vault_atrium_lower)
+"pgF" = (
+/obj/structure/table/ms13/wood/constructed,
+/obj/effect/spawner/random/ms13/tools/hardware,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/underground/underground_town)
 "pgT" = (
 /obj/structure/ms13/storage/trashcan,
 /turf/open/floor/ms13/concrete/bricks,
@@ -16106,8 +16185,7 @@
 /area/ms13/underground/underground_town)
 "pnk" = (
 /obj/structure/closet/crate/ms13/footlocker,
-/obj/effect/spawner/random/ms13/drink/soda,
-/obj/effect/spawner/random/ms13/drink/soda,
+/obj/effect/spawner/random/ms13/armor/lowrandom,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/underground/underground_town)
 "pnz" = (
@@ -16201,7 +16279,6 @@
 /obj/machinery/ms13/coffee{
 	pixel_y = 8
 	},
-/obj/item/reagent_containers/food/drinks/mug/ms13,
 /obj/structure/table/ms13/no_smooth/counter/wood/crafted/bend,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/underground/underground_town)
@@ -16227,8 +16304,8 @@
 /area/ms13/underground/mountain)
 "pNH" = (
 /obj/structure/closet/crate/ms13/aluminum,
-/obj/effect/spawner/random/ms13/ammo/tier3,
-/obj/effect/spawner/random/ms13/ammo/tier3,
+/obj/effect/spawner/random/ms13/ammo/lowrandom,
+/obj/effect/spawner/random/ms13/ammo/lowrandom,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/underground/underground_town)
 "pNI" = (
@@ -16425,7 +16502,7 @@
 /area/ms13/underground/mountain)
 "qzJ" = (
 /obj/structure/table/ms13/metal/grate,
-/obj/effect/spawner/random/ms13/gun/tier1,
+/obj/effect/spawner/random/ms13/gun/lowrandom,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/underground/underground_town)
 "qzW" = (
@@ -16438,8 +16515,13 @@
 /obj/structure/table/ms13/wood/constructed,
 /obj/effect/spawner/random/ms13/crafting/lowrandom,
 /obj/effect/spawner/random/ms13/crafting/highrandom,
-/obj/effect/spawner/random/ms13/crafting/highrandom,
-/obj/effect/spawner/random/ms13/crafting/highrandom,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/underground/underground_town)
+"qDT" = (
+/obj/structure/ms13/storage/shelf{
+	dir = 1
+	},
+/obj/effect/spawner/random/ms13/tools/tool,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/underground/underground_town)
 "qEs" = (
@@ -16590,7 +16672,7 @@
 /area/ms13/underground/mountain)
 "rvK" = (
 /obj/structure/table/ms13/metal/grate,
-/obj/effect/spawner/random/ms13/guarenteed/tools/tool,
+/obj/effect/spawner/random/ms13/ammo/lowrandom,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/underground/underground_town)
 "rwJ" = (
@@ -16693,7 +16775,7 @@
 /area/ms13/underground/underground_town)
 "rLH" = (
 /obj/structure/table/ms13/no_smooth/counter/wood/crafted,
-/obj/effect/spawner/random/ms13/tools/tool,
+/obj/effect/spawner/random/ms13/crafting/electrical,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/underground/underground_town)
 "rLV" = (
@@ -16748,6 +16830,8 @@
 /obj/structure/closet/crate/ms13/footlocker{
 	dir = 4
 	},
+/obj/effect/spawner/random/ms13/crafting/household,
+/obj/effect/spawner/random/ms13/crafting/household,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/underground/underground_town)
 "rZz" = (
@@ -17040,6 +17124,7 @@
 /obj/structure/ms13/rug/red{
 	dir = 4
 	},
+/obj/effect/spawner/random/ms13/drink/soda,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/underground/underground_town)
 "sUA" = (
@@ -17144,6 +17229,14 @@
 /obj/structure/table/ms13/crafting/armorbench,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/underground/underground_town)
+"tnO" = (
+/obj/structure/ms13/storage/large/shelf{
+	dir = 8
+	},
+/obj/effect/spawner/random/ms13/tools/tool,
+/obj/effect/spawner/random/ms13/tools/tool,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/underground/underground_town)
 "tpy" = (
 /obj/effect/spawner/random/ms13/clothing/hat,
 /turf/open/floor/ms13/concrete,
@@ -17173,8 +17266,8 @@
 /area/ms13/underground/vault_atrium_lower)
 "tzs" = (
 /obj/structure/closet/crate/ms13/woodcrate/compact,
-/obj/effect/spawner/random/ms13/crafting/household,
-/obj/effect/spawner/random/ms13/crafting/household,
+/obj/effect/spawner/random/ms13/crafting/lowrandom,
+/obj/effect/spawner/random/ms13/crafting/lowrandom,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/underground/underground_town)
 "tAf" = (
@@ -17273,8 +17366,7 @@
 /obj/structure/safe/ms13,
 /obj/effect/spawner/random/ms13/guarenteed/crafting/precious,
 /obj/effect/spawner/random/ms13/guarenteed/crafting/precious,
-/obj/effect/spawner/random/ms13/guarenteed/crafting/precious,
-/obj/effect/spawner/random/ms13/guarenteed/gun/tier3,
+/obj/effect/spawner/random/ms13/gun/tier3,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/underground/underground_town)
 "tSb" = (
@@ -17357,6 +17449,7 @@
 	dir = 4
 	},
 /obj/effect/spawner/random/ms13/gun/tier1,
+/obj/effect/spawner/random/ms13/ammo/tier1,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/underground/underground_town)
 "ucv" = (
@@ -17630,11 +17723,6 @@
 /obj/structure/ms13/tank,
 /turf/open/floor/plating/ms13/ground/mountain,
 /area/ms13/underground/mountain)
-"vbu" = (
-/obj/structure/closet/crate/ms13/footlocker,
-/obj/effect/spawner/random/ms13/food/produce_random,
-/turf/open/floor/wood/ms13/wide,
-/area/ms13/underground/underground_town)
 "vbZ" = (
 /mob/living/basic/ms13/hostile_animal/giantant,
 /turf/open/floor/plating/ms13/ground/mountain,
@@ -17804,6 +17892,10 @@
 	},
 /turf/open/floor/ms13/concrete/industrial/split,
 /area/ms13/underground/vault_atrium_lower)
+"vJr" = (
+/obj/effect/spawner/random/ms13/medical/herbal,
+/turf/open/floor/plating/ms13/ground/mountain,
+/area/ms13/underground/mountain)
 "vJE" = (
 /obj/structure/table/ms13/wood,
 /obj/structure/ms13/phone/black{
@@ -17816,6 +17908,13 @@
 /obj/structure/flora/junglebush/large,
 /turf/open/floor/plating/ms13/ground/mountain,
 /area/ms13/underground/mountain)
+"vPh" = (
+/obj/structure/ms13/storage/large/shelf{
+	dir = 8
+	},
+/obj/effect/spawner/random/ms13/ammo/lowrandom,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/underground/underground_town)
 "vPO" = (
 /obj/machinery/light/ms13{
 	dir = 1
@@ -18269,6 +18368,11 @@
 /obj/effect/spawner/random/ms13/armor/highrandom,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
+"xXc" = (
+/obj/structure/table/ms13/no_smooth/wood/stand,
+/obj/effect/spawner/random/ms13/drink/soda,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/underground/underground_town)
 "xYg" = (
 /obj/structure/ms13/skeleton,
 /obj/effect/decal/cleanable/blood/splatter,
@@ -22192,10 +22296,10 @@ akx
 akx
 akx
 akx
-hSa
+eiN
 qzJ
 aff
-doq
+meJ
 aEQ
 afU
 afU
@@ -22796,7 +22900,7 @@ akx
 akx
 akx
 akx
-hSa
+eiN
 aff
 aff
 aff
@@ -23083,7 +23187,7 @@ aEQ
 aEQ
 aEQ
 aEQ
-lSB
+aff
 mgH
 aff
 aEQ
@@ -23989,7 +24093,7 @@ aEQ
 kRO
 aff
 aEQ
-spV
+owY
 ajG
 mTV
 aff
@@ -24594,7 +24698,7 @@ akx
 akx
 aYb
 aEQ
-aNI
+drL
 aff
 aff
 aff
@@ -26103,11 +26207,11 @@ afU
 afU
 afU
 aEQ
-lVO
-mIf
+mYl
+vPh
 mWQ
 mYl
-mIf
+vPh
 aEQ
 afU
 afU
@@ -26992,7 +27096,7 @@ akx
 aWu
 afU
 aEQ
-dYh
+idz
 aff
 fbk
 doq
@@ -27597,7 +27701,7 @@ akx
 akx
 dEt
 aff
-dYh
+fBS
 aff
 aff
 aEQ
@@ -28202,7 +28306,7 @@ aWu
 aEQ
 eSq
 tJd
-fwP
+aff
 doq
 aEQ
 afU
@@ -28492,7 +28596,7 @@ afU
 afU
 afU
 aEQ
-bka
+gwh
 cnS
 aff
 aaO
@@ -29427,7 +29531,7 @@ akx
 akx
 aEQ
 myV
-qtd
+tnO
 qCo
 nic
 aEQ
@@ -31242,7 +31346,7 @@ aEQ
 aEQ
 aEQ
 aEQ
-fQW
+qzJ
 rvK
 aEQ
 aEQ
@@ -31514,9 +31618,9 @@ afU
 afU
 afU
 aEQ
-ooH
+cgs
 uoD
-doq
+kzA
 aEQ
 aff
 aff
@@ -31816,7 +31920,7 @@ afU
 afU
 afU
 aEQ
-vbu
+aff
 otb
 aff
 aEQ
@@ -32118,7 +32222,7 @@ afU
 afU
 afU
 aEQ
-vbu
+sPd
 eWL
 cRh
 uJU
@@ -32741,8 +32845,8 @@ afU
 aEQ
 dkG
 hNk
-aff
-kEb
+auR
+kMt
 aEQ
 aEQ
 aEQ
@@ -33343,7 +33447,7 @@ afU
 afU
 afU
 aEQ
-gGb
+dkG
 aff
 aff
 aff
@@ -33949,7 +34053,7 @@ fEd
 gel
 yer
 hZc
-afa
+jph
 aff
 aff
 yer
@@ -34232,7 +34336,7 @@ afU
 afU
 afU
 aEQ
-spV
+jml
 aff
 aff
 aEQ
@@ -34275,7 +34379,7 @@ aEQ
 pDv
 aff
 aEQ
-aNI
+hxx
 pTP
 tZI
 uEh
@@ -34539,7 +34643,7 @@ aff
 acf
 aEQ
 ncu
-spV
+jdz
 aqj
 aEQ
 afU
@@ -34577,7 +34681,7 @@ aEQ
 aEQ
 aEQ
 aEQ
-aNI
+qDT
 aff
 ncu
 uIk
@@ -34853,7 +34957,7 @@ afU
 aEQ
 aEQ
 aEQ
-gHg
+aEQ
 kEb
 aff
 aff
@@ -34882,7 +34986,7 @@ rLG
 aff
 aff
 aff
-akm
+gQq
 aEQ
 afU
 afU
@@ -35164,7 +35268,7 @@ aff
 aff
 lvu
 aEQ
-akx
+vJr
 aew
 aYr
 aZb
@@ -36646,7 +36750,7 @@ afU
 afU
 afU
 aEQ
-bpy
+hRu
 abi
 aff
 kEb
@@ -36989,10 +37093,10 @@ afU
 afU
 aEQ
 aEQ
-alR
+aff
 doq
 aEQ
-spV
+pgF
 sTR
 aEQ
 afU
@@ -37280,7 +37384,7 @@ afU
 afU
 afU
 akx
-akx
+awI
 akx
 afU
 afU
@@ -38205,7 +38309,7 @@ aff
 aff
 aaO
 akx
-akx
+aaS
 vac
 vac
 vac
@@ -38498,7 +38602,7 @@ afp
 akx
 akx
 aEQ
-ppD
+xXc
 aff
 qvP
 aEQ
@@ -39996,7 +40100,7 @@ aYb
 akx
 akx
 hSa
-afa
+eeU
 trm
 doq
 aEQ
@@ -42121,7 +42225,7 @@ afU
 afU
 afU
 aNR
-akx
+nLb
 akx
 aew
 afU


### PR DESCRIPTION
## About The Pull Request

This is basically just a touch up to the mining facility area of the map. This includes the mining facility itself, the ant village, the molerat village, and the Radscorpion hell village underground. Mostly this is just some loot and mob tweaks to make the area make more sense, it's a mixture of toning down some loot in areas that had way too much or too high tier loot and didn't deserve it, and toning up some loot in areas that were pretty hard to clear and deserved a better reward. The only actual layout change I've done is moved the Yaoguai further into a cave to prevent people from getting insta fragged by him the second they enter the mine. I saw this happen numerous times last testing period. 

## Why It's Good For The Game

Well balanced areas are good and fun for the players and the previous iteration of this area of the map needed a lot of love on the gameplay side of things, the actual layout of the area is pretty good overall though. 