### PR TITLE
Gives stairs slowdown

### DIFF
--- a/code/__DEFINES/zmojave_defines/traits.dm
+++ b/code/__DEFINES/zmojave_defines/traits.dm
@@ -1,3 +1,5 @@
 #define TRAIT_REMOVE_SLOWDOWN "remove_slowdown" // Used by structures if you want to remove turf slowdown below it
+#define TRAIT_ADD_SLOWDOWN "add_slowdown" // Used by structures if you want to add turf slowdown above it
 #define CATWALK_ON_TURF "catwalk_on_turf" // Source for adding/removing traits, namely the above trait
 #define BOARDS_ON_TURF "boards_on_turf" // Like above, but for board walkways
+#define STAIRS_ON_TURF "stairs_on_turf" // Like above, but for stairs!

--- a/code/game/objects/structures/stairs.dm
+++ b/code/game/objects/structures/stairs.dm
@@ -40,10 +40,20 @@
 
 	AddElement(/datum/element/connect_loc, loc_connections)
 
+	// MOJAVE SUN EDIT BEGIN
+	var/turf/my_turf = get_turf(loc)
+	if(my_turf)
+		ADD_TRAIT(my_turf, TRAIT_ADD_SLOWDOWN, STAIRS_ON_TURF)
+	// MOJAVE SUN EDIT END
 	return ..()
 
 /obj/structure/stairs/Destroy()
 	listeningTo = null
+	// MOJAVE SUN EDIT BEGIN
+	var/turf/my_turf = get_turf(loc)
+	if(my_turf)
+		REMOVE_TRAIT(my_turf, TRAIT_REMOVE_SLOWDOWN, BOARDS_ON_TURF)
+	// MOJAVE SUN EDIT END
 	return ..()
 
 /obj/structure/stairs/Move() //Look this should never happen but...

--- a/code/game/objects/structures/stairs.dm
+++ b/code/game/objects/structures/stairs.dm
@@ -52,7 +52,7 @@
 	// MOJAVE SUN EDIT BEGIN
 	var/turf/my_turf = get_turf(loc)
 	if(my_turf)
-		REMOVE_TRAIT(my_turf, TRAIT_REMOVE_SLOWDOWN, BOARDS_ON_TURF)
+		REMOVE_TRAIT(my_turf, TRAIT_REMOVE_SLOWDOWN, STAIRS_ON_TURF)
 	// MOJAVE SUN EDIT END
 	return ..()
 

--- a/code/modules/mob/living/living_movement.dm
+++ b/code/modules/mob/living/living_movement.dm
@@ -30,6 +30,9 @@
 	if(isopenturf(T))
 		if(HAS_TRAIT(T, TRAIT_REMOVE_SLOWDOWN)) //MOJAVE SUN EDIT STARTS
 			add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/turf_slowdown, multiplicative_slowdown = 0)
+			return
+		else if(HAS_TRAIT(T, TRAIT_ADD_SLOWDOWN))
+			add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/turf_slowdown, multiplicative_slowdown = 4)
 			return //MOJAVE SUN EDIT ENDS
 		add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/turf_slowdown, multiplicative_slowdown = T.slowdown)
 	else


### PR DESCRIPTION

## About The Pull Request

https://user-images.githubusercontent.com/51188571/185577239-9011a54d-9942-408b-b576-898b5724a04f.mp4

As the title says, this adds a slowdown to stairs! This will help prevent people GAMING and also add slightly to the atmosphere of the server. This of course keeps stairs as a more reliable Z-transition method, (flying off the side of a roof is a close contender)

The slowdown additive is a bit hardcoded, and could probably be expanded to multiple slowdown values later on, but I don't foresee many structures that would need to give turfs a slowdown, so I decided to just hardcode the multiplicative slowdown at '4'.  I really can't imagine what else we'd ever use this for, anyways.

Hello, future self!

## Why It's Good For The Game

Good for the atmosphere, soul, and balance.

