### PR TITLE
Fixes Medical Lamp & Desc Fixes

### DIFF
--- a/mojave/items/clothing/head/helmet.dm
+++ b/mojave/items/clothing/head/helmet.dm
@@ -332,7 +332,7 @@
 
 /obj/item/clothing/head/helmet/ms13/army
 	name = "army helmet"
-	desc = "A US army helmet, old by pre-war standards. Seems to have the addition of quite a bit of ballistic padding on the inside, likely to try and modernize it."
+	desc = "An old US army helmet. Seems someone added quite a bit of ballistic padding on the inside, likely to try and modernize it."
 	icon_state = "armyhelmet"
 	inhand_icon_state = "combathelmet"
 	subarmor = list(SUBARMOR_FLAGS = NONE, \

--- a/mojave/items/clothing/head/helmet.dm
+++ b/mojave/items/clothing/head/helmet.dm
@@ -332,7 +332,7 @@
 
 /obj/item/clothing/head/helmet/ms13/army
 	name = "army helmet"
-	desc = "An old US army helmet. Seems someone added quite a bit of ballistic padding on the inside, likely to try and modernize it."
+	desc = "An old pre-war helmet. Seems someone added quite a bit of ballistic padding on the inside, likely to try and modernize it."
 	icon_state = "armyhelmet"
 	inhand_icon_state = "combathelmet"
 	subarmor = list(SUBARMOR_FLAGS = NONE, \

--- a/mojave/items/clothing/head/helmet.dm
+++ b/mojave/items/clothing/head/helmet.dm
@@ -332,7 +332,7 @@
 
 /obj/item/clothing/head/helmet/ms13/army
 	name = "army helmet"
-	desc = "An old pre-war helmet, even by their standards. Seems to have the addition of quite a bit of ballistic padding on the inside, likely to try and modernize it."
+	desc = "A US army helmet, old by pre-war standards. Seems to have the addition of quite a bit of ballistic padding on the inside, likely to try and modernize it."
 	icon_state = "armyhelmet"
 	inhand_icon_state = "combathelmet"
 	subarmor = list(SUBARMOR_FLAGS = NONE, \

--- a/mojave/items/clothing/masks/masks.dm
+++ b/mojave/items/clothing/masks/masks.dm
@@ -73,6 +73,7 @@
 
 /obj/item/clothing/mask/ms13/bandana/surgical
 	name = "surgical mask"
+	desc = "A mask used by doctors to keep blood out of their mouth and nose."
 	icon_state = "surgical"
 
 // Generic Wasteland Facemasks //

--- a/mojave/machinery/medical.dm
+++ b/mojave/machinery/medical.dm
@@ -10,26 +10,3 @@
 	if(!(flags_1 & NODECONSTRUCT_1))
 		new /obj/item/stack/sheet/ms13/scrap(loc)
 	qdel(src)
-
-/obj/machinery/power/floodlight/ms13
-	name = "Generic MS13 floodlight"
-	desc = "One day we'll have another so this can be more than just a basetype"
-
-/obj/machinery/power/floodlight/ms13/process()
-	if(setting > FLOODLIGHT_OFF) //If on
-		if(avail(active_power_usage))
-			add_load(active_power_usage)
-		else
-			change_setting(FLOODLIGHT_OFF)
-	else if(avail(idle_power_usage))
-		add_load(idle_power_usage)
-
-/obj/machinery/power/floodlight/ms13/medical_lamp
-	name = "medical lamp"
-	desc = "A once sterile lamp used in medical areas, good to get a view of your patient."
-	icon = 'mojave/icons/structure/medical.dmi'
-	icon_state = "medlamp"
-	density = TRUE
-	max_integrity = 250
-	anchored = TRUE
-	light_power = 1.75

--- a/mojave/structures/lighting/lamps.dm
+++ b/mojave/structures/lighting/lamps.dm
@@ -187,3 +187,37 @@
     light_range = 4.5
     light_power = 0.8
     on = TRUE
+
+// Medical lamp
+
+/obj/structure/ms13/lamp/medical_lamp
+	name = "medical lamp"
+	desc = "A once sterile lamp used in medical areas, good to get a view of your patient."
+	icon = 'mojave/icons/structure/medical.dmi'
+	icon_state = "medlamp"
+	density = TRUE
+	max_integrity = 250
+	anchored = TRUE
+	light_range = 4
+
+/obj/structure/ms13/lamp/attack_hand(mob/living/user, list/modifiers)
+    if(!on)
+        to_chat(user, span_notice("You switch the lamp on."))
+        playsound(user, 'mojave/sound/ms13effects/buttonpush.ogg', 20)
+        set_light(4, 2, COLOR_WHITE)
+        on = TRUE
+        icon_state = "medlamp_on"
+        return
+    else
+        to_chat(user, span_notice("You switch the lamp off."))
+        playsound(user, 'mojave/sound/ms13effects/buttonpush.ogg', 20)
+        set_light(4, 0, COLOR_WHITE)
+        on = FALSE
+        icon_state = "medlamp"
+        return
+
+/obj/structure/ms13/lamp/medical_lamp/on
+    icon_state = "medlamp_on"
+    on = TRUE
+    light_range = 4
+    light_power = 2

--- a/mojave/structures/lighting/lamps.dm
+++ b/mojave/structures/lighting/lamps.dm
@@ -200,7 +200,7 @@
 	anchored = TRUE
 	light_range = 4
 
-/obj/structure/ms13/lamp/attack_hand(mob/living/user, list/modifiers)
+/obj/structure/ms13/lamp/medical_lamp/attack_hand(mob/living/user, list/modifiers)
     if(!on)
         to_chat(user, span_notice("You switch the lamp on."))
         playsound(user, 'mojave/sound/ms13effects/buttonpush.ogg', 20)


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Medical lamps weren't working and would break into a TG floodlight and a broken TG light tube. A surgical mask bandana subtype had no description, so it inherited the black bandana's, fixed this. The US army helmet had some weird wording, changed it to sound better, imo!
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
WHOEVER MADE MEDICAL LAMPS A TG FLOODLIGHT SUBTYPE NEEDS TO BE PUT AGAINST A WALL AND SHOT
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: medical lamps :)
fix: surgical mask desc
tweak: army helmet desc
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
