### PR TITLE
Disables the transparency component

### DIFF
--- a/mojave/code/datums/components/transparency.dm
+++ b/mojave/code/datums/components/transparency.dm
@@ -1,5 +1,5 @@
 // Ported from Fortune, made by Rohesie //
-
+// Busted right now. After the first time it turns the icon transparent, the entire icon's dimensions block mouse clicks.
 ///Makes large icons partially see through if high priority atoms are behind them.
 /datum/component/largetransparency
 	//Can be positive or negative. Determines how far away from parent the first registered turf is.

--- a/mojave/flora/wasteplants.dm
+++ b/mojave/flora/wasteplants.dm
@@ -342,7 +342,7 @@
 /obj/structure/flora/ms13/tree/Initialize()
 	. = ..()
 	pixel_x = rand(-20,-16)
-	AddComponent(/datum/component/largetransparency, 1, 1, -1, 1)
+	//AddComponent(/datum/component/largetransparency, 1, 1, -1, 1) // Busted right now. After the first time it turns the icon transparent, the entire icon's dimensions block mouse clicks.
 	AddElement(/datum/element/climbable) // People should be able to pass trees hypothetically. Just not quickly... One day, unscuff the text for this.
 
 /obj/structure/flora/ms13/tree/attackby(obj/item/W, mob/user, params)

--- a/mojave/structures/street_decorations.dm
+++ b/mojave/structures/street_decorations.dm
@@ -13,7 +13,7 @@
 
 /obj/machinery/power/ms13/streetlamp/Initialize()
 	. = ..()
-	AddComponent(/datum/component/largetransparency, 1, 1, 1, 1)
+	//AddComponent(/datum/component/largetransparency, 1, 1, 1, 1) // Busted right now. After the first time it turns the icon transparent, the entire icon's dimensions block mouse clicks.
 
 /obj/machinery/power/ms13/streetlamp/CanAllowThrough(atom/movable/mover, turf/target)
 	. = ..()
@@ -70,7 +70,7 @@
 
 /obj/structure/ms13/street_sign/Initialize()
 	. = ..()
-	AddComponent(/datum/component/largetransparency, 1, 1, 1, 1)
+	//AddComponent(/datum/component/largetransparency, 1, 1, 1, 1) // Busted right now. After the first time it turns the icon transparent, the entire icon's dimensions block mouse clicks.
 	register_context()
 
 /obj/structure/ms13/street_sign/CanAllowThrough(atom/movable/mover, turf/target)


### PR DESCRIPTION

## About The Pull Request

This PR disables the transparency component on trees and street poles. As unfortunate as it is, it's currently broken. After the first time it turns the icon transparent, the entire icon's dimensions block mouse clicks. As you can imagine, this gets really dumb when you're in a place like a forest. Plant picking is virtually impossible right now.

## Why It's Good For The Game

Aesthetic loss for functionality. Layering doesn't work anyways currently and regardless people are on top of trees. Later on, we'll have to look for an alternate method of seeing past large objects reliably, as currently forest gameplay leaves something to be desired... By a lot. 

## Changelog
:cl:
del: transparency component's implementation
/:cl:

