### PR TITLE
Censors radio frequency from radio transmissions. No peeking

### DIFF
--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -54,7 +54,7 @@ GLOBAL_LIST_INIT(freqtospan, list(
 	//Start name span.
 	var/spanpart2 = "<span class='name'>"
 	//Radio freq/name display
-	var/freqpart = radio_freq ? "\[[get_radio_name(radio_freq)]\] " : ""
+	var/freqpart = radio_freq ? "(RADIO) " : "" // MOJAVE SUN EDIT - ORIGINAL IS 	var/freqpart = radio_freq ? "\[[get_radio_name(radio_freq)]\] " : ""
 	//Speaker name
 	var/namepart = "[speaker.GetVoice()][speaker.get_alt_name()]"
 	if(face_name && ishuman(speaker))


### PR DESCRIPTION

## About The Pull Request


![image](https://user-images.githubusercontent.com/51188571/190336440-be54adfd-f143-4412-80b3-5a38409beb1f.png)

This PR removes the frequency LORE DROP from every single one of your messages. Gone are the days of the entire bar knowing FREQUENCY your radio is set to just because it popped off in public.

## Why It's Good For The Game

This is a massive roleplay W. Players will no longer be able to just casually meta snag radio frequencies through text with no effort, and will be required to acquire the radio themselves if they want to peek inside. This is a big thing considering we don't do the encryption keys. (They wouldn't be needed if this was a base feature >:( )

## Changelog

:cl:
del: Radio freq drops on say
/:cl:
