### PR TITLE
Roaming mobs/dungeon defenders draft concept

### DIFF
--- a/mojave/code/_DEFINES/nodes.dm
+++ b/mojave/code/_DEFINES/nodes.dm
@@ -8,3 +8,5 @@
 
 ///A define for a node variable which is the last world.time that a AI visited it
 #define NODE_LAST_VISITED "node_last_visited"
+//Set this to be TRUE for certain nodes and for pathers that specifically want to stay in those nodes
+#define DUNGEON_AREA "dungeon_related_area"

--- a/mojave/code/datums/elements/generic_patrol_animal.dm
+++ b/mojave/code/datums/elements/generic_patrol_animal.dm
@@ -59,5 +59,5 @@ The simple animal this is attached to should also be able to destroy obstacles s
 				animal_current_node[animal] = animal_target_node[animal]
 				var/obj/effect/ai_node/linted_current_node = animal_current_node[animal]
 				linted_current_node.set_weight(animal_identifier[animal], NODE_LAST_VISITED, world.time)
-				animal_target_node[animal] =linted_current_node.get_best_adj_node(animal_node_weights[animal], animal_identifier[animal])
+				animal_target_node[animal] = linted_current_node.get_best_adj_node(animal_node_weights[animal], animal_identifier[animal])
 			walk_to(animal, animal_target_node[animal], 0, patrol_move_delay[animal])

--- a/mojave/code/modules/ai/effect_node.dm
+++ b/mojave/code/modules/ai/effect_node.dm
@@ -7,14 +7,14 @@
 	icon_state = "x6" //Pure white 'X' with black borders
 	anchored = TRUE //No pulling those nodes yo
 	invisibility = INVISIBILITY_MAXIMUM //Why was this visible towrds ghosts, just change it if testing
-	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
+	//mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	///list of adjacent landmark nodes
 	var/list/adjacent_nodes
 
 	///List of weights for scoring stuff happening here; ultilizes "identifiers" to differentiate different kinds of AI types looking at the same node.
 	var/list/weights = list(
-		IDENTIFIER_GENERIC_SIMPLE = list(NODE_LAST_VISITED = 0),
-		IDENTIFIER_EYEBOT = list(NODE_LAST_VISITED = 0)
+		IDENTIFIER_GENERIC_SIMPLE = list(NODE_LAST_VISITED = 0, DUNGEON_AREA = 0),
+		IDENTIFIER_EYEBOT = list(NODE_LAST_VISITED = 0, DUNGEON_AREA = 0)
 		)
 	//TODO: MAKE DYNAMICALLY INITIALIZED WHEN REQUESTED
 
@@ -71,7 +71,7 @@
 	var/obj/effect/ai_node/node_to_return
 	var/current_best_node_score = -INFINITY
 	var/current_score
-	for(var/thing in shuffle_inplace(adjacent_nodes)) //We keep a score for the nodes and see which one is best
+	for(var/thing in adjacent_nodes) //We keep a score for the nodes and see which one is best
 		var/obj/effect/ai_node/node = thing
 		current_score = 0
 		for(var/weight in weight_modifiers)
@@ -107,3 +107,10 @@
 	icon_state = "x6" //Pure white 'X' with black borders
 	color = "#ffffff"
 	invisibility = 0
+
+/obj/effect/ai_node/debug/dungeon
+	color = "#693737"
+	weights = list(
+		IDENTIFIER_GENERIC_SIMPLE = list(NODE_LAST_VISITED = 0, DUNGEON_AREA = 1),
+		IDENTIFIER_EYEBOT = list(NODE_LAST_VISITED = 0, DUNGEON_AREA = 1)
+		)

--- a/mojave/code/modules/mob/living/basic/mob_camp.dm
+++ b/mojave/code/modules/mob/living/basic/mob_camp.dm
@@ -1,0 +1,32 @@
+//A place where patroling mobs are spawned at and told to move around
+/obj/structure/mob_camp
+	var/mob/mob_to_spawn = /mob/living/simple_animal/hostile/retaliate/ms13/robot/eyebot
+	var/max_mobs_spawned = 6
+	var/spawn_cooldown = 0.5 SECONDS
+	var/ratio_of_roamers_defenders = 0.5
+	var/existing_defenders = 0
+	var/existing_roamers = 0
+	COOLDOWN_DECLARE(delayed_spawning)
+	icon = 'icons/obj/structures.dmi'
+	icon_state = "grille"
+	base_icon_state = "grille"
+
+/obj/structure/mob_camp/Initialize(mapload)
+	. = ..()
+	START_PROCESSING(SSobj,src)
+
+/obj/structure/mob_camp/process(delta_time)
+	if(COOLDOWN_FINISHED(src, delayed_spawning) && (existing_defenders + existing_roamers < max_mobs_spawned))
+		COOLDOWN_START(src, delayed_spawning, spawn_cooldown)
+		var/mob/the_mob = new mob_to_spawn(loc)
+		//Prioritize making defenders first then roamers
+		if(existing_defenders < (max_mobs_spawned * ratio_of_roamers_defenders))
+			the_mob.RemoveElement(/datum/element/generic_patrol_animal)
+			existing_defenders++
+			the_mob.AddElement(/datum/element/generic_patrol_animal, _animal_node_weights = list(NODE_LAST_VISITED = -1, DUNGEON_AREA = INFINITY), _animal_identifier = IDENTIFIER_EYEBOT, _patrol_move_delay = 6)
+
+		else
+			if(existing_roamers < (max_mobs_spawned * ratio_of_roamers_defenders))
+				the_mob.RemoveElement(/datum/element/generic_patrol_animal)
+				existing_roamers++
+				the_mob.AddElement(/datum/element/generic_patrol_animal, _animal_node_weights = list(NODE_LAST_VISITED = 1, DUNGEON_AREA = -INFINITY), _animal_identifier = IDENTIFIER_EYEBOT, _patrol_move_delay = 6)

--- a/mojave/code/modules/mob/robots/eyebots.dm
+++ b/mojave/code/modules/mob/robots/eyebots.dm
@@ -40,7 +40,7 @@
 	return INITIALIZE_HINT_LATELOAD
 
 /mob/living/simple_animal/hostile/retaliate/ms13/robot/eyebot/LateInitialize()
-	AddElement(/datum/element/generic_patrol_animal, _animal_node_weights = list(NODE_LAST_VISITED = -1), _animal_identifier = IDENTIFIER_EYEBOT, _patrol_move_delay = 6)
+	AddElement(/datum/element/generic_patrol_animal, _animal_node_weights = list(NODE_LAST_VISITED = -1, DUNGEON_AREA = 0), _animal_identifier = IDENTIFIER_EYEBOT, _patrol_move_delay = 6)
 
 /mob/living/simple_animal/hostile/retaliate/ms13/robot/eyebot/LoseAggro()
 	//stop_automated_movement = 0 For patrolling


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
A placeholder object that spawns a certain amount of mobs; the mobs will either travel outside of a marked node network or stay inside of one.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Could be used for respawning roaming mobs until a camp/dungeon is taken out
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: ma44
add: Certain areas of the map can have respawning mobs that defend it's designated area or roam exclusively outside of it
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
