### PR TITLE
Structure universal projectile passthrough and window combat

### DIFF
--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -11,6 +11,7 @@
 	blocks_emissive = EMISSIVE_BLOCK_GENERIC
 	var/broken = FALSE
 	var/weatherproof = FALSE //MOJAVE SUN EDIT - Weather
+	var/projectile_passchance = 0 // MOJAVE SUN EDIT - projectile passthrough chance 100% always goes through, 0% never goes through. Definition isn't required if structure doesn't have density, duh.
 
 /obj/structure/Initialize(mapload)
 	if (!armor)
@@ -63,3 +64,23 @@
 		take_damage(power/8000, BURN, "energy")
 	power -= power/2000 //walls take a lot out of ya
 	. = ..()
+
+// MOJAVE SUN EDIT BEGIN - This is put here so that we don't have to redefine this on every single structure and can do it cleaner.
+
+/obj/structure/CanAllowThrough(atom/movable/mover, border_dir)
+	. = ..()
+	if(!projectile_passchance)
+		return
+	if(locate(/obj/structure) in get_turf(mover))
+		return TRUE
+	else if(istype(mover, /obj/projectile))
+		if(!anchored)
+			return TRUE
+		var/obj/projectile/proj = mover
+		if(proj.firer && Adjacent(proj.firer))
+			return TRUE
+		if(prob((projectile_passchance)))
+			return TRUE
+		return FALSE
+
+// MOJAVE SUN EDIT END

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -54,7 +54,14 @@
 		return
 	visible_message(span_danger("[src] crashes into [T] with a sickening noise!"), \
 					span_userdanger("You crash into [T] with a sickening noise!"))
-	adjustBruteLoss(levels * 20) // You'll probably think twice before flying off the side of a cliff
+	adjustBruteLoss(levels * 40) // You'll probably think twice before flying off the side of a cliff // MOJAVE SUN EDIT - ORIGINAL IS 	adjustBruteLoss((levels * 5) ** 1.5)
+	// MOJAVE SUN EDIT BEGIN
+	if(istype(src, /mob/living/carbon/human))
+		var/mob/living/carbon/human/human_yeetus = src
+		var/obj/item/bodypart/limb = pick(human_yeetus.bodyparts)
+		var/type_wound = pick(list(/datum/wound/blunt/severe, /datum/wound/blunt/severe))
+		limb.force_wound_upwards(type_wound)
+	// MOJAVE SUN EDIT END
 	Knockdown(levels * 50)
 
 //Generic Bump(). Override MobBump() and ObjBump() instead of this.

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -77,7 +77,7 @@
 		. += mutable_appearance('icons/obj/power.dmi', "grown_wires")
 	if((charge < 0.01) || !charge_light_type)
 		return
-    
+
 	// MOJAVE EDIT REMOVAL BEGIN - Ammo cell overlays
 	/*
 	. += mutable_appearance('icons/obj/power.dmi', "cell-[charge_light_type]-o[(percent() >= 99.5) ? 2 : 1]")

--- a/mojave/flora/wasteplants.dm
+++ b/mojave/flora/wasteplants.dm
@@ -340,7 +340,7 @@
 	var/log_amount = 1
 	layer = ABOVE_ALL_MOB_LAYER
 	plane = ABOVE_GAME_PLANE
-	projectile_passchance = 75 // thin mf tree
+	projectile_passchance = 60 // mf tree
 
 /obj/structure/flora/ms13/tree/Initialize()
 	. = ..()

--- a/mojave/flora/wasteplants.dm
+++ b/mojave/flora/wasteplants.dm
@@ -340,6 +340,7 @@
 	var/log_amount = 1
 	layer = ABOVE_ALL_MOB_LAYER
 	plane = ABOVE_GAME_PLANE
+	projectile_passchance = 75 // thin mf tree
 
 /obj/structure/flora/ms13/tree/Initialize()
 	. = ..()

--- a/mojave/structures/chairs.dm
+++ b/mojave/structures/chairs.dm
@@ -5,6 +5,7 @@
 	item_chair = /obj/item/chair/ms13
 	layer = BELOW_OBJ_LAYER
 	max_integrity = 100
+	projectile_passchance = 100
 
 /obj/structure/chair/ms13/wrench_act_secondary(mob/living/user, obj/item/weapon)
 	return

--- a/mojave/structures/decorative.dm
+++ b/mojave/structures/decorative.dm
@@ -8,6 +8,7 @@
 	icon = 'mojave/icons/structure/miscellaneous.dmi'
 	icon_state = "mailbox"
 	pixel_y = 12
+	projectile_passchance = 50
 
 /obj/structure/filingcabinet/ms13/mail/old
 	icon_state = "mailbox_old"
@@ -20,20 +21,7 @@
 	anchored = FALSE
 	pixel_y = 10
 	materialtype = /obj/item/stack/sheet/ms13/scrap
-
-/obj/structure/ms13/storage/trashcan/CanAllowThrough(atom/movable/mover, turf/target)
-	. = ..()
-	if(locate(/obj/structure/ms13/storage/trashcan) in get_turf(mover))
-		return TRUE
-	else if(istype(mover, /obj/projectile))
-		if(!anchored)
-			return TRUE
-		var/obj/projectile/proj = mover
-		if(proj.firer && Adjacent(proj.firer))
-			return TRUE
-		if(prob(75))
-			return TRUE
-		return FALSE
+	projectile_passchance = 65
 
 /obj/structure/ms13/storage/trashcan/Initialize()
 	. = ..()
@@ -171,14 +159,7 @@
 	pixel_y = 12
 	opacity = TRUE
 	density = TRUE
-
-/obj/structure/ms13/medical_curtain/CanAllowThrough(atom/movable/mover, turf/target)
-	. = ..()
-	if(locate(/obj/structure/ms13/medical_curtain) in get_turf(mover))
-		return TRUE
-	else if(istype(mover, /obj/projectile))
-		if(!anchored)
-			return TRUE
+	projectile_passchance = 95 // occasional dink off a pole or somethin...
 
 // Skeletons //
 
@@ -202,6 +183,7 @@
 	var/icon_type = null
 	var/amount = 3 //used for icon randomisation amount
 	var/unique = FALSE //used to set if the icon is randomised or not
+	projectile_passchance = 65
 
 /obj/structure/fluff/ms13/barrel/deconstruct(disassembled = TRUE)
 	if(!(flags_1 & NODECONSTRUCT_1))
@@ -213,20 +195,6 @@
 	. = ..()
 	if(!unique)
 		icon_state = "[icon_type]_[rand(1, amount)]"
-
-/obj/structure/fluff/ms13/barrel/CanAllowThrough(atom/movable/mover, turf/target)
-	. = ..()
-	if(locate(/obj/structure/fluff/ms13/barrel) in get_turf(mover))
-		return TRUE
-	else if(istype(mover, /obj/projectile))
-		if(!anchored)
-			return TRUE
-		var/obj/projectile/proj = mover
-		if(proj.firer && Adjacent(proj.firer))
-			return TRUE
-		if(prob(65))
-			return TRUE
-		return FALSE
 
 /obj/structure/fluff/ms13/barrel/single
 

--- a/mojave/structures/furniture.dm
+++ b/mojave/structures/furniture.dm
@@ -470,6 +470,7 @@
 	max_integrity = 50
 	density = FALSE
 	anchored = TRUE
+	projectile_passchance = 100
 
 /obj/structure/ms13/pot/deconstruct(disassembled = TRUE)
 	if(!(flags_1 & NODECONSTRUCT_1))
@@ -499,6 +500,7 @@
 	density = TRUE
 	anchored = TRUE
 	max_integrity = 200
+	projectile_passchance = 80
 
 /obj/structure/ms13/deli/Initialize()
 	. = ..()
@@ -544,6 +546,7 @@
 	density = TRUE
 	anchored = TRUE
 	max_integrity = 200
+	projectile_passchance = 80
 
 /obj/structure/ms13/fruit_empty/attackby(obj/item/W, mob/user, params)
 	if(W.sharpness == IS_SHARP_AXE)

--- a/mojave/structures/furniture.dm
+++ b/mojave/structures/furniture.dm
@@ -338,6 +338,7 @@
 	icon = 'mojave/icons/structure/cabinets.dmi'
 	var/dresser_type = "circabinet_orange"
 	max_integrity = 225
+	projectile_passchance = 85
 
 /obj/structure/dresser/ms13/attack_hand(mob/user)
 	icon_state = "[dresser_type]-open"
@@ -382,6 +383,7 @@
 	icon = 'mojave/icons/structure/cabinets.dmi'
 	icon_state = "filing_cabinet"
 	max_integrity = 150
+	projectile_passchance = 70
 
 /obj/structure/filingcabinet/ms13/deconstruct(disassembled = TRUE)
 	if(!(flags_1 & NODECONSTRUCT_1))
@@ -413,6 +415,7 @@
 	max_integrity = 350
 	density = TRUE
 	anchored = TRUE
+	projectile_passchance = 65
 
 /obj/structure/ms13/jukebox/Initialize()
 	. = ..()

--- a/mojave/structures/morgue.dm
+++ b/mojave/structures/morgue.dm
@@ -3,6 +3,7 @@
 	desc = "A place to keep the dead, until they can be properly buried or cremated."
 	icon = 'mojave/icons/structure/morgue.dmi'
 	icon_state = "morgue"
+	projectile_passchance = 65
 
 /obj/structure/bodycontainer/ms13/morgue/Initialize(mapload)
 	. = ..()

--- a/mojave/structures/obstacles.dm
+++ b/mojave/structures/obstacles.dm
@@ -381,8 +381,9 @@
 	desc = "You see nothing out of the ordinary."
 	icon = 'mojave/icons/obstacles/obstacles.dmi'
 	icon_state = "normal_fence"
-	density = 1
-	anchored = 1
+	density = TRUE
+	anchored = TRUE
+	projectile_passchance = 95
 
 /obj/structure/fence/fencenormal/Initialize()
 	. = ..()
@@ -417,8 +418,6 @@
 	desc = "It's still pretty sturdy.<br>You see nothing out of the ordinary."
 	icon = 'mojave/icons/obstacles/obstacles.dmi'
 	icon_state = "fence_corner"
-	density = 1
-	anchored = 1
 
 /obj/structure/fence/fencecorner/attackby(obj/item/W, mob/user, params)
 	if(istype(W, /obj/item/wirecutters))
@@ -429,8 +428,6 @@
 	desc = "Intersection of the fence.<br>You see nothing out of the ordinary."
 	icon = 'mojave/icons/obstacles/obstacles.dmi'
 	icon_state = "fence_intersect_middle"
-	density = 1
-	anchored = 1
 
 /obj/structure/fence/fenceintersectmiddle/attackby(obj/item/W, mob/user, params)
 	if(istype(W, /obj/item/wirecutters))
@@ -441,8 +438,6 @@
 	desc = "Intersection of the fence.<br>You see nothing out of the ordinary."
 	icon = 'mojave/icons/obstacles/obstacles.dmi'
 	icon_state = "fence_intersect_bottom"
-	density = 1
-	anchored = 1
 
 /obj/structure/fence/fenceintersectbottom/attackby(obj/item/W, mob/user, params)
 	if(istype(W, /obj/item/wirecutters))
@@ -453,8 +448,6 @@
 	desc = "Intersection of the fence.<br>You see nothing out of the ordinary."
 	icon = 'mojave/icons/obstacles/obstacles.dmi'
 	icon_state = "fence_intersect_corner"
-	density = 1
-	anchored = 1
 
 /obj/structure/fence/fencecornerintersect/attackby(obj/item/W, mob/user, params)
 	if(istype(W, /obj/item/wirecutters))
@@ -465,8 +458,6 @@
 	desc = "The hinges are a bit rusty.<br>Who cares, it's just a door anyway."
 	icon = 'mojave/icons/obstacles/obstacles.dmi'
 	icon_state = "fence_door_front_closed"
-	density = 1
-	anchored = 1
 	ms13_flags_1 = LOCKABLE_1
 	var/open_sound = 'mojave/sound/ms13machines/doorchainlink_open.ogg'
 	var/close_sound = 'mojave/sound/ms13machines/doorchainlink_close.ogg'
@@ -524,8 +515,6 @@
 	desc = "It opens and closes."
 	icon = 'mojave/icons/obstacles/obstacles.dmi'
 	icon_state = "fence_door_side_closed"
-	density = 1
-	anchored = 1
 	ms13_flags_1 = LOCKABLE_1
 	var/open_sound = 'mojave/sound/ms13machines/doorchainlink_open.ogg'
 	var/close_sound = 'mojave/sound/ms13machines/doorchainlink_close.ogg'
@@ -579,10 +568,11 @@
 	density = TRUE
 	anchored = FALSE
 	max_integrity = 150
+	projectile_passchance = 85
 	var/hasaltstates = FALSE
 	var/altstates = 0
-	var/proj_pass_rate = 85
 	var/climbable = FALSE
+
 /obj/structure/ms13/road_barrier/Initialize()
 	. = ..()
 	if(climbable)
@@ -600,26 +590,12 @@
 	climbable = TRUE
 	max_integrity = 550
 	altstates = 5
-	proj_pass_rate = 45
+	projectile_passchance = 40
 
 /obj/structure/ms13/road_barrier/concrete/alt
 	desc = "A heavy duty concrete road barrier featuring a pattern that to this day is still somewhat vibrant. Used to direct traffic and prevent going off the lane."
 	icon_state = "concrete_barrier_alt"
 	altstates = 1
-
-/obj/structure/ms13/road_barrier/concrete/CanAllowThrough(atom/movable/mover, turf/target)
-	. = ..()
-	if(locate(/obj/structure/ms13/road_barrier/concrete) in get_turf(mover))
-		return TRUE
-	else if(istype(mover, /obj/projectile))
-		if(!anchored)
-			return TRUE
-		var/obj/projectile/proj = mover
-		if(proj.firer && Adjacent(proj.firer))
-			return TRUE
-		if(prob(proj_pass_rate))
-			return TRUE
-		return FALSE
 
 // Railings //
 
@@ -630,6 +606,7 @@
 	layer = CLOSED_TURF_LAYER
 	max_integrity = 150
 	climbable = FALSE //so we can override TG
+	projectile_passchance = 80
 
 /obj/structure/railing/ms13/Initialize()
 	. = ..()
@@ -664,6 +641,7 @@
 	name = "wooden fence"
 	desc = "A classic wooden fence. It doesn't get more homely than this."
 	icon_state = "wood_full"
+	projectile_passchance = 75
 
 /obj/structure/railing/ms13/wood/Initialize()
 	. = ..()

--- a/mojave/structures/smelter.dm
+++ b/mojave/structures/smelter.dm
@@ -6,6 +6,7 @@
 	max_integrity = 160
 	density = TRUE
 	anchored = TRUE
+	projectile_passchance = 75
 	var/crafting_interface = CRAFTING_BENCH_SMELTER
 
 /obj/structure/ms13/smelter/examine(mob/user)

--- a/mojave/structures/storage/crates.dm
+++ b/mojave/structures/storage/crates.dm
@@ -172,6 +172,7 @@
 	icon_state = "enclave"
 	material_drop = /obj/item/stack/sheet/ms13/scrap
 	material_drop_amount = 2
+	projectile_passchance = 85
 
 /obj/structure/closet/crate/ms13/medical
 	name = "medical locker"

--- a/mojave/structures/storage/crates.dm
+++ b/mojave/structures/storage/crates.dm
@@ -26,6 +26,7 @@
 	open_sound_volume = 25
 	close_sound_volume = 50
 	max_integrity = 500
+	projectile_passchance = 45
 	var/breakable = TRUE
 	var/prying = FALSE
 	var/altstates = 0
@@ -96,6 +97,7 @@
 	anchored = FALSE //smaller bois
 	max_integrity = 400
 	altstates = 3
+	projectile_passchance = 70
 
 /obj/structure/closet/crate/ms13/woodcrate/compact/boom
 	icon_state = "3X_crate"
@@ -118,6 +120,7 @@
 	max_integrity = 400
 	material_drop = /obj/item/stack/sheet/ms13/scrap
 	material_drop_amount = 2
+	projectile_passchance = 70
 
 /obj/structure/closet/crate/ms13/vault_tec/pristine
 	name = "\improper Vault-Tec crate"
@@ -128,6 +131,7 @@
 	name = "compact Vault-Tec crate"
 	desc = "A crate designed for the rigours of vault life. This one is fun-sized. Looks like it didn't handle life outside too well."
 	icon_state = "vault_compact"
+	projectile_passchance = 85
 
 /obj/structure/closet/crate/ms13/vault_tec/compact/pristine
 	name = "compact Vault-Tec crate"
@@ -160,6 +164,7 @@
 	icon_state = "footlocker_wood"
 	material_drop = /obj/item/stack/sheet/ms13/scrap_wood
 	material_drop_amount = 2
+	projectile_passchance = 90
 
 /obj/structure/closet/crate/ms13/enclave
 	name = "high-tech crate"
@@ -176,6 +181,7 @@
 	drag_slowdown = 1
 	material_drop = /obj/item/stack/sheet/ms13/scrap
 	material_drop_amount = 2
+	projectile_passchance = 60
 
 /obj/structure/closet/crate/ms13/cash_register
 	name = "cash register"
@@ -187,6 +193,7 @@
 	mob_storage_capacity = 1
 	material_drop = /obj/item/stack/sheet/ms13/scrap
 	material_drop_amount = 2
+	projectile_passchance = 50
 
 /obj/structure/closet/crate/ms13/cash_register/prewar
 	name = "pristine cash register"
@@ -199,6 +206,7 @@
 	icon_state = "army"
 	material_drop = /obj/item/stack/sheet/ms13/scrap
 	material_drop_amount = 2
+	projectile_passchance = 85
 
 /obj/structure/closet/crate/ms13/aluminum
 	name = "aluminum crate"
@@ -206,6 +214,7 @@
 	icon_state = "aluminum"
 	material_drop = /obj/item/stack/sheet/ms13/scrap_alu
 	material_drop_amount = 2
+	projectile_passchance = 85
 
 /obj/structure/closet/crate/ms13/red
 	name = "red crate"
@@ -213,6 +222,7 @@
 	icon_state = "red"
 	material_drop = /obj/item/stack/sheet/ms13/scrap
 	material_drop_amount = 2
+	projectile_passchance = 85
 
 /obj/structure/closet/crate/ms13/vault
 	name = "vault crate"
@@ -220,3 +230,4 @@
 	icon_state = "vault"
 	material_drop = /obj/item/stack/sheet/ms13/scrap
 	material_drop_amount = 2
+	projectile_passchance = 85

--- a/mojave/structures/storage/safes.dm
+++ b/mojave/structures/storage/safes.dm
@@ -5,6 +5,7 @@
 	icon_state = "safe_spinner"
 	ms13_flags_1 = LOCKABLE_1
 	maxspace = 2000
+	projectile_passchance = 80
 
 /obj/structure/safe/ms13/advanced
 	name = "safe"
@@ -17,6 +18,7 @@
 	icon_state = "safe_wall"
 	pixel_y = 32
 	density = FALSE
+	projectile_passchance = 100
 
 /obj/structure/safe/ms13/wall/Initialize(mapload)
 	. = ..()

--- a/mojave/structures/street_decorations.dm
+++ b/mojave/structures/street_decorations.dm
@@ -55,6 +55,20 @@
 	icon_state = "trafficlightright"
 	resistance_flags = INDESTRUCTIBLE
 
+/obj/machinery/power/ms13/trafficlight/CanAllowThrough(atom/movable/mover, turf/target)
+	. = ..()
+	if(locate(/obj/machinery/power/ms13/trafficlight) in get_turf(mover))
+		return TRUE
+	else if(istype(mover, /obj/projectile))
+		if(!anchored)
+			return TRUE
+		var/obj/projectile/proj = mover
+		if(proj.firer && Adjacent(proj.firer))
+			return TRUE
+		if(prob(75)) // These things are pretty thin
+			return TRUE
+		return FALSE
+
 /obj/machinery/power/ms13/trafficlight/alt
 	icon_state = "trafficlightleft"
 
@@ -68,25 +82,12 @@
 	density = TRUE
 	layer = ABOVE_MOB_LAYER
 	max_integrity = 500 // Hardy but not immortal
+	projectile_passchance = 95
 
 /obj/structure/ms13/street_sign/Initialize()
 	. = ..()
 	//AddComponent(/datum/component/largetransparency, 1, 1, 1, 1) // Busted right now. After the first time it turns the icon transparent, the entire icon's dimensions block mouse clicks.
 	register_context()
-
-/obj/structure/ms13/street_sign/CanAllowThrough(atom/movable/mover, turf/target)
-	. = ..()
-	if(locate(/obj/structure/ms13/street_sign) in get_turf(mover))
-		return TRUE
-	else if(istype(mover, /obj/projectile))
-		if(!anchored)
-			return TRUE
-		var/obj/projectile/proj = mover
-		if(proj.firer && Adjacent(proj.firer))
-			return TRUE
-		if(prob(90)) // These things are very thin
-			return TRUE
-		return FALSE
 
 /obj/structure/ms13/street_sign/welder_act_secondary(mob/living/user, obj/item/I)
 	if(!I.tool_start_check(user, amount=0))

--- a/mojave/turfs/window.dm
+++ b/mojave/turfs/window.dm
@@ -10,6 +10,27 @@
 	break_sound = 'mojave/sound/ms13effects/glass_break.ogg'
 	hitted_sound = 'mojave/sound/ms13effects/glass_hit.ogg'
 	knock_sound = 'mojave/sound/ms13effects/glass_knock.ogg'
+	var/shatter_immune = FALSE // immune to passthrough bullshittery
+
+/obj/structure/window/fulltile/ms13/CanAllowThrough(atom/movable/mover, turf/target)
+	. = ..()
+	if(shatter_immune)
+		return
+	else if(istype(mover, /obj/projectile))
+		var/obj/projectile/proj = mover
+		if(proj.damage > 10)
+			deconstruct(disassembled = FALSE)
+			return TRUE
+	else if(istype(mover, /obj/item))
+		var/obj/item/thrown_item = mover
+		if(thrown_item.throwing && thrown_item.throwforce >= 10 || thrown_item.w_class >= WEIGHT_CLASS_NORMAL)
+			deconstruct(disassembled = FALSE)
+			return TRUE
+	else if(istype(mover, /mob/living))
+		var/mob/living/yeetus_fetus = mover
+		if(yeetus_fetus.throwing && yeetus_fetus.mob_size >= 2)
+			deconstruct(disassembled = FALSE)
+			return TRUE
 
 /obj/structure/window/fulltile/ms13/spawnDebris(location)
 	. = list()

--- a/mojave/turfs/window.dm
+++ b/mojave/turfs/window.dm
@@ -16,6 +16,10 @@
 	. = ..()
 	if(shatter_immune)
 		return
+	if(istype(mover, /obj/projectile/beam/ms13))
+		return TRUE
+	if(istype(mover, /obj/projectile/bullet/ms13/plasma))
+		return FALSE
 	else if(istype(mover, /obj/projectile))
 		var/obj/projectile/proj = mover
 		if(proj.damage > 10)
@@ -36,7 +40,7 @@
 					var/type_wound = pick(list(/datum/wound/slash/moderate, /datum/wound/slash/moderate))
 					limb.force_wound_upwards(type_wound)
 				human_yeetus.adjustBruteLoss(rand(10,20))
-				human_yeetus.Knockdown(10)
+				human_yeetus.Knockdown(5)
 			deconstruct(disassembled = FALSE)
 			return TRUE
 

--- a/mojave/turfs/window.dm
+++ b/mojave/turfs/window.dm
@@ -35,12 +35,11 @@
 		if(mob_yote.throwing && mob_yote.mob_size >= 2)
 			if(istype(mover, /mob/living/carbon/human))
 				var/mob/living/carbon/human/human_yeetus = mover
-				for(var/_limb in human_yeetus.bodyparts)
-					var/obj/item/bodypart/limb = _limb
-					var/type_wound = pick(list(/datum/wound/slash/moderate, /datum/wound/slash/moderate))
-					limb.force_wound_upwards(type_wound)
+				var/obj/item/bodypart/limb = pick(human_yeetus.bodyparts)
+				var/type_wound = pick(list(/datum/wound/slash/moderate, /datum/wound/slash/severe))
+				limb.force_wound_upwards(type_wound)
 				human_yeetus.adjustBruteLoss(rand(10,20))
-				human_yeetus.Knockdown(5)
+				human_yeetus.Knockdown(10)
 			deconstruct(disassembled = FALSE)
 			return TRUE
 

--- a/mojave/turfs/window.dm
+++ b/mojave/turfs/window.dm
@@ -4,7 +4,7 @@
 	smoothing_flags = SMOOTH_BITMASK
 	layer = ABOVE_ALL_MOB_LAYER
 	plane = ABOVE_GAME_PLANE
-	damage_deflection = 10
+	max_integrity = 25
 	glass_type = /obj/item/stack/sheet/ms13/glass
 	glass_amount = 1
 	break_sound = 'mojave/sound/ms13effects/glass_break.ogg'
@@ -27,8 +27,16 @@
 			deconstruct(disassembled = FALSE)
 			return TRUE
 	else if(istype(mover, /mob/living))
-		var/mob/living/yeetus_fetus = mover
-		if(yeetus_fetus.throwing && yeetus_fetus.mob_size >= 2)
+		var/mob/living/mob_yote = mover
+		if(mob_yote.throwing && mob_yote.mob_size >= 2)
+			if(istype(mover, /mob/living/carbon/human))
+				var/mob/living/carbon/human/human_yeetus = mover
+				for(var/_limb in human_yeetus.bodyparts)
+					var/obj/item/bodypart/limb = _limb
+					var/type_wound = pick(list(/datum/wound/slash/moderate, /datum/wound/slash/moderate))
+					limb.force_wound_upwards(type_wound)
+				human_yeetus.adjustBruteLoss(rand(10,20))
+				human_yeetus.Knockdown(10)
 			deconstruct(disassembled = FALSE)
 			return TRUE
 
@@ -53,6 +61,7 @@
 	smoothing_flags = SMOOTH_BITMASK
 	layer = ABOVE_ALL_MOB_LAYER
 	plane = ABOVE_GAME_PLANE
+	damage_deflection = 20
 	max_integrity = 300
 	damage_deflection = 16 //This basically means it blocks 15 damage weapons and weaker
 	glass_type = /obj/item/stack/sheet/ms13/glass


### PR DESCRIPTION
## About The Pull Request

This PR makes all structures have an inherent projectile passthrough proc set up. You can modify the chance a projectile has to pass through it with the _projectile_passchance_ variable.

In addition to this all, I've added considerable soul to our windows! You can throw semi-hefty items straight through windows, now. Along with that, large mobs and humans can be thrown, blown, or even smacked clean through as well! It'll make them bleed and hurt a bit, too. It's great fun. 

https://user-images.githubusercontent.com/51188571/193732684-4185aa05-cb5e-4c31-918d-5632a15d733a.mp4


https://user-images.githubusercontent.com/51188571/193732688-d13cceb7-39af-45fa-ad17-ce7d76e1e942.mp4



## Why It's Good For The Game

Allows easier setup of passthrough on structure subtypes

Window combat is awesome.