### PR TITLE
tweaker PR

### DIFF
--- a/code/modules/surgery/bodyparts/head.dm
+++ b/code/modules/surgery/bodyparts/head.dm
@@ -12,7 +12,7 @@
 	px_x = 0
 	px_y = -8
 	stam_damage_coeff = 1
-	body_damage_coeff = 1.1 //MOJAVE EDIT - Original value is 1
+	body_damage_coeff = 1.15 //MOJAVE EDIT - Original value is 1
 	max_stamina_damage = 100
 	wound_resistance = 0 //MOJAVE EDIT - Original value is 5
 	disabled_wound_penalty = 25

--- a/code/modules/surgery/bodyparts/parts.dm
+++ b/code/modules/surgery/bodyparts/parts.dm
@@ -69,7 +69,7 @@
 	body_part = ARM_LEFT
 	aux_zone = BODY_ZONE_PRECISE_L_HAND
 	aux_layer = HANDS_PART_LAYER
-	body_damage_coeff = 0.7 //MOJAVE EDIT - Original TG value is 0.75
+	body_damage_coeff = 0.6 //MOJAVE EDIT - Original TG value is 0.75
 	held_index = 1
 	px_x = -6
 	px_y = 0
@@ -168,7 +168,7 @@
 	body_part = ARM_RIGHT
 	aux_zone = BODY_ZONE_PRECISE_R_HAND
 	aux_layer = HANDS_PART_LAYER
-	body_damage_coeff = 0.7 //MOJAVE EDIT - Original TG value is 0.75
+	body_damage_coeff = 0.6 //MOJAVE EDIT - Original TG value is 0.75
 	held_index = 2
 	px_x = 6
 	px_y = 0
@@ -266,7 +266,7 @@
 	//MOJAVE EDIT END
 	body_zone = BODY_ZONE_L_LEG
 	body_part = LEG_LEFT
-	body_damage_coeff = 0.7 //MOJAVE EDIT - Original TG value is 0.75
+	body_damage_coeff = 0.6 //MOJAVE EDIT - Original TG value is 0.75
 	px_x = -2
 	px_y = 12
 	can_be_disabled = TRUE
@@ -361,7 +361,7 @@
 	//MOJAVE EDIT END
 	body_zone = BODY_ZONE_R_LEG
 	body_part = LEG_RIGHT
-	body_damage_coeff = 0.7 //MOJAVE EDIT - Original TG value is 0.75
+	body_damage_coeff = 0.6 //MOJAVE EDIT - Original TG value is 0.75
 	px_x = 2
 	px_y = 12
 	can_be_disabled = TRUE

--- a/mojave/jobs/job_types/bos/head_scribe.dm
+++ b/mojave/jobs/job_types/bos/head_scribe.dm
@@ -28,7 +28,8 @@
 	backpack_contents = list(
 		/obj/item/stack/medical/gauze/ms13/half=1, \
 		/obj/item/stack/medical/ointment/ms13/half=1, \
-		/obj/item/stack/ms13/currency/prewar/eighty=1)
+		/obj/item/stack/ms13/currency/prewar/eighty=1, \
+		/obj/item/radio/ms13/broadcast/advanced=1)
 
 /datum/outfit/job/ms13/bos/head_scribe/pre_equip(mob/living/carbon/human/H)
 	..()

--- a/mojave/jobs/job_types/ncr/lieutenant.dm
+++ b/mojave/jobs/job_types/ncr/lieutenant.dm
@@ -27,7 +27,7 @@
 		/obj/item/stack/medical/gauze/ms13/half=1,
 		/obj/item/flashlight/ms13=1, \
 		/obj/item/stack/medical/ointment/ms13/half=1, \
-		/obj/item/radio/ms13=1, \
+		/obj/item/radio/ms13/broadcast=1, \
 		/obj/item/stack/ms13/currency/ncr_dollar/eighty=1)
 
 /datum/outfit/job/ms13/ncr/lieutenant/pre_equip(mob/living/carbon/human/H)

--- a/mojave/jobs/job_types/ncr/sergeant.dm
+++ b/mojave/jobs/job_types/ncr/sergeant.dm
@@ -25,6 +25,7 @@
 		/obj/item/stack/medical/gauze/ms13/three=1, \
 		/obj/item/flashlight/flare/ms13=1, \
 		/obj/item/ammo_box/magazine/ms13/m9mm=1, \
+		/obj/item/radio/ms13=1, \
 		/obj/item/stack/ms13/currency/ncr_dollar/fourty=1)
 
 /datum/outfit/job/ms13/ncr/sergeant/pre_equip(mob/living/carbon/human/H)

--- a/mojave/jobs/job_types/ncr/staffsergeant.dm
+++ b/mojave/jobs/job_types/ncr/staffsergeant.dm
@@ -25,6 +25,7 @@
 		/obj/item/ammo_box/magazine/ms13/m9mm=2, \
 		/obj/item/flashlight/flare/ms13=1, \
 		/obj/item/clothing/head/helmet/ms13/ncr/beret=1, \
+		/obj/item/radio/ms13=1, \
 		/obj/item/stack/ms13/currency/ncr_dollar/fifty=1)
 
 /datum/outfit/job/ms13/ncr/staffsergeant/pre_equip(mob/living/carbon/human/H)

--- a/mojave/jobs/job_types/raiders/enforcer.dm
+++ b/mojave/jobs/job_types/raiders/enforcer.dm
@@ -31,7 +31,7 @@
 		/obj/item/stack/medical/ointment/ms13/half=1, \
 		/obj/item/stack/medical/gauze/ms13/half=1, \
 		/obj/item/flashlight/ms13/crafted=1, \
-		/obj/item/radio/ms13=1, \
+		/obj/item/radio/ms13/broadcast=1, \
 		/obj/item/stack/ms13/currency/prewar/fifty=1)
 
 /datum/outfit/job/ms13/raiders/enforcer/pre_equip(mob/living/carbon/human/H)

--- a/mojave/jobs/job_types/town/worker.dm
+++ b/mojave/jobs/job_types/town/worker.dm
@@ -29,7 +29,8 @@
 		/obj/item/wrench/ms13=1, \
 		/obj/item/ms13/handsaw=1, \
 		/obj/item/ms13/hammer=1, \
-		/obj/item/screwdriver/ms13=1)
+		/obj/item/screwdriver/ms13=1, \
+		/obj/item/radio/ms13=1)
 
 
 /datum/outfit/job/ms13/town/worker/pre_equip(mob/living/carbon/human/H)


### PR DESCRIPTION
## About The Pull Request

Distributes some more/better radios to some round start roles after a discussion about doing so with Original. Willing to budge on some of the radio choices but overall I think the distribution is fine relative across all the factions. 

Also adjusts limb damage transfer down to 60% from 70% and increases head damage transfer to 115% from 110%. Overall this should mean 1 less hit to crit to the head for _most_ weapons/attacks and 1-2 more hits to crit to the limbs for basically every weapon/attack. This was another thing me and Original talked about. I'd like to try 60% for now and potentially adjust to 50% later if limb damage is still too punishing. 

## Why It's Good For The Game

I love tweaking