### PR TITLE
Dead ghosts - Decapitated specter edition

### DIFF
--- a/code/__DEFINES/ghost.dm
+++ b/code/__DEFINES/ghost.dm
@@ -21,7 +21,7 @@
 /// The default ghost display selection for the main player
 #define GHOST_ACCS_DEFAULT_OPTION GHOST_ACCS_FULL
 
-/// The other players ghosts will display as a simple white ghost 
+/// The other players ghosts will display as a simple white ghost
 #define GHOST_OTHERS_SIMPLE "White ghosts"
 /// The other players ghosts will display as transparent mobs
 #define GHOST_OTHERS_DEFAULT_SPRITE "Default sprites"
@@ -56,3 +56,9 @@
 #define CAMERA_SEE_GHOSTS_BASIC 1
 /// Pictures taken by a camera will display ghosts and their orbits
 #define CAMERA_SEE_GHOSTS_ORBIT 2 // this doesn't do anything right now as of Jan 2022
+
+// MOJAVE SUN EDIT BEGIN
+/// Alpha of ghost appearances copying the original mob
+#define GHOST_COPY_ALPHA 127
+/// Maximum motion blur a ghost can accumulate in the x or y axis
+// MOJAVE SUN EDIT END

--- a/code/datums/components/orbiter.dm
+++ b/code/datums/components/orbiter.dm
@@ -77,7 +77,7 @@
 
 	var/matrix/initial_transform = matrix(orbiter.transform)
 	orbiter_list[orbiter] = initial_transform
-
+	/* MOJAVE SUN EDIT BEGIN
 	// Head first!
 	if(pre_rotation)
 		var/matrix/M = matrix(orbiter.transform)
@@ -91,7 +91,7 @@
 	shift.Translate(0, radius)
 	orbiter.transform = shift
 
-	orbiter.SpinAnimation(rotation_speed, -1, clockwise, rotation_segments, parallel = FALSE)
+	orbiter.SpinAnimation(rotation_speed, -1, clockwise, rotation_segments, parallel = FALSE) */ // MOJAVE SUN EDIT END
 
 	if(ismob(orbiter))
 		var/mob/orbiter_mob = orbiter

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -49,6 +49,9 @@ GLOBAL_VAR_INIT(observer_default_invisibility, INVISIBILITY_OBSERVER)
 	var/facial_hair_color
 	var/mutable_appearance/facial_hair_overlay
 
+	/// Appearance of the mob we supposedly come from, preferrably used instead of all the bullshit above // MOJAVE SUN EDIT
+	var/mutable_appearance/body_appearance // MOJAVE SUN EDIT
+
 	var/updatedir = 1 //Do we have to update our dir as the ghost moves around?
 	var/lastsetting = null //Stores the last setting that ghost_others was set to, for a little more efficiency when we update ghost images. Null means no update is necessary
 
@@ -113,6 +116,8 @@ GLOBAL_VAR_INIT(observer_default_invisibility, INVISIBILITY_OBSERVER)
 			if(FACEHAIR in body_human.dna.species.species_traits)
 				facial_hairstyle = body_human.facial_hairstyle
 				facial_hair_color = brighten_color(body_human.facial_hair_color)
+
+		body_appearance = copy_appearance(body) // MOJAVE SUN EDIT
 
 	update_appearance()
 
@@ -181,6 +186,39 @@ GLOBAL_VAR_INIT(observer_default_invisibility, INVISIBILITY_OBSERVER)
 	QDEL_NULL(minigames_menu)
 	return ..()
 
+// MOJAVE SUN EDIT BEGIN
+
+/**
+ * This seems stupid, but it's the easiest way to avoid absolutely ridiculous shit from happening.
+ * Copying an appearance directly from a mob includes it's verb list, it's invisibility, it's alpha, and it's density!
+ * You might recognize these things as "fucking ridiculous to put in an appearance" - You'd be right, but that's fucking BYOND for you!
+ * Instead, we have to do this to copy only relevant information out of the original mob's appearance.
+ */
+/mob/dead/observer/proc/copy_appearance(atom/original)
+	var/mutable_appearance/final_appearance = new()
+
+	final_appearance.icon = original.icon
+	final_appearance.icon_state = original.icon_state
+	final_appearance.overlays = original.overlays
+	final_appearance.underlays = original.underlays
+	// Gibbing/dusting/melting removes the icon before ghostize()ing the mob - In that case, we use the old ghost system
+	if(!isicon(final_appearance.icon) && !LAZYLEN(final_appearance.overlays) && !LAZYLEN(final_appearance.underlays))
+		return
+	final_appearance.appearance_flags = original.appearance_flags
+	final_appearance.appearance_flags |= KEEP_TOGETHER
+	final_appearance.blend_mode = original.blend_mode
+	final_appearance.color = original.color
+	final_appearance.maptext = original.maptext
+	final_appearance.maptext_width = original.maptext_width
+	final_appearance.maptext_height = original.maptext_height
+	final_appearance.maptext_x = original.maptext_x
+	final_appearance.maptext_y = original.maptext_y
+	final_appearance.mouse_opacity = original.mouse_opacity
+	final_appearance.alpha = GHOST_COPY_ALPHA
+
+	return final_appearance
+// MOJAVE SUN EDIT END
+
 /*
  * This proc will update the icon of the ghost itself, with hair overlays, as well as the ghost image.
  * Please call update_icon(updates, icon_state) from now on when you want to update the icon_state of the ghost,
@@ -190,6 +228,17 @@ GLOBAL_VAR_INIT(observer_default_invisibility, INVISIBILITY_OBSERVER)
  */
 /mob/dead/observer/update_icon(updates=ALL, new_form)
 	. = ..()
+
+	// We always prefer having an appearance similar to that of the original mob // MOJAVE SUN EDIT BEGIN
+	if(body_appearance)
+		updatedir = TRUE
+		icon = null
+		icon_state = null
+		ADD_TRAIT(src, TRAIT_NO_FLOATING_ANIM, INNATE_TRAIT)
+		cut_overlays()
+		add_overlay(body_appearance)
+		return
+	// MOJAVE SUN EDIT END
 
 	if(client) //We update our preferences in case they changed right before update_appearance was called.
 		ghost_accs = client.prefs.read_preference(/datum/preference/choiced/ghost_accessories)


### PR DESCRIPTION
## About The Pull Request
This PR ports from this repository on this commit, all credit goes to bob for it. https://gitgud.io/bobstation/necrosis13/-/commit/81238b50292dcd3f887a88d2143fe436e02f0c75

This PR adds in the after-image of your mutilated body. How cool is that? Instead of being reduced to a generic ghost, you live on in the secondary plane as a mirror image of how the world remembers you...

In reality, people in Dchat are just going to bully the ghost they notice is wearing a set of Advanced Power Armour with a plasma caster on their back. But that's equally funny.
![image](https://user-images.githubusercontent.com/51188571/200677659-a4b85a12-0289-4543-93b9-637ba7c2f2cf.png)
![image](https://user-images.githubusercontent.com/51188571/200677690-7c6af5a1-c7d8-41b5-ac0f-db91cee8472c.png)
![image](https://user-images.githubusercontent.com/51188571/200677199-fffc5123-59f2-4495-b25b-f20eb2e9b76a.png)

I'll open this as a draft right now, but I need to figure out a bug with orbiting, or maybe add a different 'orbit' mechanic, i'm not sure of it yet.
## Why It's Good For The Game

Adds drip to your soul. Soul to your drip. Just looks better!

