### PR TITLE
Treasure Room of Wasteland: Car Junkyard

### DIFF
--- a/_maps/map_files/Drought/Drought.dmm
+++ b/_maps/map_files/Drought/Drought.dmm
@@ -66,6 +66,10 @@
 /obj/structure/closet/ms13/metal,
 /turf/open/floor/ms13/tile,
 /area/ms13/town)
+"aw" = (
+/obj/structure/fluff/ms13/barrel/double/red,
+/turf/open/floor/plating/ms13/ground/desert,
+/area/ms13/desert)
 "ay" = (
 /obj/structure/closet/ms13/fridge,
 /turf/open/floor/ms13/tile,
@@ -405,6 +409,12 @@
 "cs" = (
 /turf/closed/wall/ms13/metal/reinforced/rust,
 /area/ms13/desert)
+"cv" = (
+/obj/structure/railing/ms13/solo/industrial{
+	dir = 8
+	},
+/turf/open/floor/ms13/concrete/industrial,
+/area/ms13/town)
 "cw" = (
 /obj/machinery/light/ms13,
 /turf/open/floor/wood/ms13/common,
@@ -454,6 +464,12 @@
 "cN" = (
 /obj/structure/ms13/celldoor/locked/rusty,
 /turf/open/floor/ms13/concrete,
+/area/ms13/town)
+"cP" = (
+/obj/machinery/light/ms13/bulb/industrial{
+	dir = 8
+	},
+/turf/open/floor/ms13/metal/plate,
 /area/ms13/town)
 "cQ" = (
 /obj/structure/ms13/storage/shelf{
@@ -769,6 +785,12 @@
 /obj/structure/table/ms13/low_wall/scrap,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
+"eB" = (
+/obj/structure/table/ms13/metal/grate,
+/obj/effect/spawner/random/ms13/tools/tool,
+/obj/structure/ms13/storage/vent,
+/turf/open/floor/ms13/concrete,
+/area/ms13/town)
 "eC" = (
 /obj/structure/ms13/departure,
 /turf/open/openspace/ms13,
@@ -864,6 +886,13 @@
 /obj/structure/table/ms13/metal/grate,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/factory)
+"fe" = (
+/obj/structure/ms13/storage/store/metal{
+	dir = 4
+	},
+/obj/effect/spawner/random/ms13/crafting/lowrandom,
+/turf/open/floor/ms13/concrete/industrial,
+/area/ms13/town)
 "fg" = (
 /obj/effect/decal/cleanable/generic,
 /obj/structure/chair/ms13/metal/blue/broken{
@@ -944,7 +973,7 @@
 /turf/open/floor/ms13/tile/large/navy,
 /area/ms13/town)
 "fA" = (
-/obj/structure/fluff/ms13/trash/papers,
+/obj/structure/ms13/fence/wire/barb,
 /turf/open/floor/plating/ms13/ground/desert,
 /area/ms13/desert)
 "fC" = (
@@ -1204,6 +1233,10 @@
 	pixel_y = 4
 	},
 /turf/open/floor/wood/ms13/carpet,
+/area/ms13/town)
+"gL" = (
+/obj/structure/table/ms13/metal/grate,
+/turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "gM" = (
 /obj/structure/table/ms13/no_smooth/counter/metal{
@@ -1539,6 +1572,10 @@
 	},
 /turf/open/floor/ms13/tile/large/white,
 /area/ms13/town)
+"ik" = (
+/obj/structure/ladder/ms13,
+/turf/open/floor/plating/ms13/ground/desertalt,
+/area/ms13/desert)
 "il" = (
 /obj/machinery/door/unpowered/ms13/wood/red{
 	dir = 1
@@ -1849,6 +1886,12 @@
 	dir = 1
 	},
 /area/ms13/desert)
+"jS" = (
+/obj/machinery/door/unpowered/ms13/seethrough/fence/wire{
+	dir = 1
+	},
+/turf/open/floor/plating/ms13/ground/sidewalk,
+/area/ms13/desert)
 "jU" = (
 /obj/structure/table/ms13/low_wall/brick,
 /obj/effect/decal/cleanable/glass{
@@ -1913,6 +1956,14 @@
 "kp" = (
 /mob/living/basic/ms13/ghoul/brown,
 /turf/open/floor/ms13/tile/large/cafeteria,
+/area/ms13/town)
+"kq" = (
+/obj/structure/table/ms13/no_smooth/counter/metal,
+/obj/structure/closet/crate/ms13/cash_register{
+	pixel_y = 8
+	},
+/obj/effect/spawner/random/ms13/currency/mammoth/prewar/lowrandom,
+/turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "kr" = (
 /obj/effect/decal/cleanable/generic,
@@ -2063,6 +2114,12 @@
 	dir = 1
 	},
 /turf/open/floor/wood/ms13/common,
+/area/ms13/town)
+"la" = (
+/obj/structure/ms13/storage/vent,
+/turf/open/floor/ms13/metal/grate/border/warning{
+	dir = 1
+	},
 /area/ms13/town)
 "lc" = (
 /obj/machinery/door/unpowered/ms13/wood/red{
@@ -2246,6 +2303,10 @@
 /obj/machinery/ms13/terminal/wall,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/factory)
+"mh" = (
+/obj/structure/stairs/north,
+/turf/open/floor/ms13/concrete/industrial,
+/area/ms13/town)
 "ml" = (
 /obj/structure/sink/kitchen{
 	dir = 8;
@@ -2298,6 +2359,11 @@
 	},
 /obj/machinery/light/ms13/bulb,
 /turf/open/floor/ms13/tile/large/white,
+/area/ms13/town)
+"mC" = (
+/turf/open/floor/ms13/concrete/industrial/walkway{
+	dir = 1
+	},
 /area/ms13/town)
 "mD" = (
 /obj/structure/closet/crate/ms13/cash_register{
@@ -2672,6 +2738,10 @@
 "oz" = (
 /turf/open/floor/ms13/metal/pipe/intersection,
 /area/ms13/desert)
+"oA" = (
+/obj/effect/turf_decal/ms13/covering/paint/white,
+/turf/closed/wall/ms13/brick/alt,
+/area/ms13/town)
 "oD" = (
 /obj/structure/ms13/pot/plant{
 	pixel_y = 7
@@ -2786,6 +2856,14 @@
 /obj/structure/ms13/pot/plant,
 /turf/open/floor/wood/ms13/common,
 /area/ms13/town)
+"pl" = (
+/obj/machinery/door/poddoor/shutters/ms13/vertical/red/mid/pre_open{
+	id = "car_junk_press_door"
+	},
+/turf/open/floor/ms13/concrete/industrial/walkway/end{
+	dir = 8
+	},
+/area/ms13/town)
 "pm" = (
 /obj/structure/ms13/skeleton,
 /turf/open/floor/wood/ms13/common,
@@ -2858,6 +2936,10 @@
 	},
 /turf/open/floor/wood/ms13/mosaic,
 /area/ms13/town)
+"pH" = (
+/obj/structure/fluff/ms13/barrel/quadruple/red/one,
+/turf/open/floor/plating/ms13/ground/desertalt,
+/area/ms13/desert)
 "pI" = (
 /obj/structure/ms13/foundation/common/variantsix{
 	dir = 4
@@ -2967,6 +3049,12 @@
 	},
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
+"qj" = (
+/obj/machinery/door/unpowered/ms13/metal/red{
+	dir = 4
+	},
+/turf/open/floor/ms13/concrete/industrial,
+/area/ms13/town)
 "qm" = (
 /turf/open/floor/ms13/tile/navy,
 /area/ms13/town)
@@ -2988,6 +3076,12 @@
 	dir = 1
 	},
 /turf/open/floor/ms13/tile/large/white,
+/area/ms13/town)
+"qt" = (
+/obj/structure/ms13/storage/store/metal{
+	dir = 4
+	},
+/turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "qu" = (
 /obj/item/chair/ms13/metal/broken{
@@ -3093,6 +3187,10 @@
 /obj/machinery/iv_drip/ms13,
 /turf/open/floor/wood/ms13/common,
 /area/ms13/town)
+"rc" = (
+/obj/structure/ms13/fence/vertical/wire/east/barb,
+/turf/open/floor/plating/ms13/ground/sidewalk,
+/area/ms13/desert)
 "rd" = (
 /obj/structure/chair/ms13/metal/folding{
 	dir = 1
@@ -3192,6 +3290,9 @@
 /obj/structure/window/fulltile/ms13/glass,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
+"rI" = (
+/turf/open/floor/plating/ms13/ground/sidewalk,
+/area/ms13/town)
 "rJ" = (
 /obj/structure/ms13/storage/shelf,
 /turf/open/floor/wood/ms13/wide,
@@ -3232,6 +3333,12 @@
 "rQ" = (
 /mob/living/basic/ms13/ghoul/brown,
 /turf/open/floor/wood/ms13/wide,
+/area/ms13/town)
+"rR" = (
+/obj/structure/chair/ms13/metal/broken{
+	dir = 4
+	},
+/turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "rT" = (
 /obj/effect/decal/cleanable/glass,
@@ -3897,6 +4004,15 @@
 /obj/structure/ms13/medical_curtain,
 /turf/open/floor/ms13/tile/blue/long,
 /area/ms13/town)
+"vJ" = (
+/obj/structure/table/ms13/metal/grate,
+/obj/effect/spawner/random/ms13/tools/tool,
+/turf/open/floor/ms13/concrete/industrial,
+/area/ms13/town)
+"vL" = (
+/obj/machinery/light/ms13/bulb/industrial,
+/turf/open/floor/ms13/concrete/industrial,
+/area/ms13/town)
 "vM" = (
 /obj/effect/spawner/random/ms13/food/random,
 /turf/closed/wall/ms13/brick/alt,
@@ -3974,6 +4090,10 @@
 	pixel_x = 11
 	},
 /turf/open/floor/ms13/tile/large/checkered,
+/area/ms13/town)
+"wo" = (
+/obj/machinery/ms13/fusion_generator,
+/turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "wp" = (
 /obj/structure/closet/crate/ms13/footlocker{
@@ -4151,6 +4271,14 @@
 /obj/machinery/door/unpowered/ms13/wood/red,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
+"xC" = (
+/obj/structure/ms13/vehicle_ruin{
+	dir = 8
+	},
+/turf/open/floor/ms13/concrete/industrial/walkway{
+	dir = 1
+	},
+/area/ms13/town)
 "xF" = (
 /obj/structure/ms13/foundation/wide/variantfive{
 	dir = 1
@@ -4163,6 +4291,11 @@
 	dir = 4
 	},
 /turf/open/floor/plating/ms13/ground/mountain,
+/area/ms13/town)
+"xH" = (
+/obj/structure/table/ms13/metal/grate,
+/obj/effect/spawner/random/ms13/melee/lowrandom,
+/turf/open/floor/ms13/concrete,
 /area/ms13/town)
 "xI" = (
 /obj/effect/decal/cleanable/glass,
@@ -4409,6 +4542,10 @@
 	},
 /turf/open/floor/plating/ms13/ground/mountain,
 /area/ms13/town)
+"yW" = (
+/obj/structure/table/ms13/metal/grate,
+/turf/open/floor/ms13/concrete,
+/area/ms13/town)
 "yY" = (
 /obj/structure/table/ms13/no_smooth/counter/metal,
 /obj/machinery/light/ms13{
@@ -4468,6 +4605,10 @@
 "zj" = (
 /obj/machinery/door/unpowered/ms13/wood/mirrored,
 /turf/open/floor/ms13/tile/large/black,
+/area/ms13/town)
+"zm" = (
+/obj/machinery/light/ms13,
+/turf/open/floor/ms13/concrete,
 /area/ms13/town)
 "zn" = (
 /obj/machinery/light/ms13/bulb,
@@ -4573,6 +4714,16 @@
 /obj/machinery/ms13/terminal,
 /turf/open/floor/wood/ms13/common,
 /area/ms13/town)
+"zX" = (
+/obj/machinery/door/poddoor/shutters/ms13/vertical/red/mid{
+	id = "car_junk_storage"
+	},
+/turf/open/floor/ms13/concrete/industrial,
+/area/ms13/town)
+"Ae" = (
+/mob/living/basic/ms13/robot/handy,
+/turf/open/floor/ms13/concrete,
+/area/ms13/town)
 "Ag" = (
 /obj/structure/dresser/ms13/orange/tall,
 /turf/open/floor/wood/ms13/carpet/shaggy,
@@ -4601,6 +4752,10 @@
 	},
 /obj/item/knife/ms13,
 /turf/open/floor/ms13/tile/large/white,
+/area/ms13/town)
+"Aq" = (
+/obj/structure/table/ms13/no_smooth/counter/metal,
+/turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "At" = (
 /obj/machinery/door/unpowered/ms13/metal/red,
@@ -4714,6 +4869,13 @@
 	},
 /turf/open/floor/ms13/tile/large/cafeteria,
 /area/ms13/town)
+"By" = (
+/obj/structure/table/ms13/no_smooth/counter/metal{
+	dir = 1
+	},
+/obj/effect/spawner/random/ms13/tools/tool,
+/turf/open/floor/ms13/concrete/industrial,
+/area/ms13/town)
 "BD" = (
 /obj/item/chair/ms13/metal{
 	dir = 1
@@ -4804,6 +4966,10 @@
 /obj/structure/ms13/rug/mat/rubber/single,
 /turf/open/floor/wood/ms13/carpet/shaggy,
 /area/ms13/town)
+"Co" = (
+/obj/structure/fluff/ms13/barrel/single/red/one,
+/turf/open/floor/plating/ms13/ground/desertalt,
+/area/ms13/desert)
 "Cs" = (
 /obj/structure/chair/office/ms13/red/broken{
 	dir = 1
@@ -4838,12 +5004,20 @@
 /obj/structure/table/ms13/metal,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
+"CG" = (
+/obj/structure/fluff/ms13/barrel/single/red/three,
+/turf/open/floor/plating/ms13/ground/desertalt,
+/area/ms13/desert)
 "CJ" = (
 /obj/structure/ms13/storage/trashcan{
 	pixel_y = 4
 	},
 /turf/open/floor/plating/ms13/ground/sidewalk,
 /area/ms13/desert)
+"CL" = (
+/obj/machinery/door/unpowered/ms13/metal/mirrored/red,
+/turf/open/floor/ms13/concrete/industrial,
+/area/ms13/town)
 "CM" = (
 /obj/structure/railing/ms13/solo,
 /turf/open/floor/wood/ms13/common,
@@ -4892,6 +5066,10 @@
 	},
 /turf/open/floor/wood/ms13/carpet/shaggy,
 /area/ms13/town)
+"Di" = (
+/obj/structure/fluff/ms13/trash/papers,
+/turf/open/floor/ms13/concrete/industrial,
+/area/ms13/town)
 "Dk" = (
 /obj/structure/toilet{
 	dir = 8
@@ -4919,6 +5097,10 @@
 /obj/machinery/ms13/plant_machinery/broken,
 /turf/open/floor/ms13/metal/grate,
 /area/ms13/desert)
+"Dy" = (
+/obj/structure/fluff/ms13/barrel/single/flammable/two,
+/turf/open/floor/ms13/concrete,
+/area/ms13/town)
 "Dz" = (
 /obj/structure/closet/ms13/metal,
 /turf/open/floor/wood/ms13/wide,
@@ -4937,6 +5119,11 @@
 /obj/structure/window/fulltile/ms13/glass,
 /turf/closed/wall/ms13/brick,
 /area/ms13/town)
+"DL" = (
+/obj/structure/table/ms13/metal/grate,
+/obj/effect/spawner/random/ms13/crafting/electrical,
+/turf/open/floor/ms13/concrete/industrial,
+/area/ms13/town)
 "DN" = (
 /obj/machinery/light/ms13/bulb,
 /obj/structure/table/ms13/no_smooth/counter/metal{
@@ -4947,6 +5134,12 @@
 "DO" = (
 /obj/structure/chair/ms13/metal/unfinished,
 /turf/open/floor/wood/ms13/wide,
+/area/ms13/town)
+"DQ" = (
+/obj/structure/filingcabinet/ms13/empty{
+	dir = 1
+	},
+/turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "DS" = (
 /obj/effect/decal/cleanable/glass{
@@ -4969,6 +5162,17 @@
 "Eb" = (
 /obj/structure/ms13/storage/trashcan,
 /turf/open/floor/ms13/tile/large/cafeteria,
+/area/ms13/town)
+"Ec" = (
+/obj/structure/ms13/storage/shelf,
+/obj/effect/spawner/random/ms13/tools/hardware,
+/turf/open/floor/ms13/concrete/industrial,
+/area/ms13/town)
+"Ed" = (
+/obj/structure/ms13/storage/shelf{
+	dir = 8
+	},
+/turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "Eh" = (
 /obj/structure/table/ms13/no_smooth/metal,
@@ -4993,6 +5197,12 @@
 	dir = 8
 	},
 /turf/open/floor/wood/ms13/common,
+/area/ms13/town)
+"Eq" = (
+/obj/structure/window/fulltile/ms13/glass,
+/obj/structure/table/ms13/low_wall/brick/alt,
+/obj/structure/ms13/barricade,
+/turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "Et" = (
 /obj/structure/table/ms13/no_smooth/counter/metal,
@@ -5073,11 +5283,20 @@
 /obj/machinery/light/ms13/bulb,
 /turf/open/floor/wood/ms13/common,
 /area/ms13/town)
+"EP" = (
+/obj/structure/table/ms13/no_smooth/counter/metal,
+/obj/effect/spawner/random/ms13/tools/tool,
+/turf/open/floor/ms13/concrete/industrial,
+/area/ms13/town)
 "ER" = (
 /obj/effect/decal/cleanable/glass{
 	dir = 8
 	},
 /turf/open/floor/wood/ms13/wide,
+/area/ms13/town)
+"ES" = (
+/obj/structure/fluff/ms13/barrel/quadruple/yellow/one,
+/turf/open/floor/ms13/concrete,
 /area/ms13/town)
 "EV" = (
 /obj/structure/closet/ms13/fridge,
@@ -5167,6 +5386,10 @@
 /obj/structure/chair/sofa/corner,
 /turf/open/floor/wood/ms13/common,
 /area/ms13/town)
+"FH" = (
+/obj/machinery/door/unpowered/ms13/metal/red,
+/turf/open/floor/ms13/concrete/industrial,
+/area/ms13/town)
 "FP" = (
 /turf/open/floor/ms13/metal/stayclear,
 /area/ms13/town)
@@ -5179,6 +5402,10 @@
 "FX" = (
 /obj/effect/decal/cleanable/plastic,
 /turf/open/floor/wood/ms13/common,
+/area/ms13/town)
+"Ga" = (
+/obj/machinery/door/poddoor/shutters/ms13/horizontal/red/right,
+/turf/open/floor/plating/ms13/ground/road,
 /area/ms13/town)
 "Gb" = (
 /obj/structure/chair/ms13/metal/folding{
@@ -5221,6 +5448,14 @@
 	},
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/factory)
+"Gm" = (
+/obj/machinery/door/poddoor/shutters/ms13/vertical/red/mid/pre_open{
+	id = "car_junk_press_door"
+	},
+/turf/open/floor/ms13/concrete/industrial/walkway/end{
+	dir = 4
+	},
+/area/ms13/town)
 "Gn" = (
 /obj/structure/stairs/east,
 /turf/open/floor/ms13/concrete/industrial,
@@ -5304,6 +5539,10 @@
 /obj/structure/bed/ms13/sleepingbag/green,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
+"Hn" = (
+/obj/structure/fluff/ms13/barrel/quadruple/red/two,
+/turf/open/floor/plating/ms13/ground/desert,
+/area/ms13/desert)
 "Hp" = (
 /obj/structure/chair/ms13/overlaypickup/plastic{
 	dir = 1
@@ -5322,9 +5561,21 @@
 /obj/structure/railing/ms13/wood/ending,
 /turf/open/floor/plating/ms13/ground/desert,
 /area/ms13/desert)
+"Hv" = (
+/obj/structure/safe/ms13/wall,
+/obj/effect/spawner/random/ms13/currency/mammoth/prewar/lowrandom,
+/obj/effect/spawner/random/ms13/currency/mammoth/prewar/lowrandom,
+/obj/effect/spawner/random/ms13/gun/lowrandom,
+/turf/open/floor/ms13/concrete/industrial,
+/area/ms13/town)
 "Hz" = (
 /obj/structure/stairs/north,
 /turf/open/floor/wood/ms13/wide,
+/area/ms13/town)
+"HA" = (
+/obj/structure/closet/ms13/metal,
+/obj/effect/spawner/random/ms13/armor/lowrandom,
+/turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "HB" = (
 /turf/open/floor/wood/ms13/carpet/shaggy/green,
@@ -5359,6 +5610,16 @@
 	},
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/factory)
+"HS" = (
+/obj/machinery/door/unpowered/ms13/seethrough/fence/wire,
+/turf/open/floor/plating/ms13/ground/sidewalk,
+/area/ms13/desert)
+"HU" = (
+/obj/structure/ms13/storage/large/shelf{
+	dir = 8
+	},
+/turf/open/floor/ms13/concrete/industrial,
+/area/ms13/town)
 "HW" = (
 /obj/machinery/light/ms13/bulb{
 	dir = 1
@@ -5369,6 +5630,13 @@
 /obj/structure/table/ms13/low_wall/brick,
 /turf/open/floor/wood/ms13/common,
 /area/ms13/desert)
+"Ib" = (
+/obj/structure/ms13/storage/store/metal{
+	dir = 4
+	},
+/obj/effect/spawner/random/ms13/crafting/electrical,
+/turf/open/floor/ms13/concrete/industrial,
+/area/ms13/town)
 "Ic" = (
 /obj/structure/table/ms13/no_smooth/counter/wood,
 /turf/open/floor/ms13/tile/blue,
@@ -5394,6 +5662,10 @@
 "Im" = (
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/ms13/tile/large/black,
+/area/ms13/town)
+"In" = (
+/obj/effect/spawner/random/ms13/crafting/lowrandom,
+/turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "Iq" = (
 /obj/structure/table/ms13/no_smooth/large/wood/square,
@@ -5495,6 +5767,10 @@
 /mob/living/simple_animal/hostile/ms13/robot/protectron/reinforced,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/factory)
+"Ji" = (
+/obj/structure/fluff/ms13/barrel/double/red/one,
+/turf/open/floor/plating/ms13/ground/desert,
+/area/ms13/desert)
 "Jk" = (
 /obj/item/chair/ms13/wood{
 	dir = 1
@@ -5544,6 +5820,11 @@
 /obj/structure/ms13/pay_phone/withthephone,
 /turf/open/floor/plating/ms13/ground/sidewalk,
 /area/ms13/desert)
+"Jx" = (
+/turf/open/floor/ms13/metal/grate/border/warning{
+	dir = 1
+	},
+/area/ms13/town)
 "JA" = (
 /obj/machinery/door/unpowered/ms13/metal/red{
 	dir = 1
@@ -5555,6 +5836,10 @@
 /obj/effect/spawner/random/ms13/clothing/under,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
+"JE" = (
+/obj/structure/fluff/ms13/barrel/single/warning/one,
+/turf/open/floor/plating/ms13/ground/desert,
+/area/ms13/desert)
 "JG" = (
 /obj/structure/fluff/ms13/trash/papers{
 	dir = 8
@@ -5583,6 +5868,13 @@
 	},
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/factory)
+"JR" = (
+/obj/structure/railing/ms13/solo/industrial{
+	dir = 8
+	},
+/obj/structure/ms13/wall_decor/clock,
+/turf/open/floor/ms13/concrete/industrial,
+/area/ms13/town)
 "JS" = (
 /obj/structure/table/ms13/no_smooth/counter/wood{
 	dir = 4
@@ -5662,6 +5954,13 @@
 	dir = 8
 	},
 /turf/open/floor/wood/ms13/carpet/shaggy/green,
+/area/ms13/town)
+"Kv" = (
+/obj/structure/ms13/storage/store/metal{
+	dir = 4
+	},
+/obj/effect/spawner/random/ms13/guaranteed/crafting/electrical,
+/turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "Kw" = (
 /obj/effect/decal/cleanable/glass{
@@ -5818,6 +6117,11 @@
 	},
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
+"LB" = (
+/obj/structure/table/ms13/metal/grate,
+/obj/effect/spawner/random/ms13/crafting/lowrandom,
+/turf/open/floor/ms13/concrete/industrial,
+/area/ms13/town)
 "LF" = (
 /obj/structure/window/fulltile/ms13/glass,
 /obj/structure/table/ms13/low_wall/brick,
@@ -5922,6 +6226,12 @@
 /obj/effect/spawner/random/ms13/medical/bloodbag,
 /turf/open/floor/ms13/tile/blue/long,
 /area/ms13/town)
+"Mz" = (
+/obj/structure/table/ms13/no_smooth/counter/metal{
+	dir = 1
+	},
+/turf/open/floor/ms13/concrete/industrial,
+/area/ms13/town)
 "MA" = (
 /obj/structure/chair/office/ms13/red/broken{
 	dir = 8
@@ -6007,6 +6317,10 @@
 /obj/effect/spawner/random/ms13/crafting/electrical,
 /turf/closed/wall/ms13/brick/alt,
 /area/ms13/factory)
+"NB" = (
+/obj/structure/ms13/vehicle_ruin,
+/turf/open/floor/plating/ms13/ground/desert,
+/area/ms13/desert)
 "ND" = (
 /obj/machinery/door/poddoor/shutters/ms13/vertical/red/mid/pre_open{
 	id = "robco_factory_wh2"
@@ -6072,12 +6386,38 @@
 /obj/machinery/door/unpowered/ms13/seethrough/mirrored/grate,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
+"Oi" = (
+/obj/structure/table/ms13/no_smooth/counter/metal,
+/obj/effect/spawner/random/ms13/crafting/lowrandom,
+/turf/open/floor/ms13/concrete/industrial,
+/area/ms13/town)
+"Om" = (
+/obj/structure/ms13/barricade{
+	dir = 4
+	},
+/turf/open/floor/ms13/concrete,
+/area/ms13/town)
 "Op" = (
 /obj/structure/bed/ms13/bedframe/wire,
 /turf/open/floor/ms13/concrete,
 /area/ms13/town)
+"Or" = (
+/obj/machinery/power/ms13/streetlamp/corner,
+/turf/open/floor/plating/ms13/ground/sidewalk,
+/area/ms13/desert)
 "Ot" = (
 /obj/structure/toilet,
+/turf/open/floor/ms13/concrete,
+/area/ms13/town)
+"Ow" = (
+/obj/machinery/door/poddoor/shutters/ms13/horizontal/red/left,
+/turf/open/floor/plating/ms13/ground/road,
+/area/ms13/town)
+"Ox" = (
+/obj/structure/table/ms13/metal/grate,
+/obj/structure/ms13/lamp/makeshift{
+	pixel_y = 4
+	},
 /turf/open/floor/ms13/concrete,
 /area/ms13/town)
 "Oy" = (
@@ -6149,6 +6489,12 @@
 /obj/structure/railing/ms13/solo,
 /turf/open/floor/ms13/tile/large/black,
 /area/ms13/town)
+"OU" = (
+/obj/machinery/door/poddoor/shutters/ms13/vertical/red/mid/pre_open{
+	id = "car_junk_press_door"
+	},
+/turf/open/floor/ms13/concrete/industrial,
+/area/ms13/town)
 "OW" = (
 /obj/structure/table/ms13/no_smooth/wood/stand,
 /turf/open/floor/wood/ms13/carpet/shaggy,
@@ -6194,6 +6540,10 @@
 /obj/structure/table/ms13/metal,
 /obj/effect/spawner/random/ms13/tools/hardware,
 /turf/open/floor/ms13/tile/full/navy,
+/area/ms13/town)
+"Pq" = (
+/obj/machinery/door/poddoor/shutters/ms13/horizontal/red/mid,
+/turf/open/floor/plating/ms13/ground/road,
 /area/ms13/town)
 "Pr" = (
 /obj/structure/chair/ms13/wood/padded{
@@ -6246,6 +6596,18 @@
 /obj/machinery/ms13/substation/discharge,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
+"PL" = (
+/obj/structure/table/ms13/no_smooth/counter/metal,
+/obj/structure/ms13/storage/vent,
+/turf/open/floor/ms13/concrete/industrial,
+/area/ms13/town)
+"PS" = (
+/obj/machinery/ms13/terminal/wall{
+	dir = 8;
+	id = "car_junk_press_door"
+	},
+/turf/open/floor/plating/ms13/ground/desertalt,
+/area/ms13/desert)
 "PZ" = (
 /obj/machinery/door/unpowered/ms13/wood,
 /turf/open/floor/wood/ms13/wide,
@@ -6283,6 +6645,10 @@
 	pixel_y = 6
 	},
 /turf/open/floor/ms13/tile/blue/long,
+/area/ms13/town)
+"Qr" = (
+/obj/machinery/door/unpowered/ms13/seethrough/metal,
+/turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "Qx" = (
 /obj/machinery/light/ms13{
@@ -6330,10 +6696,20 @@
 /obj/structure/ms13/barricade,
 /turf/open/floor/ms13/tile/large/black,
 /area/ms13/town)
+"QM" = (
+/mob/living/simple_animal/hostile/ms13/radscorpion/desert,
+/turf/open/floor/plating/ms13/ground/desertalt,
+/area/ms13/desert)
 "QO" = (
 /mob/living/simple_animal/hostile/ms13/robot/protectron,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/factory)
+"QP" = (
+/obj/machinery/door/unpowered/ms13/seethrough/fence/wire/barb{
+	dir = 1
+	},
+/turf/open/floor/plating/ms13/ground/desert,
+/area/ms13/desert)
 "QQ" = (
 /obj/structure/filingcabinet/ms13,
 /turf/open/floor/wood/ms13/wide,
@@ -6473,6 +6849,11 @@
 /obj/structure/filingcabinet/ms13,
 /turf/open/floor/wood/ms13/common,
 /area/ms13/town)
+"Sp" = (
+/obj/structure/window/fulltile/ms13/glass,
+/obj/structure/table/ms13/low_wall/brick/alt,
+/turf/open/floor/ms13/concrete/industrial,
+/area/ms13/town)
 "Ss" = (
 /turf/open/floor/ms13/concrete/industrial/walkway/corner{
 	dir = 4
@@ -6524,6 +6905,12 @@
 	},
 /turf/open/floor/plating/ms13/ground/desert,
 /area/ms13/town)
+"SW" = (
+/obj/structure/ms13/barricade{
+	dir = 8
+	},
+/turf/open/floor/ms13/concrete/industrial,
+/area/ms13/town)
 "SZ" = (
 /obj/structure/chair/sofa/right{
 	dir = 8
@@ -6557,6 +6944,14 @@
 	},
 /turf/open/floor/wood/ms13/common,
 /area/ms13/desert)
+"Tk" = (
+/obj/structure/table/ms13/metal/grate,
+/obj/machinery/light/ms13{
+	dir = 8
+	},
+/obj/effect/spawner/random/ms13/crafting/lowrandom,
+/turf/open/floor/ms13/concrete/industrial,
+/area/ms13/town)
 "Tl" = (
 /obj/effect/decal/cleanable/generic,
 /obj/structure/chair/office/ms13/green/broken,
@@ -6617,6 +7012,12 @@
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/ms13/ceramic,
 /area/ms13/desert)
+"TZ" = (
+/obj/machinery/door/unpowered/ms13/metal{
+	dir = 4
+	},
+/turf/open/floor/ms13/concrete,
+/area/ms13/town)
 "Ub" = (
 /obj/structure/table/ms13/no_smooth/counter/metal,
 /obj/machinery/ms13/coffee{
@@ -6638,6 +7039,10 @@
 	dir = 4
 	},
 /turf/open/floor/ms13/tile/blue,
+/area/ms13/town)
+"Um" = (
+/obj/structure/ms13/storage/vent,
+/turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "Uo" = (
 /obj/structure/chair/sofa/corp/right{
@@ -6665,6 +7070,13 @@
 	dir = 9
 	},
 /turf/open/floor/plating/ms13/ground/desert,
+/area/ms13/town)
+"UH" = (
+/obj/structure/ms13/storage/shelf{
+	dir = 8
+	},
+/obj/effect/spawner/random/ms13/tools/tool,
+/turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "UK" = (
 /obj/structure/bed/ms13/bedframe/cot,
@@ -6724,12 +7136,22 @@
 	},
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
+"Vt" = (
+/obj/structure/railing/ms13/solo/industrial{
+	dir = 8
+	},
+/turf/open/openspace/ms13,
+/area/ms13/town)
 "Vw" = (
 /obj/machinery/light/ms13{
 	dir = 4
 	},
 /turf/open/floor/ms13/tile/large/cafeteria,
 /area/ms13/factory)
+"Vy" = (
+/obj/structure/ms13/storage/shelf,
+/turf/open/floor/ms13/concrete,
+/area/ms13/town)
 "VA" = (
 /obj/structure/table/ms13/metal,
 /turf/open/floor/ms13/tile/large/white,
@@ -6754,6 +7176,10 @@
 	},
 /turf/open/floor/ms13/concrete,
 /area/ms13/town)
+"VK" = (
+/obj/machinery/door/unpowered/ms13/seethrough/fence/wire/barb,
+/turf/open/floor/plating/ms13/ground/desert,
+/area/ms13/desert)
 "VL" = (
 /obj/effect/spawner/random/ms13/tools/tool,
 /turf/open/floor/ms13/concrete/industrial,
@@ -6767,6 +7193,14 @@
 	},
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
+"VQ" = (
+/obj/structure/ms13/storage/store/metal{
+	dir = 4
+	},
+/obj/effect/spawner/random/ms13/crafting/lowrandom,
+/obj/effect/spawner/random/ms13/crafting/lowrandom,
+/turf/open/floor/ms13/concrete/industrial,
+/area/ms13/town)
 "VR" = (
 /obj/structure/table/ms13/no_smooth/large/metal/desk,
 /obj/structure/ms13/phone/black{
@@ -6777,6 +7211,11 @@
 "VU" = (
 /obj/machinery/ms13/substation/rusty,
 /turf/open/floor/ms13/concrete/industrial,
+/area/ms13/town)
+"VV" = (
+/obj/structure/ms13/storage/shelf,
+/obj/effect/spawner/random/ms13/tools/tool,
+/turf/open/floor/ms13/concrete,
 /area/ms13/town)
 "Wd" = (
 /obj/structure/chair/sofa/corp/left{
@@ -6834,6 +7273,13 @@
 	},
 /turf/open/floor/wood/ms13/common,
 /area/ms13/town)
+"Wx" = (
+/obj/structure/fluff/ms13/barrel/single/hazard/one,
+/obj/machinery/light/ms13{
+	dir = 8
+	},
+/turf/open/floor/ms13/concrete,
+/area/ms13/town)
 "WB" = (
 /obj/structure/ms13/storage/shelf,
 /turf/open/floor/wood/ms13/wide,
@@ -6843,6 +7289,13 @@
 	id = "farm-biker-garage"
 	},
 /turf/open/floor/plating/ms13/ground/road,
+/area/ms13/town)
+"WI" = (
+/obj/structure/table/ms13/metal/grate,
+/obj/machinery/light/ms13{
+	dir = 1
+	},
+/turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "WK" = (
 /obj/structure/ms13/storage/bookshelf{
@@ -6857,6 +7310,12 @@
 "WQ" = (
 /obj/effect/spawner/random/ms13/crafting/household,
 /turf/open/floor/wood/ms13/common,
+/area/ms13/town)
+"WT" = (
+/obj/machinery/light/ms13{
+	dir = 4
+	},
+/turf/open/floor/ms13/concrete,
 /area/ms13/town)
 "WU" = (
 /obj/structure/chair/ms13/metal/unfinished{
@@ -6921,6 +7380,12 @@
 	},
 /turf/open/floor/ms13/concrete,
 /area/ms13/town)
+"XJ" = (
+/obj/machinery/door/unpowered/ms13/metal{
+	dir = 8
+	},
+/turf/open/floor/ms13/concrete/industrial,
+/area/ms13/town)
 "XL" = (
 /turf/open/floor/ms13/tile/full/navy,
 /area/ms13/town)
@@ -6948,6 +7413,9 @@
 	},
 /turf/open/floor/wood/ms13/common,
 /area/ms13/town)
+"XR" = (
+/turf/closed/wall/ms13/brick/alt,
+/area/ms13/underground/mountain)
 "XT" = (
 /obj/machinery/light/ms13/bulb/industrial{
 	dir = 4
@@ -6977,6 +7445,10 @@
 	dir = 1
 	},
 /area/ms13/town)
+"Yd" = (
+/obj/structure/fluff/ms13/barrel/single/red/one,
+/turf/open/floor/plating/ms13/ground/desert,
+/area/ms13/desert)
 "Ye" = (
 /obj/structure/chair/ms13/metal/unfinished{
 	dir = 1
@@ -7010,6 +7482,24 @@
 /area/ms13/town)
 "Yl" = (
 /obj/effect/spawner/random/ms13/guaranteed/crafting/electrical,
+/turf/open/floor/ms13/concrete/industrial,
+/area/ms13/town)
+"Yn" = (
+/obj/structure/table/ms13/metal/grate,
+/obj/structure/ms13/barricade{
+	dir = 4
+	},
+/turf/open/floor/ms13/concrete/industrial,
+/area/ms13/town)
+"Yp" = (
+/obj/effect/turf_decal/ms13/covering/paint/white,
+/obj/effect/spawner/random/ms13/crafting/highrandom,
+/turf/closed/wall/ms13/brick/alt,
+/area/ms13/town)
+"Yq" = (
+/obj/machinery/button/ms13{
+	id = "car_junk_press_door"
+	},
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "Yr" = (
@@ -7070,6 +7560,13 @@
 	},
 /turf/open/floor/plating/ms13/ground/desert,
 /area/ms13/desert)
+"YP" = (
+/obj/structure/ms13/storage/shelf{
+	dir = 8
+	},
+/obj/effect/spawner/random/ms13/crafting/electrical,
+/turf/open/floor/ms13/concrete/industrial,
+/area/ms13/town)
 "YQ" = (
 /mob/living/basic/ms13/ghoul/brown,
 /turf/open/floor/wood/ms13/carpet/shaggy/green,
@@ -7110,6 +7607,13 @@
 /obj/structure/stairs/east,
 /turf/open/floor/plating/ms13/ground/sidewalk,
 /area/ms13/desert)
+"Zs" = (
+/obj/structure/closet/ms13/metal,
+/obj/effect/spawner/random/ms13/clothing/under,
+/obj/effect/spawner/random/ms13/clothing/hat,
+/obj/structure/ms13/storage/vent,
+/turf/open/floor/ms13/concrete/industrial,
+/area/ms13/town)
 "Zw" = (
 /obj/effect/decal/cleanable/glass{
 	dir = 8
@@ -7126,6 +7630,10 @@
 	},
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/factory)
+"ZE" = (
+/obj/machinery/door/unpowered/ms13/seethrough/mirrored/metal,
+/turf/open/floor/ms13/concrete/industrial,
+/area/ms13/town)
 "ZK" = (
 /obj/effect/decal/cleanable/glass{
 	dir = 8
@@ -7163,6 +7671,12 @@
 "ZV" = (
 /obj/structure/ms13/storage/shelf,
 /turf/open/floor/ms13/tile/full/navy,
+/area/ms13/town)
+"ZX" = (
+/obj/structure/table/ms13/no_smooth/counter/metal{
+	dir = 1
+	},
+/turf/open/floor/ms13/concrete,
 /area/ms13/town)
 "ZZ" = (
 /obj/structure/ms13/foundation/wide/varianttwo{
@@ -27944,36 +28458,36 @@ aX
 aX
 aX
 Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
+Oy
+eN
+eN
+eN
+eN
+eN
+eN
+eN
+rc
+rc
+Oy
+rc
+rc
+rc
+rc
+EZ
+EZ
+EZ
+EZ
+EZ
+EZ
+EZ
+EZ
+EZ
+EZ
+EZ
+EZ
+EZ
+eN
+eN
 ZU
 ZU
 "}
@@ -28146,34 +28660,34 @@ Vm
 aX
 aX
 Xv
+fA
 Xv
 Xv
 Xv
 Xv
+dp
 Xv
 Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
+Tc
+Tc
+js
+Or
+Tc
+Tc
+Tc
+oA
+Um
+HU
+LB
+Tk
+VL
+HU
+oA
+mh
+mh
+kv
+CW
+EZ
 Xv
 Xv
 ZU
@@ -28348,34 +28862,34 @@ aX
 aX
 aX
 Xv
+fA
 Xv
+dp
+dp
+dp
+dp
+dp
 Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
+Tc
+Tc
+HS
+Tc
+Tc
+Tc
+Tc
+Qr
+CW
+CW
+CW
+CW
+CW
+CW
+oA
+JR
+cv
+CW
+CW
+Sp
 Xv
 Xv
 ZU
@@ -28550,34 +29064,34 @@ aX
 aX
 aX
 Xv
+fA
 Xv
 Xv
+dp
+dp
+dp
+dp
 Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
+Tc
+Tc
+jS
+Tc
+Tc
+Tc
+Tc
+ZE
+CW
+CW
+CW
+CW
+pc
+CW
+xk
+CW
+CW
+CW
+CW
+Sp
 Xv
 Xv
 ZU
@@ -28752,34 +29266,34 @@ Vm
 aX
 aX
 Xv
+fA
 Xv
 Xv
+dp
 Xv
+dp
+dp
 Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
+Tc
+Tc
+js
+Tc
+fh
+nB
+Yw
+oA
+rv
+dm
+rv
+CW
+CW
+CW
+oA
+UH
+CW
+CW
+Ed
+EZ
 Xv
 Xv
 Xv
@@ -28954,34 +29468,34 @@ aX
 aX
 aX
 Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
+VK
+Tc
+Tc
+Tc
+Tc
+Tc
+Tc
+Tc
+Tc
+Tc
+EZ
+EZ
+EZ
+EZ
+EZ
+EZ
+EZ
+EZ
+EZ
+EZ
+XJ
+EZ
+EZ
+EZ
+EZ
+XJ
+EZ
+EZ
 Xv
 Xv
 Xv
@@ -29156,34 +29670,34 @@ aX
 aX
 aX
 Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
+QP
+Tc
+Tc
+Tc
+Tc
+Tc
+Tc
+Tc
+Tc
+Tc
+oA
+fe
+Ib
+qt
+oA
+Kv
+Ib
+VQ
+oA
+Hv
+CW
+DQ
+oA
+Vd
+CW
+CW
+Ec
+EZ
 Xv
 Xv
 Xv
@@ -29358,6 +29872,7 @@ Vm
 aX
 aX
 Xv
+fA
 Xv
 Xv
 Xv
@@ -29365,27 +29880,26 @@ Xv
 Xv
 Xv
 Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
+Tc
+Tc
+Eq
+CW
+pc
+CW
+CW
+CW
+CW
+CW
+kq
+CW
+JG
+GA
+oA
+HA
+CW
+CW
+CW
+Sp
 Xv
 Xv
 Xv
@@ -29560,34 +30074,34 @@ aX
 aX
 aX
 Xv
+fA
 Xv
 Xv
 Xv
 Xv
+dp
+dp
 Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
+Tc
+Tc
+Eq
+CW
+CW
+CW
+CW
+CW
+CW
+CW
+Aq
+sK
+CW
+IN
+oA
+WI
+CW
+pc
+CW
+Sp
 Xv
 Xv
 Xv
@@ -29762,34 +30276,34 @@ aX
 aX
 aX
 Xv
+fA
 Xv
 Xv
+dp
+dp
+dp
+dp
 Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
+Tc
+Tc
+Sp
+CW
+CW
+Qe
+CW
+Qe
+pc
+CW
+Aq
+zN
+CW
+Di
+oA
+Xl
+CW
+CW
+By
+Sp
 Xv
 Xv
 Xv
@@ -29964,34 +30478,34 @@ Vm
 aX
 aX
 Xv
+fA
 Xv
+dp
+dp
+dp
+dp
+dp
 Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
+Tc
+Tc
+oA
+LB
+Yn
+oA
+qj
+EZ
+vJ
+DL
+Yp
+Ed
+gL
+YP
+oA
+Zs
+CW
+CW
+Mz
+EZ
 Xv
 Xv
 ZU
@@ -30166,34 +30680,34 @@ aX
 aX
 aX
 Xv
+Oy
+Xv
+dp
+dp
+dp
+dp
 Xv
 Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
+Tc
+Tc
+EZ
+Sp
+Sp
+EZ
+rI
+EZ
+Sp
+Sp
+EZ
+EZ
+EZ
+EZ
+EZ
+EZ
+EZ
+Li
+EZ
+EZ
 Xv
 Xv
 ZU
@@ -30368,34 +30882,34 @@ aX
 aX
 aX
 Xv
+fA
+Xv
+Xv
+dp
+dp
 Xv
 Xv
 Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
+Tc
+Tc
+Tc
+Tc
+Tc
+Tc
+Tc
+aX
+aX
+aX
+Ow
+cz
+cz
+cz
+Wx
+cz
+cz
+cz
+Vy
+EZ
 Xv
 Xv
 ZU
@@ -30570,6 +31084,7 @@ Vm
 aX
 aX
 Xv
+fA
 Xv
 Xv
 Xv
@@ -30577,27 +31092,26 @@ Xv
 Xv
 Xv
 Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
+dp
+dp
+dp
+dp
+dp
+dp
+Tc
+aX
+aX
+aX
+Pq
+Kc
+Kc
+Kc
+Kc
+cz
+cz
+cz
+yW
+Sp
 Xv
 Xv
 ZU
@@ -30772,34 +31286,34 @@ aX
 aX
 aX
 Xv
+fA
+dp
 Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
+Tc
+Tc
+Tc
+Tc
+dp
+dp
+dp
+dp
+Tc
+Tc
+Tc
+Tc
+aX
+aX
+aX
+Pq
+Kc
+Kc
+Kc
+Kc
+cz
+cz
+cz
+xH
+Sp
 Xv
 ZU
 ZU
@@ -30968,40 +31482,40 @@ Xv
 Xv
 Xv
 Xv
-Xv
 aX
 aX
 aX
 aX
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
+aX
+aX
+aX
+dp
+aX
+aX
+aX
+aX
+aX
+aX
+dp
+aX
+aX
+aX
+aX
+aX
+aX
+aX
+aX
+aX
+Ga
+cz
+cz
+cz
+cz
+cz
+cz
+cz
+Vy
+EZ
 Xv
 ZU
 ZU
@@ -31170,40 +31684,40 @@ Xv
 Xv
 Xv
 Xv
-Xv
-Xv
+aX
+aX
 Vm
 aX
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
+aX
+aX
+aX
+aX
+aX
+aX
+aX
+aX
+aX
+dp
+dp
+dp
+aX
+aX
+aX
+aX
+aX
+aX
+aX
+aX
+EZ
+oA
+eB
+Ox
+oA
+ES
+cz
+zm
+EZ
+EZ
 Xv
 Xv
 ZU
@@ -31372,40 +31886,40 @@ Xv
 Xv
 Xv
 Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
+aX
+aX
+aX
+aX
+aX
+aX
+aX
+aX
+aX
+aX
+aX
+aX
+dp
+dp
+dp
+dp
+aX
+dp
+dp
+aX
+aX
+aX
+aX
+aX
+Ow
+Dy
+cz
+cz
+cz
+cz
+cz
+cz
+Vy
+EZ
 Xv
 Xv
 ZU
@@ -31574,40 +32088,40 @@ Xv
 Xv
 Xv
 Xv
+aX
+aX
+aX
+aX
+aX
 Xv
+fA
+Tc
+Tc
+Tc
+Tc
+dp
+dp
+dp
+dp
+dp
 Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
+dp
+dp
+Tc
+Tc
+aX
+aX
+aX
+Pq
+Kc
+Kc
+Kc
+Kc
+cz
+cz
+cz
+ZX
+Sp
 Xv
 Xv
 ZU
@@ -31776,40 +32290,40 @@ Xv
 Xv
 Xv
 Xv
-Xv
-Xv
-Xv
-Xv
+aX
+aX
+Vm
+aX
 aX
 Xv
+fA
 Xv
 Xv
 Xv
 Xv
 Xv
+dp
+dp
+dp
 Xv
 Xv
 Xv
 Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
+dp
+Tc
+aX
+aX
+aX
+Pq
+Kc
+Kc
+Kc
+Kc
+cz
+Ae
+cz
+ZX
+Sp
 Xv
 Xv
 Xv
@@ -31978,11 +32492,13 @@ Xv
 Xv
 Xv
 Xv
-aX
 Xv
 aX
 aX
 aX
+aX
+Xv
+fA
 Xv
 Xv
 Xv
@@ -31992,26 +32508,24 @@ Xv
 Xv
 Xv
 Xv
+mz
 Xv
 Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
+dp
+Tc
+aX
+aX
+aX
+Ga
+cz
+Om
+Om
+WT
+cz
+cz
+cz
+VV
+EZ
 Xv
 Xv
 Xv
@@ -32180,11 +32694,16 @@ Xv
 Xv
 Xv
 Xv
+Xv
+Xv
 aX
 aX
-aX
-aX
-aX
+Xv
+Xv
+Oy
+Xv
+Xv
+mz
 Xv
 Xv
 Xv
@@ -32192,28 +32711,23 @@ Xv
 Xv
 Xv
 Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
+dp
+dp
+dp
+Tc
+Tc
+Tc
+Tc
+EZ
+EZ
+Sp
+Sp
+EZ
+EZ
+TZ
+EZ
+EZ
+EZ
 Xv
 Xv
 Xv
@@ -32382,11 +32896,13 @@ Xv
 Xv
 Xv
 Xv
-aX
-aX
-Vm
-aX
-aX
+Xv
+Xv
+Xv
+Xv
+Xv
+Xv
+fA
 Xv
 Xv
 Xv
@@ -32397,6 +32913,10 @@ Xv
 Xv
 Xv
 Xv
+dp
+dp
+dp
+dp
 Xv
 Xv
 Xv
@@ -32405,15 +32925,9 @@ Xv
 Xv
 Xv
 Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
+dp
+dp
+dp
 Xv
 Xv
 Xv
@@ -32584,11 +33098,28 @@ Xv
 Xv
 Xv
 Xv
-aX
-aX
-aX
-aX
-aX
+Xv
+Xv
+Xv
+Xv
+Xv
+Xv
+fA
+Xv
+Xv
+Xv
+Xv
+Xv
+dp
+dp
+dp
+dp
+dp
+dp
+dp
+dp
+dp
+dp
 Xv
 Xv
 Xv
@@ -32596,29 +33127,12 @@ Xv
 Xv
 Xv
 Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
+dp
+dp
+dp
+dp
+dp
+dp
 Xv
 ZU
 ZU
@@ -32786,41 +33300,41 @@ Xv
 Xv
 Xv
 Xv
+Xv
+Xv
+Xv
+Xv
 aX
-aX
-aX
-aX
-aX
+Xv
+fA
 Xv
 Xv
 Xv
 Xv
+mz
+dp
+dp
+dp
+dp
+dp
+dp
+dp
+dp
+dp
+JX
+dp
+dp
+dp
+dp
 Xv
 Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
+mz
+dp
+dp
+dp
+dp
+dp
+dp
 Xv
 ZU
 ZU
@@ -32989,40 +33503,40 @@ Xv
 Xv
 Xv
 aX
+Xv
 aX
-Vm
 aX
 aX
 Xv
+fA
 Xv
 Xv
 Xv
 Xv
 Xv
+dp
+dp
+dp
+dp
+dp
+dp
+Xv
+dp
+dp
+dp
+dp
+dp
+dp
+dp
 Xv
 Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
+dp
+dp
+dp
+dp
+dp
+JX
+dp
 Xv
 ZU
 ZU
@@ -33196,35 +33710,35 @@ aX
 aX
 aX
 Xv
+fA
 Xv
 Xv
 Xv
+dp
+dp
+dp
+pH
+dp
+zx
+dp
 Xv
 Xv
 Xv
+dp
+dp
+dp
+dp
+zx
+dp
+dp
+Xv
+dp
+dp
+dp
 Xv
 Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
+dp
+dp
 Xv
 ZU
 ZU
@@ -33398,30 +33912,30 @@ aX
 aX
 aX
 Xv
+fA
 Xv
 Xv
 Xv
+dp
+dp
+dp
+dp
+dp
+dp
+dp
 Xv
 Xv
 Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
+dp
+dp
+dp
+dp
+dp
+dp
+dp
+dp
+dp
+dp
 Xv
 Xv
 Xv
@@ -33600,34 +34114,34 @@ Vm
 aX
 aX
 Xv
+fA
 Xv
 Xv
 Xv
+dp
+dp
+dp
+dp
+dp
+dp
+dp
+dp
+dp
+Xv
+dp
+dp
+dp
+dp
+dp
+dp
+dp
+dp
+dp
+dp
 Xv
 Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
+dp
+dp
 Xv
 Xv
 ZU
@@ -33806,30 +34320,30 @@ fA
 Xv
 Xv
 Xv
+dp
+dp
 Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
+dp
+dp
+dp
+dp
+dp
+dp
+dp
+dp
+dp
+dp
+dp
+Co
+dp
+dp
+dp
+dp
+dp
+dp
+dp
+dp
+dp
 Xv
 Xv
 Xv
@@ -34004,34 +34518,34 @@ aX
 aX
 aX
 Xv
+Oy
+Xv
+Xv
+mz
+dp
 Xv
 Xv
 Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
+dp
+JX
+dp
+dp
+dp
+JX
+dp
+dp
+dp
+dp
+dp
+dp
+dp
+dp
+dp
+dp
+dp
+dp
+dp
+dp
 Xv
 Xv
 Xv
@@ -34206,36 +34720,36 @@ Vm
 aX
 aX
 Xv
+fA
 Xv
 Xv
 Xv
+dp
 Xv
+WO
+dp
+dp
+dp
+dp
+dp
+dp
+dp
+dp
+dp
+dp
+QM
+dp
+dp
+dp
+cF
+PS
+dp
+dp
+dp
+ik
+cF
 Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
+dp
 Xv
 ZU
 "}
@@ -34408,36 +34922,36 @@ aX
 aX
 aX
 Xv
+fA
 Xv
 Xv
 Xv
+dp
+dp
 Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
+dp
+dp
+dp
+dp
+dp
+dp
+dp
+dp
+dp
+dp
+dp
+dp
+dp
+cF
+cF
+cF
+OU
+pl
+OU
+cF
+cF
+cF
+dp
 Xv
 ZU
 "}
@@ -34610,36 +35124,36 @@ aX
 aX
 aX
 Xv
+fA
 Xv
 Xv
 Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
+dp
+dp
+dp
+dp
+dp
+dp
+dp
+dp
+dp
+CG
+dp
+dp
+dp
+dp
+dp
+zx
+dp
+cF
+CW
+CW
+mC
+CW
+CW
+cF
+Ji
+dp
 Xv
 ZU
 "}
@@ -34812,36 +35326,36 @@ Vm
 aX
 aX
 Xv
+fA
 Xv
 Xv
 Xv
+dp
+dp
+JX
+dp
+dp
+dp
+dp
+dp
+dp
 Xv
+dp
 Xv
+dp
+dp
+dp
+dp
 Xv
+cF
+CW
+CW
+mC
+CW
+CW
+cF
 Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
+dp
 Xv
 ZU
 "}
@@ -35014,6 +35528,16 @@ aX
 aX
 aX
 Xv
+fA
+Xv
+Xv
+Xv
+Xv
+dp
+dp
+dp
+dp
+dp
 Xv
 Xv
 Xv
@@ -35021,29 +35545,19 @@ Xv
 Xv
 Xv
 Xv
+dp
+dp
+dp
+dp
+cF
+CW
+CW
+xC
+CW
+CW
+cF
 Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
+dp
 Xv
 ZU
 "}
@@ -35216,36 +35730,36 @@ aX
 aX
 aX
 Xv
+fA
+Xv
+Xv
+Xv
+Xv
+dp
+dp
+dp
+dp
+Xv
+Hn
 Xv
 Xv
 Xv
 Xv
 Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
+dp
+dp
+dp
+dp
+cF
+cF
+cF
+Yq
+mC
+vL
+cF
+cF
+cF
+dp
 Xv
 ZU
 "}
@@ -35418,36 +35932,36 @@ Vm
 aX
 aX
 Xv
+fA
 Xv
 Xv
 Xv
 Xv
+dp
+dp
+dp
+dp
 Xv
 Xv
 Xv
+dp
 Xv
 Xv
 Xv
+dp
+dp
+dp
+dp
+Hn
+cF
+CW
+CW
+mC
+CW
+CW
+cF
 Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
+dp
 ZU
 ZU
 "}
@@ -35620,36 +36134,36 @@ aX
 aX
 aX
 Xv
+fA
 Xv
 Xv
 Xv
 Xv
+dp
+dp
+dp
+dp
+dp
 Xv
+dp
+dp
+JX
+dp
+dp
+dp
+zx
+dp
+dp
 Xv
+cF
+CW
+CW
+mC
+CW
+CW
+cF
 Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
+dp
 ZU
 ZU
 "}
@@ -35822,36 +36336,36 @@ aX
 aX
 aX
 Xv
+fA
+Xv
+Xv
+Xv
+Hn
+dp
+dp
+zx
+dp
+dp
+dp
+dp
+dp
+dp
+dp
+dp
+dp
 Xv
 Xv
 Xv
 Xv
+cF
+CW
+CW
+mC
+CW
+CW
+cF
 Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
+dp
 ZU
 ZU
 "}
@@ -36024,36 +36538,36 @@ Vm
 aX
 aX
 Xv
+EZ
+EZ
+Sp
+Sp
+EZ
+EZ
+Xv
+dp
+dp
+dp
+dp
+dp
+dp
+dp
+dp
+dp
+dp
 Xv
 Xv
 Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
+cF
+cF
+cF
+OU
+Gm
+OU
+cF
+cF
+cF
+dp
 ZU
 ZU
 "}
@@ -36226,36 +36740,36 @@ aX
 aX
 aX
 Xv
+EZ
+In
+HU
+SW
+rR
+EZ
+Xv
+dp
+dp
+dp
+zx
+dp
+dp
+dp
+dp
+dp
+dp
+aw
 Xv
 Xv
 Xv
+cF
+dp
+dp
+dp
+dp
+Yd
+cF
 Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
+dp
 ZU
 ZU
 "}
@@ -36428,35 +36942,35 @@ aX
 aX
 aX
 Xv
+EZ
+PL
+CW
+pc
+CW
+FH
+Xv
+Xv
+Xv
+dp
+dp
+dp
+dp
+dp
+QM
+dp
+dp
 Xv
 Xv
 Xv
 Xv
 Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
+dp
+dp
+dp
+dp
+dp
+dp
+dp
 Xv
 ZU
 ZU
@@ -36630,6 +37144,17 @@ Vm
 aX
 aX
 Xv
+EZ
+EP
+CW
+CW
+CW
+CL
+Xv
+Xv
+Xv
+dp
+dp
 Xv
 Xv
 Xv
@@ -36639,26 +37164,15 @@ Xv
 Xv
 Xv
 Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
+dp
+dp
+dp
+dp
+dp
+dp
+dp
+dp
+dp
 Xv
 ZU
 ZU
@@ -36832,6 +37346,12 @@ aX
 aX
 aX
 Xv
+EZ
+Kq
+Bs
+CW
+XT
+EZ
 Xv
 Xv
 Xv
@@ -36841,24 +37361,18 @@ Xv
 Xv
 Xv
 Xv
+NB
 Xv
 Xv
 Xv
 Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
+dp
+dp
+dp
+dp
+dp
+zx
+dp
 Xv
 Xv
 Xv
@@ -37034,6 +37548,17 @@ aX
 aX
 aX
 Xv
+EZ
+EZ
+EZ
+KQ
+EZ
+EZ
+EZ
+zX
+zX
+EZ
+EZ
 Xv
 Xv
 Xv
@@ -37043,24 +37568,13 @@ Xv
 Xv
 Xv
 Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
+NB
+dp
+dp
+dp
+dp
+dp
+dp
 Xv
 Xv
 ZU
@@ -37236,6 +37750,17 @@ Vm
 aX
 aX
 Xv
+EZ
+la
+cP
+CW
+fx
+EZ
+Oi
+CW
+CW
+fx
+EZ
 Xv
 Xv
 Xv
@@ -37246,22 +37771,11 @@ Xv
 Xv
 Xv
 Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
+dp
+dp
+dp
+dp
+dp
 Xv
 Xv
 Xv
@@ -37437,6 +37951,18 @@ aX
 aX
 aX
 aX
+xT
+EZ
+wo
+FP
+CW
+CW
+EZ
+PL
+CW
+CW
+CW
+EZ
 Xv
 Xv
 Xv
@@ -37448,22 +37974,10 @@ Xv
 Xv
 Xv
 Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
+dp
+dp
+dp
+dp
 Xv
 Xv
 ZU
@@ -37640,6 +38154,20 @@ aX
 aX
 aX
 Xv
+EZ
+CW
+Sv
+CW
+CW
+EZ
+Vt
+Vt
+CW
+IN
+EZ
+Xv
+Xv
+JE
 Xv
 Xv
 Xv
@@ -37649,23 +38177,9 @@ Xv
 Xv
 Xv
 Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
+dp
+dp
+dp
 Xv
 ZU
 ZU
@@ -37842,17 +38356,17 @@ Vm
 aX
 aX
 Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
+EZ
+Jx
+bu
+CW
+YP
+EZ
+Kc
+Kc
+CW
+CW
+EZ
 Xv
 Xv
 Xv
@@ -38044,37 +38558,37 @@ aX
 aX
 aX
 Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-Xv
-ZU
-ZU
+EZ
+EZ
+EZ
+EZ
+EZ
+EZ
+EZ
+EZ
+EZ
+EZ
+EZ
+eN
+eN
+eN
+eN
+eN
+eN
+eN
+eN
+eN
+Oy
+eN
+eN
+eN
+eN
+eN
+eN
+eN
+eN
+eN
+XR
 ZU
 "}
 (154,1,1) = {"
@@ -38248,7 +38762,7 @@ aX
 Xv
 Xv
 Xv
-Xv
+xT
 Xv
 Xv
 Xv

--- a/_maps/map_files/Drought/Drought.dmm
+++ b/_maps/map_files/Drought/Drought.dmm
@@ -1962,7 +1962,6 @@
 /obj/structure/closet/crate/ms13/cash_register{
 	pixel_y = 8
 	},
-/obj/effect/spawner/random/ms13/currency/mammoth/prewar/lowrandom,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "kr" = (
@@ -5563,8 +5562,6 @@
 /area/ms13/desert)
 "Hv" = (
 /obj/structure/safe/ms13/wall,
-/obj/effect/spawner/random/ms13/currency/mammoth/prewar/lowrandom,
-/obj/effect/spawner/random/ms13/currency/mammoth/prewar/lowrandom,
 /obj/effect/spawner/random/ms13/gun/lowrandom,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
@@ -5726,10 +5723,8 @@
 /turf/open/floor/ms13/tile/large/white,
 /area/ms13/town)
 "IU" = (
-/obj/structure/ms13/vehicle_ruin{
-	dir = 1
-	},
-/turf/open/floor/plating/ms13/ground/road,
+/mob/living/simple_animal/hostile/ms13/radscorpion/desert,
+/turf/open/floor/plating/ms13/ground/desertalt,
 /area/ms13/desert)
 "IW" = (
 /turf/open/floor/ms13/tile/large/cafeteria,
@@ -6520,11 +6515,12 @@
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/factory)
 "Pc" = (
-/obj/structure/ms13/vehicle_ruin{
-	dir = 4
+/obj/structure/ms13/storage/shelf{
+	dir = 8
 	},
-/turf/open/floor/plating/ms13/ground/road,
-/area/ms13/desert)
+/obj/effect/spawner/random/ms13/crafting/highrandom,
+/turf/open/floor/ms13/concrete/industrial,
+/area/ms13/town)
 "Pd" = (
 /obj/structure/table/ms13/low_wall/brick,
 /obj/structure/ms13/barricade{
@@ -6696,10 +6692,6 @@
 /obj/structure/ms13/barricade,
 /turf/open/floor/ms13/tile/large/black,
 /area/ms13/town)
-"QM" = (
-/mob/living/simple_animal/hostile/ms13/radscorpion/desert,
-/turf/open/floor/plating/ms13/ground/desertalt,
-/area/ms13/desert)
 "QO" = (
 /mob/living/simple_animal/hostile/ms13/robot/protectron,
 /turf/open/floor/ms13/concrete/industrial,
@@ -7490,11 +7482,6 @@
 	dir = 4
 	},
 /turf/open/floor/ms13/concrete/industrial,
-/area/ms13/town)
-"Yp" = (
-/obj/effect/turf_decal/ms13/covering/paint/white,
-/obj/effect/spawner/random/ms13/crafting/highrandom,
-/turf/closed/wall/ms13/brick/alt,
 /area/ms13/town)
 "Yq" = (
 /obj/machinery/button/ms13{
@@ -24804,7 +24791,7 @@ Tc
 Tc
 Tc
 Tc
-Pc
+HD
 aX
 aX
 aX
@@ -30281,7 +30268,7 @@ Xv
 Xv
 dp
 dp
-dp
+IU
 dp
 Xv
 Tc
@@ -30292,7 +30279,7 @@ CW
 Qe
 CW
 Qe
-pc
+CW
 CW
 Aq
 zN
@@ -30496,8 +30483,8 @@ qj
 EZ
 vJ
 DL
-Yp
-Ed
+oA
+Pc
 gL
 YP
 oA
@@ -34332,7 +34319,7 @@ dp
 dp
 dp
 dp
-dp
+IU
 dp
 Co
 dp
@@ -34726,7 +34713,7 @@ Xv
 Xv
 dp
 Xv
-WO
+Xv
 dp
 dp
 dp
@@ -34737,7 +34724,7 @@ dp
 dp
 dp
 dp
-QM
+dp
 dp
 dp
 dp
@@ -36956,7 +36943,7 @@ dp
 dp
 dp
 dp
-QM
+dp
 dp
 dp
 Xv
@@ -37570,7 +37557,7 @@ Xv
 Xv
 NB
 dp
-dp
+IU
 dp
 dp
 dp
@@ -43556,7 +43543,7 @@ aX
 Vm
 aX
 Vm
-IU
+HD
 Vm
 aX
 GL

--- a/_maps/map_files/Drought/Drought.dmm
+++ b/_maps/map_files/Drought/Drought.dmm
@@ -6692,6 +6692,13 @@
 /obj/structure/ms13/barricade,
 /turf/open/floor/ms13/tile/large/black,
 /area/ms13/town)
+"QM" = (
+/obj/structure/ms13/storage/large/shelf{
+	dir = 8
+	},
+/obj/effect/spawner/random/ms13/tools/tool,
+/turf/open/floor/ms13/concrete/industrial,
+/area/ms13/town)
 "QO" = (
 /mob/living/simple_animal/hostile/ms13/robot/protectron,
 /turf/open/floor/ms13/concrete/industrial,
@@ -28667,8 +28674,8 @@ Um
 HU
 LB
 Tk
-VL
-HU
+CW
+QM
 oA
 mh
 mh

--- a/_maps/map_files/Drought/Drought_above.dmm
+++ b/_maps/map_files/Drought/Drought_above.dmm
@@ -260,7 +260,7 @@
 "cL" = (
 /obj/structure/lattice/catwalk/ms13,
 /obj/machinery/light/ms13/bulb/industrial,
-/turf/open/space/basic,
+/turf/open/floor/ms13/concrete,
 /area/ms13/town)
 "cO" = (
 /obj/machinery/light/ms13{
@@ -593,7 +593,7 @@
 /obj/machinery/light/ms13/bulb/industrial{
 	dir = 1
 	},
-/turf/open/space/basic,
+/turf/open/floor/ms13/concrete,
 /area/ms13/town)
 "gX" = (
 /obj/structure/railing/ms13/solo{
@@ -783,7 +783,7 @@
 /area/ms13/underground/mountain)
 "iS" = (
 /obj/structure/lattice/catwalk/ms13,
-/turf/open/space/basic,
+/turf/open/openspace/ms13,
 /area/ms13/town)
 "iT" = (
 /obj/structure/table/ms13/metal,
@@ -1132,7 +1132,7 @@
 "mE" = (
 /obj/structure/lattice/catwalk/ms13,
 /obj/structure/railing/ms13/solo/industrial,
-/turf/open/space/basic,
+/turf/open/openspace/ms13,
 /area/ms13/town)
 "mH" = (
 /obj/machinery/light/ms13/bulb{
@@ -1227,8 +1227,11 @@
 /turf/open/floor/wood/ms13/carpet,
 /area/ms13/town)
 "nu" = (
-/obj/effect/spawner/random/ms13/tools/tool,
+/obj/structure/ms13/storage/shelf{
+	dir = 4
+	},
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
+/obj/effect/spawner/random/ms13/tools/tool,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "nB" = (
@@ -2169,7 +2172,7 @@
 "yy" = (
 /obj/structure/lattice/catwalk/ms13,
 /obj/structure/railing/ms13/solo/industrial,
-/turf/open/openspace/ms13,
+/turf/open/floor/ms13/concrete,
 /area/ms13/town)
 "yz" = (
 /obj/structure/railing/ms13/solo{
@@ -2681,7 +2684,7 @@
 /obj/machinery/light/ms13/bulb/industrial{
 	dir = 1
 	},
-/turf/open/space/basic,
+/turf/open/floor/ms13/concrete,
 /area/ms13/town)
 "EU" = (
 /obj/structure/table/ms13/no_smooth/large/wood,
@@ -2766,9 +2769,6 @@
 /area/ms13/desert)
 "Ga" = (
 /obj/structure/safe/ms13,
-/obj/effect/spawner/random/ms13/guaranteed/currency/mammoth/prewar/lowrandom,
-/obj/effect/spawner/random/ms13/guaranteed/currency/mammoth/prewar/lowrandom,
-/obj/effect/spawner/random/ms13/currency/mammoth/prewar/highrandom,
 /obj/effect/spawner/random/ms13/locked/guaranteed/random,
 /obj/structure/ms13/storage/vent,
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
@@ -3470,10 +3470,10 @@
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "Oo" = (
-/obj/machinery/vending/ms13/nuka{
+/obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
+/obj/machinery/vending/ms13/sarsaparilla{
 	dir = 8
 	},
-/obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "Oq" = (
@@ -3818,7 +3818,7 @@
 /area/ms13/town)
 "So" = (
 /obj/structure/lattice/catwalk/ms13,
-/turf/open/openspace/ms13,
+/turf/open/floor/ms13/concrete,
 /area/ms13/town)
 "Ss" = (
 /obj/machinery/door/unpowered/ms13/wood,
@@ -25411,8 +25411,8 @@ Ly
 hY
 ac
 IF
+Ug
 nu
-Uk
 hY
 yY
 Ug

--- a/_maps/map_files/Drought/Drought_above.dmm
+++ b/_maps/map_files/Drought/Drought_above.dmm
@@ -2214,10 +2214,6 @@
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
-"zc" = (
-/obj/structure/lattice/catwalk/ms13,
-/turf/closed/wall/ms13/scrap,
-/area/ms13/town)
 "zg" = (
 /obj/structure/table/ms13/no_smooth/counter/metal/bend{
 	dir = 1
@@ -32490,7 +32486,7 @@ ZX
 ZX
 tn
 cL
-zc
+QD
 QD
 Ly
 Ly

--- a/_maps/map_files/Drought/Drought_above.dmm
+++ b/_maps/map_files/Drought/Drought_above.dmm
@@ -1,4 +1,10 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"ac" = (
+/obj/structure/chair/comfy/ms13/ergo,
+/obj/structure/ms13/wall_decor/clock,
+/obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
+/turf/open/floor/ms13/concrete/industrial,
+/area/ms13/town)
 "ad" = (
 /obj/structure/bed/ms13/sleepingbag/green,
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
@@ -11,6 +17,18 @@
 	dir = 8
 	},
 /turf/open/floor/ms13/tile,
+/area/ms13/town)
+"aj" = (
+/obj/structure/table/ms13/metal/grate,
+/obj/machinery/ms13/coffee{
+	pixel_y = 8
+	},
+/obj/item/reagent_containers/food/drinks/mug/ms13{
+	pixel_x = 11;
+	pixel_y = 6
+	},
+/obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
+/turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "al" = (
 /obj/structure/table/ms13/metal,
@@ -48,6 +66,11 @@
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
+"aB" = (
+/obj/structure/fluff/ms13/trash/papers,
+/obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
+/turf/open/floor/ms13/concrete/industrial,
+/area/ms13/town)
 "aC" = (
 /obj/effect/decal/cleanable/glass{
 	dir = 8;
@@ -62,6 +85,10 @@
 	},
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /turf/open/floor/ms13/concrete,
+/area/ms13/town)
+"aK" = (
+/obj/structure/ms13/sandbag,
+/turf/open/floor/plating/ms13/roof,
 /area/ms13/town)
 "aN" = (
 /obj/structure/table/ms13/wood,
@@ -138,6 +165,12 @@
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /turf/open/floor/wood/ms13/common,
 /area/ms13/town)
+"bt" = (
+/obj/structure/chair/ms13/overlaypickup/plastic{
+	dir = 1
+	},
+/turf/open/floor/plating/ms13/roof,
+/area/ms13/town)
 "bz" = (
 /obj/structure/ms13/rug/fancy{
 	dir = 4
@@ -209,6 +242,13 @@
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /turf/open/floor/ms13/tile,
 /area/ms13/town)
+"cq" = (
+/obj/machinery/light/ms13{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
+/turf/open/floor/ms13/concrete/industrial,
+/area/ms13/town)
 "cu" = (
 /obj/structure/table/ms13/metal,
 /obj/machinery/microwave{
@@ -216,6 +256,11 @@
 	},
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /turf/open/floor/ms13/tile,
+/area/ms13/town)
+"cL" = (
+/obj/structure/lattice/catwalk/ms13,
+/obj/machinery/light/ms13/bulb/industrial,
+/turf/open/space/basic,
 /area/ms13/town)
 "cO" = (
 /obj/machinery/light/ms13{
@@ -341,6 +386,13 @@
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /turf/open/floor/wood/ms13/carpet,
 /area/ms13/town)
+"ex" = (
+/obj/structure/ms13/storage/large/shelf{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
+/turf/open/floor/ms13/concrete/industrial,
+/area/ms13/town)
 "eN" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
@@ -377,6 +429,15 @@
 	},
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /turf/open/floor/ms13/tile,
+/area/ms13/town)
+"fp" = (
+/obj/item/ammo_casing/ms13/spent,
+/turf/open/floor/plating/ms13/roof,
+/area/ms13/town)
+"fq" = (
+/obj/structure/ms13/wall_decor/clock,
+/obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
+/turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "fs" = (
 /obj/machinery/door/unpowered/ms13/metal/red{
@@ -420,12 +481,23 @@
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
+"fO" = (
+/obj/structure/railing/ms13/solo/industrial,
+/turf/open/openspace/ms13,
+/area/ms13/desert)
 "fT" = (
 /obj/machinery/light/ms13/bulb/broken{
 	dir = 1
 	},
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /turf/open/floor/wood/ms13/wide,
+/area/ms13/town)
+"fV" = (
+/obj/structure/table/ms13/no_smooth/counter/metal,
+/obj/effect/spawner/random/ms13/ammo/lowrandom,
+/obj/effect/spawner/random/ms13/ammo/lowrandom,
+/obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
+/turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "fX" = (
 /obj/structure/table/ms13/low_wall/brick,
@@ -444,6 +516,11 @@
 	},
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /turf/open/floor/ms13/tile,
+/area/ms13/town)
+"gg" = (
+/mob/living/basic/ms13/hostile_animal/radroach,
+/obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
+/turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "gk" = (
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
@@ -509,6 +586,14 @@
 	},
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /turf/open/floor/wood/ms13/wide,
+/area/ms13/town)
+"gW" = (
+/obj/structure/lattice/catwalk/ms13,
+/obj/structure/railing/ms13/solo/industrial,
+/obj/machinery/light/ms13/bulb/industrial{
+	dir = 1
+	},
+/turf/open/space/basic,
 /area/ms13/town)
 "gX" = (
 /obj/structure/railing/ms13/solo{
@@ -620,6 +705,11 @@
 	},
 /turf/open/floor/plating/ms13/roof,
 /area/ms13/desert)
+"hY" = (
+/obj/effect/turf_decal/ms13/covering/paint/white,
+/obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
+/turf/closed/wall/ms13/brick/alt,
+/area/ms13/town)
 "ic" = (
 /obj/machinery/door/unpowered/ms13/metal/red,
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
@@ -631,6 +721,13 @@
 	},
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /turf/open/floor/wood/ms13/wide,
+/area/ms13/town)
+"ig" = (
+/obj/structure/lattice/catwalk/ms13,
+/obj/structure/railing/ms13/solo/industrial{
+	dir = 8
+	},
+/turf/open/openspace/ms13,
 /area/ms13/town)
 "ih" = (
 /obj/structure/ms13/storage/large/shelf{
@@ -681,6 +778,13 @@
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /turf/open/floor/ms13/tile/blue,
 /area/ms13/town)
+"iQ" = (
+/turf/closed/wall/ms13/brick/alt,
+/area/ms13/underground/mountain)
+"iS" = (
+/obj/structure/lattice/catwalk/ms13,
+/turf/open/space/basic,
+/area/ms13/town)
 "iT" = (
 /obj/structure/table/ms13/metal,
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
@@ -693,6 +797,13 @@
 	},
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /turf/open/floor/ms13/concrete/industrial,
+/area/ms13/town)
+"jb" = (
+/obj/structure/toilet{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
+/turf/open/floor/ms13/tile/large/cream,
 /area/ms13/town)
 "jh" = (
 /obj/structure/railing/ms13/solo,
@@ -969,6 +1080,14 @@
 	},
 /turf/open/floor/wood/ms13/carpet/shaggy,
 /area/ms13/town)
+"mi" = (
+/obj/structure/closet/ms13/fridge,
+/obj/effect/spawner/random/ms13/food/random,
+/obj/effect/spawner/random/ms13/food/random,
+/obj/structure/ms13/storage/vent,
+/obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
+/turf/open/floor/ms13/concrete/industrial,
+/area/ms13/town)
 "mj" = (
 /obj/structure/bed/ms13/sleepingbag/red,
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
@@ -1010,6 +1129,11 @@
 	},
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
+"mE" = (
+/obj/structure/lattice/catwalk/ms13,
+/obj/structure/railing/ms13/solo/industrial,
+/turf/open/space/basic,
+/area/ms13/town)
 "mH" = (
 /obj/machinery/light/ms13/bulb{
 	dir = 1
@@ -1039,6 +1163,13 @@
 /obj/structure/table/ms13/low_wall/brick/alt,
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /turf/open/floor/wood/ms13/common,
+/area/ms13/town)
+"mO" = (
+/obj/structure/fluff/ms13/trash/papers{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
+/turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "mP" = (
 /obj/structure/barricade/sandbags,
@@ -1095,6 +1226,11 @@
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /turf/open/floor/wood/ms13/carpet,
 /area/ms13/town)
+"nu" = (
+/obj/effect/spawner/random/ms13/tools/tool,
+/obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
+/turf/open/floor/ms13/concrete/industrial,
+/area/ms13/town)
 "nB" = (
 /obj/structure/closet/cabinet,
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
@@ -1122,11 +1258,24 @@
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /turf/open/floor/wood/ms13/carpet/blue,
 /area/ms13/town)
+"nY" = (
+/obj/structure/lattice/catwalk/ms13,
+/obj/structure/railing/ms13/solo/industrial{
+	dir = 4
+	},
+/turf/open/openspace/ms13,
+/area/ms13/town)
 "nZ" = (
 /obj/structure/table/ms13/low_wall/brick/alt,
 /obj/structure/window/fulltile/ms13/glass,
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /turf/open/floor/wood/ms13/common,
+/area/ms13/town)
+"oc" = (
+/obj/structure/railing/ms13/solo/industrial{
+	dir = 4
+	},
+/turf/open/openspace/ms13,
 /area/ms13/town)
 "oe" = (
 /obj/structure/table/ms13/no_smooth/counter/metal,
@@ -1280,6 +1429,13 @@
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /turf/open/openspace/ms13,
 /area/ms13/town)
+"pD" = (
+/obj/structure/chair/sofa/corp/left{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
+/turf/open/floor/ms13/concrete/industrial,
+/area/ms13/town)
 "pE" = (
 /obj/machinery/light/ms13/bulb/industrial,
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
@@ -1354,6 +1510,12 @@
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /turf/open/openspace/ms13,
 /area/ms13/town)
+"qr" = (
+/obj/effect/spawner/random/ms13/drink/soda,
+/obj/structure/table/ms13/metal/grate,
+/obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
+/turf/open/floor/ms13/concrete/industrial,
+/area/ms13/town)
 "qs" = (
 /obj/structure/dresser/ms13/torquise,
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
@@ -1383,6 +1545,12 @@
 /obj/machinery/light/ms13,
 /obj/effect/spawner/random/ms13/crafting/lowrandom,
 /obj/effect/spawner/random/ms13/crafting/lowrandom,
+/obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
+/turf/open/floor/ms13/concrete/industrial,
+/area/ms13/town)
+"qJ" = (
+/obj/structure/table/ms13/metal/grate,
+/obj/effect/spawner/random/ms13/gun/tier2,
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
@@ -1438,6 +1606,12 @@
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
+"rr" = (
+/obj/structure/table/ms13/metal/grate,
+/obj/machinery/light/ms13,
+/obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
+/turf/open/floor/ms13/concrete/industrial,
+/area/ms13/town)
 "rt" = (
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/ms13/concrete/industrial,
@@ -1448,6 +1622,12 @@
 	},
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /turf/open/floor/ms13/tile,
+/area/ms13/town)
+"ry" = (
+/obj/structure/chair/ms13/overlaypickup/plastic{
+	dir = 4
+	},
+/turf/open/floor/plating/ms13/roof,
 /area/ms13/town)
 "rG" = (
 /obj/structure/bed/ms13/bedframe/metal,
@@ -1491,6 +1671,13 @@
 /obj/effect/spawner/random/ms13/tools/tool,
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /turf/open/floor/ms13/concrete/industrial,
+/area/ms13/town)
+"rY" = (
+/obj/structure/railing/ms13/solo/industrial,
+/obj/structure/railing/ms13/solo/industrial{
+	dir = 8
+	},
+/turf/open/openspace/ms13,
 /area/ms13/town)
 "se" = (
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
@@ -1583,6 +1770,10 @@
 /obj/structure/table/ms13/crafting/tinkerbench,
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /turf/open/floor/ms13/concrete/industrial,
+/area/ms13/town)
+"tn" = (
+/obj/structure/railing/ms13/solo/industrial,
+/turf/open/openspace/ms13,
 /area/ms13/town)
 "tv" = (
 /obj/structure/table/ms13/metal,
@@ -1781,6 +1972,13 @@
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /turf/open/floor/wood/ms13/carpet/blue,
 /area/ms13/town)
+"vH" = (
+/obj/structure/chair/ms13/metal{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
+/turf/open/floor/ms13/concrete/industrial,
+/area/ms13/town)
 "vI" = (
 /obj/structure/lattice/catwalk/ms13,
 /obj/structure/railing/ms13/solo,
@@ -1907,6 +2105,13 @@
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
+"xB" = (
+/obj/structure/railing/ms13/solo/industrial{
+	dir = 4
+	},
+/obj/structure/railing/ms13/solo/industrial,
+/turf/open/openspace/ms13,
+/area/ms13/town)
 "xC" = (
 /obj/structure/table/ms13/metal/grate,
 /obj/effect/spawner/random/ms13/crafting/electrical,
@@ -1917,6 +2122,22 @@
 /obj/machinery/light/ms13/bulb,
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /turf/open/floor/wood/ms13/mosaic,
+/area/ms13/town)
+"xO" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = 13
+	},
+/obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
+/turf/open/floor/ms13/tile/large/cream,
+/area/ms13/town)
+"xU" = (
+/obj/structure/ladder/ms13,
+/obj/structure/lattice/catwalk/ms13,
+/obj/structure/railing/ms13/solo/industrial{
+	dir = 8
+	},
+/turf/open/openspace/ms13,
 /area/ms13/town)
 "xW" = (
 /obj/structure/ms13/storage/bookshelf,
@@ -1944,6 +2165,11 @@
 /obj/structure/table/ms13/low_wall/brick/alt,
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /turf/open/floor/ms13/concrete/industrial,
+/area/ms13/town)
+"yy" = (
+/obj/structure/lattice/catwalk/ms13,
+/obj/structure/railing/ms13/solo/industrial,
+/turf/open/openspace/ms13,
 /area/ms13/town)
 "yz" = (
 /obj/structure/railing/ms13/solo{
@@ -1980,12 +2206,28 @@
 	},
 /turf/open/floor/ms13/concrete,
 /area/ms13/desert)
+"yY" = (
+/obj/structure/noticeboard/ms13/cork,
+/obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
+/turf/open/floor/ms13/concrete/industrial,
+/area/ms13/town)
+"zc" = (
+/obj/structure/lattice/catwalk/ms13,
+/turf/closed/wall/ms13/scrap,
+/area/ms13/town)
 "zg" = (
 /obj/structure/table/ms13/no_smooth/counter/metal/bend{
 	dir = 1
 	},
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /turf/open/floor/ms13/tile,
+/area/ms13/town)
+"zj" = (
+/obj/structure/fluff/ms13/trash/papers{
+	dir = 5
+	},
+/obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
+/turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "zl" = (
 /obj/structure/table/ms13/metal,
@@ -2315,6 +2557,12 @@
 	},
 /turf/open/floor/wood/ms13/common,
 /area/ms13/town)
+"Dr" = (
+/obj/structure/ms13/storage/trashcan,
+/obj/structure/ms13/storage/vent,
+/obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
+/turf/open/floor/ms13/concrete/industrial,
+/area/ms13/town)
 "Dy" = (
 /obj/machinery/light/ms13/bulb{
 	dir = 4
@@ -2428,6 +2676,13 @@
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
+"Ey" = (
+/obj/structure/lattice/catwalk/ms13,
+/obj/machinery/light/ms13/bulb/industrial{
+	dir = 1
+	},
+/turf/open/space/basic,
+/area/ms13/town)
 "EU" = (
 /obj/structure/table/ms13/no_smooth/large/wood,
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
@@ -2509,12 +2764,28 @@
 /obj/structure/chair/ms13/metal/folding,
 /turf/open/floor/ms13/ceramic,
 /area/ms13/desert)
+"Ga" = (
+/obj/structure/safe/ms13,
+/obj/effect/spawner/random/ms13/guaranteed/currency/mammoth/prewar/lowrandom,
+/obj/effect/spawner/random/ms13/guaranteed/currency/mammoth/prewar/lowrandom,
+/obj/effect/spawner/random/ms13/currency/mammoth/prewar/highrandom,
+/obj/effect/spawner/random/ms13/locked/guaranteed/random,
+/obj/structure/ms13/storage/vent,
+/obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
+/turf/open/floor/ms13/concrete/industrial,
+/area/ms13/town)
 "Gd" = (
 /obj/machinery/door/unpowered/ms13/wood{
 	dir = 8
 	},
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /turf/open/floor/wood/ms13/mosaic,
+/area/ms13/town)
+"Gh" = (
+/obj/structure/ms13/skeleton,
+/obj/effect/spawner/random/ms13/melee/tier2,
+/obj/effect/spawner/random/ms13/drugs/prewar,
+/turf/open/floor/plating/ms13/roof,
 /area/ms13/town)
 "Gt" = (
 /obj/effect/decal/cleanable/glass,
@@ -2612,6 +2883,14 @@
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
+"Hv" = (
+/obj/structure/ladder/ms13,
+/obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
+/turf/open/floor/ms13/concrete/industrial,
+/area/ms13/town)
+"HC" = (
+/turf/open/floor/plating/ms13/roof,
+/area/ms13/town)
 "HG" = (
 /obj/structure/table/ms13/metal/grate,
 /obj/effect/spawner/random/ms13/tools/hardware,
@@ -2701,6 +2980,26 @@
 /obj/structure/ms13/bars/rusty,
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /turf/open/floor/plating/ms13/ground/sidewalk,
+/area/ms13/town)
+"Iz" = (
+/obj/structure/chair/sofa/corp/left{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
+/turf/open/floor/ms13/concrete/industrial,
+/area/ms13/town)
+"IF" = (
+/obj/structure/table/ms13/no_smooth/large/metal/desk{
+	dir = 1
+	},
+/obj/machinery/ms13/terminal{
+	dir = 1;
+	remote_capability = 1;
+	signal_id_1 = "car_junk_storage";
+	signal_title_1 = "Storage Shutters"
+	},
+/obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
+/turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "IJ" = (
 /obj/structure/lattice/catwalk/ms13,
@@ -2793,6 +3092,13 @@
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
+"JG" = (
+/obj/structure/chair/sofa/corp/right{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
+/turf/open/floor/ms13/concrete/industrial,
+/area/ms13/town)
 "JO" = (
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /obj/structure/closet/crate/ms13/footlocker,
@@ -2825,6 +3131,13 @@
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /turf/open/floor/wood/ms13/carpet/shaggy/green,
 /area/ms13/town)
+"Kq" = (
+/obj/structure/ms13/lamp{
+	pixel_y = 12
+	},
+/obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
+/turf/open/floor/ms13/concrete/industrial,
+/area/ms13/town)
 "Kw" = (
 /obj/structure/chair/ms13/metal{
 	dir = 4
@@ -2843,6 +3156,13 @@
 /obj/structure/table/ms13/metal,
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /turf/open/floor/ms13/tile,
+/area/ms13/town)
+"KD" = (
+/obj/structure/filingcabinet/ms13{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
+/turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "KM" = (
 /obj/effect/spawner/random/ms13/ammo/tier2,
@@ -2986,6 +3306,13 @@
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
+"MI" = (
+/obj/structure/filingcabinet/ms13/busted{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
+/turf/open/floor/ms13/concrete/industrial,
+/area/ms13/town)
 "MJ" = (
 /obj/machinery/light/ms13/bulb{
 	dir = 4
@@ -3002,6 +3329,12 @@
 	dir = 8
 	},
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
+/turf/open/openspace/ms13,
+/area/ms13/town)
+"MN" = (
+/obj/structure/railing/ms13/solo/industrial{
+	dir = 8
+	},
 /turf/open/openspace/ms13,
 /area/ms13/town)
 "MO" = (
@@ -3136,6 +3469,13 @@
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
+"Oo" = (
+/obj/machinery/vending/ms13/nuka{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
+/turf/open/floor/ms13/concrete/industrial,
+/area/ms13/town)
 "Oq" = (
 /obj/structure/table/ms13/metal/grate,
 /obj/machinery/light/ms13/bulb/industrial{
@@ -3204,6 +3544,13 @@
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
+"OU" = (
+/obj/structure/railing/ms13/solo/industrial{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
+/turf/open/openspace/ms13,
+/area/ms13/town)
 "OW" = (
 /obj/machinery/ms13/terminal{
 	dir = 8
@@ -3222,6 +3569,10 @@
 	dir = 1
 	},
 /turf/open/floor/wood/ms13/carpet/shaggy,
+/area/ms13/town)
+"Pq" = (
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/plating/ms13/roof,
 /area/ms13/town)
 "Pv" = (
 /obj/machinery/light/ms13/bulb,
@@ -3250,6 +3601,14 @@
 	dir = 8
 	},
 /turf/open/floor/ms13/tile,
+/area/ms13/town)
+"PD" = (
+/obj/structure/railing/ms13/solo/industrial,
+/obj/structure/railing/ms13/solo/industrial{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
+/turf/open/openspace/ms13,
 /area/ms13/town)
 "PF" = (
 /obj/structure/chair/ms13/wood{
@@ -3363,6 +3722,15 @@
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /turf/open/floor/ms13/tile/fancy,
 /area/ms13/town)
+"Rg" = (
+/obj/structure/table/ms13/no_smooth/counter/metal,
+/obj/machinery/light/ms13{
+	dir = 1
+	},
+/obj/effect/spawner/random/ms13/tools/tool,
+/obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
+/turf/open/floor/ms13/concrete/industrial,
+/area/ms13/town)
 "Ri" = (
 /obj/structure/table/ms13/low_wall/brick/alt,
 /obj/effect/decal/cleanable/glass{
@@ -3448,10 +3816,19 @@
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /turf/open/openspace/ms13,
 /area/ms13/town)
+"So" = (
+/obj/structure/lattice/catwalk/ms13,
+/turf/open/openspace/ms13,
+/area/ms13/town)
 "Ss" = (
 /obj/machinery/door/unpowered/ms13/wood,
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /turf/open/floor/wood/ms13/mosaic,
+/area/ms13/town)
+"St" = (
+/mob/living/basic/ms13/ghoul/brown,
+/obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
+/turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "Su" = (
 /obj/structure/railing/ms13/solo{
@@ -3605,6 +3982,11 @@
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /turf/open/floor/wood/ms13/common,
 /area/ms13/town)
+"Un" = (
+/obj/effect/turf_decal/ms13/covering/tiles/white,
+/obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
+/turf/closed/wall/ms13/brick/alt,
+/area/ms13/town)
 "Ut" = (
 /obj/machinery/door/unpowered/ms13/seethrough/metal{
 	dir = 1
@@ -3705,6 +4087,13 @@
 	},
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /turf/open/floor/wood/ms13/carpet,
+/area/ms13/town)
+"Wb" = (
+/obj/structure/chair/sofa/corp/right{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
+/turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "We" = (
 /obj/item/kirbyplants/dead{
@@ -3830,10 +4219,24 @@
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
+"XM" = (
+/obj/structure/fluff/ms13/trash/papers{
+	dir = 10
+	},
+/obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
+/turf/open/floor/ms13/concrete/industrial,
+/area/ms13/town)
 "XR" = (
 /obj/structure/dresser/ms13/orange,
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /turf/open/floor/wood/ms13/common,
+/area/ms13/town)
+"Yf" = (
+/obj/machinery/vending/ms13/cigarettes{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
+/turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "Yg" = (
 /obj/item/ammo_casing/c10mm,
@@ -24788,6 +25191,7 @@ Ly
 Ly
 Ly
 Ly
+mt
 Ly
 Ly
 Ly
@@ -24797,25 +25201,24 @@ Ly
 Ly
 Ly
 Ly
+mt
 Ly
 Ly
 Ly
 Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
+th
+th
+VA
+VA
+th
+th
+th
+th
+th
+th
+th
+th
+th
 Ly
 Ly
 OK
@@ -25005,19 +25408,19 @@ Ly
 Ly
 Ly
 Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
+hY
+ac
+IF
+nu
+Uk
+hY
+yY
+Ug
+OU
+PD
+Ug
+ex
+th
 Ly
 Ly
 OK
@@ -25207,19 +25610,19 @@ Ly
 Ly
 Ly
 Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
+VA
+zj
+Kq
+XM
+vL
+hY
+yY
+Ug
+Ug
+Ug
+Ug
+vL
+th
 Ly
 Ly
 OK
@@ -25409,19 +25812,19 @@ Ly
 Ly
 Ly
 Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
+VA
+Ug
+St
+Ug
+Ug
+no
+Ug
+Ug
+St
+Ug
+Ug
+QA
+th
 Ly
 Ly
 OK
@@ -25611,19 +26014,19 @@ Ly
 Ly
 Ly
 Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
+VA
+mO
+Ug
+Ug
+aB
+hY
+Dr
+Ug
+Fl
+vH
+vH
+JD
+th
 Ly
 Ly
 Ly
@@ -25808,24 +26211,24 @@ Ly
 Ly
 Ly
 Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
+HC
+HC
+HC
+HC
+HC
+hY
+Ga
+Ug
+MI
+KD
+th
+th
+uM
+th
+th
+th
+th
+th
 Ly
 Ly
 Ly
@@ -26010,24 +26413,24 @@ Ly
 Ly
 Ly
 Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
+HC
+HC
+HC
+HC
+HC
+th
+th
+ys
+VA
+th
+hY
+mi
+Ug
+cq
+Un
+jp
+jb
+th
 Ly
 Ly
 Ly
@@ -26212,24 +26615,24 @@ Ly
 Ly
 Ly
 Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
+HC
+HC
+HC
+HC
+HC
+HC
+HC
+Pq
+HC
+HC
+VA
+aj
+Ug
+Ug
+yd
+kb
+xO
+th
 Ly
 Ly
 Ly
@@ -26414,24 +26817,24 @@ Ly
 Ly
 Ly
 Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
+HC
+HC
+HC
+HC
+HC
+HC
+HC
+HC
+HC
+HC
+VA
+aA
+Ug
+gg
+th
+th
+th
+th
 Ly
 Ly
 Ly
@@ -26616,24 +27019,24 @@ Ly
 Ly
 Ly
 Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
+aK
+HC
+HC
+HC
+HC
+HC
+HC
+HC
+HC
+HC
+hY
+fq
+Ug
+Ug
+pD
+Wb
+th
+Gh
 Ly
 Ly
 Ly
@@ -26818,24 +27221,24 @@ Ly
 Ly
 Ly
 Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
+aK
+bt
+HC
+HC
+HC
+HC
+HC
+HC
+HC
+Pq
+ys
+gg
+Ug
+Ug
+qr
+rr
+th
+HC
 Ly
 Ly
 OK
@@ -27010,6 +27413,7 @@ Ly
 Ly
 Ly
 Ly
+mt
 Ly
 Ly
 Ly
@@ -27019,25 +27423,24 @@ Ly
 Ly
 Ly
 Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
+aK
+aK
+aK
+HC
+HC
+HC
+HC
+HC
+HC
+Pq
+ys
+Oo
+Yf
+Ug
+JG
+Iz
+th
+HC
 Ly
 Ly
 OK
@@ -27230,16 +27633,16 @@ Ly
 Ly
 Ly
 Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
+HC
+HC
+th
+th
+VA
+ys
+VA
+th
+th
+HC
 Ly
 Ly
 OK
@@ -27432,16 +27835,16 @@ Ly
 Ly
 Ly
 Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
+HC
+HC
+HC
+HC
+HC
+Pq
+HC
+HC
+HC
+HC
 Ly
 Ly
 OK
@@ -27634,16 +28037,16 @@ Ly
 Ly
 Ly
 Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
+HC
+HC
+HC
+HC
+HC
+HC
+HC
+HC
+HC
+HC
 Ly
 OK
 OK
@@ -27836,16 +28239,16 @@ Ly
 Ly
 Ly
 Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
+HC
+HC
+HC
+HC
+HC
+HC
+HC
+HC
+HC
+HC
 Ly
 OK
 OK
@@ -28038,16 +28441,16 @@ Ly
 Ly
 Ly
 Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
+HC
+HC
+HC
+HC
+HC
+HC
+HC
+HC
+HC
+HC
 Ly
 Ly
 OK
@@ -28240,16 +28643,16 @@ Ly
 Ly
 Ly
 Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
+HC
+HC
+HC
+HC
+HC
+HC
+HC
+HC
+HC
+HC
 Ly
 Ly
 OK
@@ -28442,16 +28845,16 @@ Ly
 Ly
 Ly
 Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
+aK
+HC
+HC
+HC
+HC
+HC
+HC
+HC
+HC
+aK
 Ly
 Ly
 OK
@@ -28644,16 +29047,16 @@ Ly
 Ly
 Ly
 Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
+aK
+HC
+HC
+HC
+HC
+HC
+HC
+HC
+HC
+aK
 Ly
 Ly
 Ly
@@ -28846,16 +29249,16 @@ Ly
 Ly
 Ly
 Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
+aK
+HC
+HC
+HC
+HC
+HC
+HC
+HC
+ry
+aK
 Ly
 Ly
 Ly
@@ -29030,6 +29433,7 @@ Ly
 Ly
 Ly
 Ly
+mt
 Ly
 Ly
 Ly
@@ -29047,17 +29451,16 @@ Ly
 Ly
 Ly
 Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
+aK
+aK
+aK
+aK
+HC
+HC
+aK
+aK
+aK
+aK
 Ly
 Ly
 Ly
@@ -30848,7 +31251,7 @@ Ly
 Ly
 Ly
 Ly
-Ly
+mt
 Ly
 Ly
 Ly
@@ -31071,13 +31474,13 @@ Ly
 Ly
 Ly
 Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
+QD
+ig
+ig
+QD
+ig
+xU
+QD
 Ly
 Ly
 Ly
@@ -31272,15 +31675,15 @@ Ly
 Ly
 Ly
 Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
+QD
+QD
+Ey
+So
+So
+So
+cL
+QD
+QD
 Ly
 Ly
 OK
@@ -31474,14 +31877,14 @@ Ly
 Ly
 Ly
 Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
+fO
+So
+mE
+MN
+MN
+rY
+iS
+yy
 Ly
 Ly
 Ly
@@ -31676,14 +32079,14 @@ Ly
 Ly
 Ly
 Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
+fO
+So
+mE
+ZX
+ZX
+tn
+iS
+yy
 Ly
 Ly
 Ly
@@ -31878,14 +32281,14 @@ Ly
 Ly
 Ly
 Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
+fO
+So
+mE
+ZX
+ZX
+tn
+iS
+yy
 Ly
 Ly
 Ly
@@ -32080,15 +32483,15 @@ Ly
 Ly
 Ly
 Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
+QD
+QD
+gW
+ZX
+ZX
+tn
+cL
+zc
+QD
 Ly
 Ly
 OK
@@ -32282,14 +32685,14 @@ Ly
 Ly
 Ly
 Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
+fO
+So
+mE
+ZX
+ZX
+tn
+iS
+yy
 Ly
 Ly
 OK
@@ -32484,14 +32887,14 @@ Ly
 Ly
 Ly
 Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
+fO
+So
+mE
+ZX
+ZX
+tn
+iS
+yy
 Ly
 Ly
 OK
@@ -32686,14 +33089,14 @@ Ly
 Ly
 Ly
 Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
+fO
+So
+mE
+oc
+oc
+xB
+iS
+yy
 Ly
 Ly
 OK
@@ -32868,6 +33271,12 @@ Ly
 Ly
 Ly
 Ly
+aK
+aK
+aK
+HC
+HC
+HC
 Ly
 Ly
 Ly
@@ -32882,21 +33291,15 @@ Ly
 Ly
 Ly
 Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
+QD
+QD
+Ey
+So
+So
+So
+cL
+QD
+QD
 Ly
 OK
 OK
@@ -33070,6 +33473,12 @@ Ly
 Ly
 Ly
 Ly
+aK
+bt
+fp
+HC
+HC
+HC
 Ly
 Ly
 Ly
@@ -33085,19 +33494,13 @@ Ly
 Ly
 Ly
 Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
+QD
+nY
+nY
+QD
+nY
+nY
+QD
 Ly
 Ly
 OK
@@ -33272,12 +33675,12 @@ Ly
 Ly
 Ly
 Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
+aK
+fp
+HC
+HC
+HC
+HC
 Ly
 Ly
 Ly
@@ -33474,12 +33877,12 @@ Ly
 Ly
 Ly
 Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
+HC
+HC
+HC
+fp
+HC
+HC
 Ly
 Ly
 Ly
@@ -33676,12 +34079,12 @@ Ly
 Ly
 Ly
 Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
+HC
+HC
+Pq
+Pq
+HC
+HC
 Ly
 Ly
 Ly
@@ -33878,17 +34281,17 @@ Ly
 Ly
 Ly
 Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
+th
+th
+ys
+ys
+th
+th
+HC
+HC
+HC
+HC
+HC
 Ly
 Ly
 Ly
@@ -34080,17 +34483,17 @@ Ly
 Ly
 Ly
 Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
+th
+Rg
+Ug
+Ug
+Hv
+th
+HC
+HC
+fp
+HC
+HC
 Ly
 Ly
 Ly
@@ -34282,17 +34685,17 @@ Ly
 Ly
 Ly
 Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
+ys
+fV
+Ug
+Ug
+Ug
+ys
+Pq
+HC
+HC
+HC
+HC
 Ly
 Ly
 Ly
@@ -34484,17 +34887,17 @@ Ly
 Ly
 Ly
 Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
+VA
+qJ
+Ug
+Ug
+Ug
+ys
+Pq
+HC
+fp
+HC
+aK
 Ly
 Ly
 Ly
@@ -34686,17 +35089,17 @@ Ly
 Ly
 Ly
 Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
+th
+pQ
+Ug
+Ug
+Ny
+th
+HC
+fp
+HC
+ry
+aK
 Ly
 Ly
 Ly
@@ -34888,6 +35291,17 @@ Ly
 Ly
 Ly
 Ly
+th
+th
+ys
+VA
+th
+th
+HC
+HC
+aK
+aK
+aK
 Ly
 Ly
 Ly
@@ -34897,6 +35311,7 @@ Ly
 Ly
 Ly
 Ly
+mt
 Ly
 Ly
 Ly
@@ -34905,20 +35320,8 @@ Ly
 Ly
 Ly
 Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-OK
-OK
+mt
+iQ
 OK
 "}
 (154,1,1) = {"

--- a/_maps/map_files/Drought/Drought_below.dmm
+++ b/_maps/map_files/Drought/Drought_below.dmm
@@ -9,9 +9,12 @@
 /turf/open/floor/plating/ms13/ground/mountain/drought,
 /area/ms13/underground/mountain)
 "ax" = (
-/obj/structure/table/ms13/metal,
-/obj/item/clothing/head/helmet/ms13/beanie,
-/turf/open/floor/wood/ms13/common,
+/obj/structure/table/ms13/metal/grate,
+/obj/effect/spawner/random/ms13/guaranteed/crafting/lowrandom,
+/obj/machinery/light/ms13{
+	dir = 1
+	},
+/turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "aV" = (
 /obj/effect/decal/cleanable/blood/tracks{
@@ -24,6 +27,11 @@
 /area/ms13/desert)
 "bc" = (
 /obj/effect/spawner/random/ms13/tools/tool,
+/turf/open/floor/ms13/concrete/industrial,
+/area/ms13/town)
+"br" = (
+/obj/structure/closet/crate/ms13/woodcrate/compact,
+/obj/effect/spawner/random/ms13/crafting/lowrandom,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "bu" = (
@@ -56,9 +64,16 @@
 /obj/effect/spawner/random/ms13/tools/hardware,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
+"du" = (
+/obj/structure/fluff/ms13/barrel/single/flammable/one,
+/obj/structure/ms13/storage/vent,
+/turf/open/floor/ms13/concrete/industrial,
+/area/ms13/town)
 "dH" = (
-/obj/machinery/light/ms13/bulb,
-/turf/open/floor/wood/ms13/common,
+/obj/machinery/ms13/terminal/wall{
+	id = "car_junk_storage1"
+	},
+/turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "ex" = (
 /obj/machinery/button/ms13{
@@ -71,15 +86,25 @@
 /obj/structure/table/ms13/metal/heavy,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
+"gr" = (
+/obj/machinery/door/poddoor/shutters/ms13/vertical/red/mid{
+	id = "car_junk_storage1"
+	},
+/turf/open/floor/ms13/concrete/industrial,
+/area/ms13/town)
+"gY" = (
+/obj/structure/fluff/ms13/barrel/quadruple/yellow/one,
+/turf/open/floor/ms13/concrete/industrial,
+/area/ms13/town)
 "hA" = (
 /mob/living/simple_animal/hostile/ms13/robot/protectron,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "hY" = (
-/obj/machinery/light/ms13{
+/obj/structure/railing/ms13/solo/industrial{
 	dir = 8
 	},
-/turf/open/floor/wood/ms13/common,
+/turf/open/floor/ms13/metal/plate,
 /area/ms13/town)
 "iA" = (
 /obj/machinery/door/poddoor/shutters/ms13/vertical/red/mid{
@@ -95,9 +120,20 @@
 /obj/item/shovel/ms13/rake,
 /turf/open/floor/plating/ms13/ground/mountain/drought,
 /area/ms13/underground/mountain)
+"jj" = (
+/obj/structure/fluff/ms13/barrel/quadruple/red/one,
+/turf/open/floor/ms13/concrete/industrial,
+/area/ms13/town)
 "jv" = (
 /obj/structure/ms13/storage/shelf{
 	dir = 1
+	},
+/turf/open/floor/ms13/concrete/industrial,
+/area/ms13/town)
+"jO" = (
+/obj/structure/fluff/ms13/barrel/double/yellow/two,
+/obj/machinery/light/ms13{
+	dir = 8
 	},
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
@@ -215,8 +251,9 @@
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "qQ" = (
-/obj/machinery/door/unpowered/ms13/metal/red,
-/turf/open/floor/wood/ms13/common,
+/obj/structure/closet/crate/ms13/woodcrate,
+/obj/effect/spawner/random/ms13/guaranteed/crafting/highrandom,
+/turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "rd" = (
 /obj/structure/table/ms13/metal/grate,
@@ -241,8 +278,11 @@
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "sq" = (
-/obj/effect/spawner/random/ms13/food/trash,
-/turf/open/floor/wood/ms13/common,
+/mob/living/simple_animal/hostile/ms13/robot/protectron,
+/obj/machinery/light/ms13{
+	dir = 4
+	},
+/turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "sr" = (
 /obj/structure/stairs/north,
@@ -275,7 +315,9 @@
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "uo" = (
-/turf/open/floor/wood/ms13/common,
+/obj/structure/table/ms13/metal/grate,
+/obj/effect/spawner/random/ms13/tools/lights,
+/turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "uv" = (
 /obj/structure/ms13/storage/vent,
@@ -317,10 +359,11 @@
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "wX" = (
-/obj/machinery/light/ms13/bulb{
+/obj/structure/ms13/storage/large/shelf{
 	dir = 8
 	},
-/turf/open/floor/wood/ms13/wide,
+/obj/effect/spawner/random/ms13/crafting/lowrandom,
+/turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "xE" = (
 /obj/structure/ms13/foundation/wide/varianttwo{
@@ -363,8 +406,10 @@
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "zv" = (
-/obj/structure/ms13/storage/washingmachine,
-/turf/open/floor/wood/ms13/common,
+/obj/structure/closet/crate/ms13/woodcrate,
+/obj/effect/spawner/random/ms13/crafting/lowrandom,
+/obj/effect/spawner/random/ms13/crafting/lowrandom,
+/turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "zK" = (
 /obj/structure/table/ms13/no_smooth/counter/metal{
@@ -422,8 +467,14 @@
 /turf/open/floor/ms13/metal/plate,
 /area/ms13/town)
 "BR" = (
-/obj/structure/ms13/storage/large/shelf/wood/drawers,
-/turf/open/floor/wood/ms13/common,
+/obj/structure/ms13/pipes/piped,
+/turf/closed/wall/ms13/brick/alt,
+/area/ms13/town)
+"BY" = (
+/obj/structure/ms13/storage/large/shelf{
+	dir = 8
+	},
+/turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "CG" = (
 /obj/structure/table/ms13/metal/grate,
@@ -431,8 +482,12 @@
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "Dl" = (
-/obj/machinery/light/ms13/bulb,
-/turf/open/floor/wood/ms13/wide,
+/obj/machinery/door/unpowered/ms13/metal,
+/turf/open/floor/ms13/concrete/industrial,
+/area/ms13/town)
+"Dt" = (
+/obj/structure/fluff/ms13/barrel/quadruple/grey,
+/turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "DD" = (
 /obj/structure/table/ms13/metal/grate,
@@ -447,10 +502,10 @@
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "FX" = (
-/obj/machinery/light/ms13/bulb/broken{
-	dir = 4
+/obj/machinery/door/unpowered/ms13/metal{
+	dir = 8
 	},
-/turf/open/floor/wood/ms13/common,
+/turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "Gs" = (
 /obj/structure/table/ms13/no_smooth/large/metal/desk,
@@ -490,9 +545,18 @@
 	},
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
+"Ia" = (
+/obj/structure/table/ms13/crafting/workbench,
+/obj/structure/noticeboard/ms13/cork,
+/turf/open/floor/ms13/concrete/industrial,
+/area/ms13/town)
 "Iq" = (
 /obj/structure/table/ms13/metal/heavy,
 /obj/machinery/light/ms13,
+/turf/open/floor/ms13/concrete/industrial,
+/area/ms13/town)
+"IP" = (
+/obj/structure/ladder/ms13,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "Jo" = (
@@ -501,8 +565,11 @@
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "Jq" = (
-/obj/structure/stairs/south,
-/turf/open/floor/wood/ms13/wide,
+/obj/structure/table/ms13/metal/heavy,
+/obj/structure/ms13/lamp/makeshift{
+	pixel_y = 4
+	},
+/turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "Jr" = (
 /obj/machinery/light/ms13/bulb/industrial{
@@ -536,8 +603,8 @@
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "Lb" = (
-/obj/structure/table/ms13/metal,
-/turf/open/floor/wood/ms13/common,
+/obj/structure/ms13/storage/shelf,
+/turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "Le" = (
 /obj/machinery/light/ms13{
@@ -555,9 +622,10 @@
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "Ma" = (
-/obj/structure/bed/ms13/sleepingbag/green,
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/turf/open/floor/wood/ms13/common,
+/obj/structure/table/ms13/metal/grate,
+/obj/effect/spawner/random/ms13/crafting/electrical,
+/obj/machinery/light/ms13,
+/turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "Mg" = (
 /obj/structure/table/ms13/metal/heavy,
@@ -596,7 +664,11 @@
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "Pj" = (
-/turf/closed/wall/ms13/brick,
+/obj/structure/table/ms13/no_smooth/counter/metal{
+	dir = 1
+	},
+/obj/effect/spawner/random/ms13/tools/lights,
+/turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "Pl" = (
 /mob/living/simple_animal/hostile/ms13/robot/protectron,
@@ -622,10 +694,11 @@
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "QQ" = (
-/obj/machinery/light/ms13/bulb/broken{
+/obj/structure/table/ms13/no_smooth/counter/metal{
 	dir = 1
 	},
-/turf/open/floor/wood/ms13/common,
+/obj/effect/spawner/random/ms13/melee/lowrandom,
+/turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "QY" = (
 /turf/open/water,
@@ -674,10 +747,14 @@
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "Vb" = (
-/obj/structure/ms13/storage/shelf{
-	dir = 1
+/obj/structure/stairs/north{
+	dir = 2
 	},
-/turf/open/floor/wood/ms13/common,
+/turf/open/floor/ms13/concrete/industrial,
+/area/ms13/town)
+"Vy" = (
+/obj/structure/fluff/ms13/barrel/single/hazard/two,
+/turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "VN" = (
 /obj/effect/decal/cleanable/blood,
@@ -691,22 +768,27 @@
 /obj/effect/spawner/random/ms13/crafting/lowrandom,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
-"Xr" = (
-/obj/machinery/light/ms13/bulb/built,
-/turf/open/floor/wood/ms13/wide,
-/area/ms13/town)
 "Xw" = (
 /turf/closed/indestructible/rock/ms13/drought,
 /area/ms13/underground/mountain)
+"XA" = (
+/obj/structure/table/ms13/crafting/weaponbench,
+/obj/structure/table/ms13/crafting/weaponbench,
+/obj/structure/noticeboard/ms13/cork,
+/turf/open/floor/ms13/concrete/industrial,
+/area/ms13/town)
 "Yl" = (
 /obj/machinery/door/poddoor/shutters/ms13/vertical/red/mid/pre_open{
 	id = "robco_protectron_wh1"
 	},
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
-"ZO" = (
-/obj/structure/bed/ms13/sleepingbag/red,
-/turf/open/floor/wood/ms13/common,
+"Ym" = (
+/obj/structure/fluff/ms13/barrel/single/red/one,
+/obj/machinery/light/ms13{
+	dir = 8
+	},
+/turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 
 (1,1,1) = {"
@@ -23924,12 +24006,12 @@ Xw
 Xw
 Xw
 Xw
-Xw
-Xw
-Xw
-Xw
-Xw
-Xw
+of
+of
+of
+of
+of
+of
 Xw
 Xw
 Xw
@@ -24126,12 +24208,12 @@ Xw
 Xw
 Xw
 Xw
-Xw
-Xw
-Xw
-Xw
-Xw
-Xw
+of
+pC
+pC
+pC
+Vb
+of
 Xw
 Xw
 Xw
@@ -24328,12 +24410,12 @@ Xw
 Xw
 Xw
 Xw
-Xw
-Xw
-Xw
-Xw
-Xw
-Xw
+of
+pC
+pC
+pC
+Vb
+of
 Xw
 Xw
 Xw
@@ -24530,12 +24612,12 @@ Xw
 Xw
 Xw
 Xw
-Xw
-Xw
-Xw
-Xw
-Xw
-Xw
+of
+of
+of
+of
+of
+of
 Xw
 Xw
 Xw
@@ -24909,16 +24991,6 @@ Xw
 Xw
 Xw
 Xw
-Pj
-Pj
-Pj
-Pj
-Pj
-Pj
-Pj
-Pj
-Pj
-Pj
 Xw
 Xw
 Xw
@@ -24940,6 +25012,16 @@ Xw
 Xw
 Xw
 Xw
+Xw
+Xw
+Xw
+Xw
+of
+of
+of
+of
+of
+of
 Xw
 Xw
 Xw
@@ -25111,16 +25193,6 @@ Xw
 Xw
 Xw
 Xw
-Pj
-zv
-hY
-uo
-Pj
-qz
-wX
-Jq
-Jq
-Pj
 Xw
 Xw
 Xw
@@ -25142,6 +25214,16 @@ Xw
 Xw
 Xw
 Xw
+Xw
+Xw
+Xw
+Xw
+of
+pC
+pC
+pC
+Vb
+of
 Xw
 Xw
 Xw
@@ -25313,16 +25395,6 @@ Xw
 Xw
 Xw
 Xw
-Pj
-zv
-uo
-uo
-Pj
-qz
-qz
-Jq
-Jq
-Pj
 Xw
 Xw
 Xw
@@ -25344,6 +25416,16 @@ Xw
 Xw
 Xw
 Xw
+Xw
+Xw
+Xw
+Xw
+of
+pC
+pC
+pC
+Vb
+of
 Xw
 Xw
 Xw
@@ -25515,16 +25597,6 @@ Xw
 Xw
 Xw
 Xw
-Pj
-Lb
-uo
-uo
-Pj
-qz
-Pj
-Pj
-Pj
-Pj
 Xw
 Xw
 Xw
@@ -25546,6 +25618,16 @@ Xw
 Xw
 Xw
 Xw
+Xw
+Xw
+Xw
+Xw
+of
+of
+of
+of
+of
+of
 Xw
 Xw
 Xw
@@ -25717,13 +25799,13 @@ Xw
 Xw
 Xw
 Xw
-Pj
-Lb
-uo
-uo
-Pj
-qz
-Pj
+Xw
+Xw
+Xw
+Xw
+Xw
+Xw
+Xw
 Xw
 Xw
 Xw
@@ -25919,13 +26001,13 @@ Xw
 Xw
 Xw
 Xw
-Pj
-Vb
-sq
-uo
-qQ
-qz
-Pj
+Xw
+Xw
+Xw
+Xw
+Xw
+Xw
+Xw
 Xw
 Xw
 Xw
@@ -26121,13 +26203,13 @@ Xw
 Xw
 Xw
 Xw
-Pj
-Vb
-FX
-uo
-Pj
-Xr
-Pj
+Xw
+Xw
+Xw
+Xw
+Xw
+Xw
+Xw
 Xw
 Xw
 Xw
@@ -26323,13 +26405,13 @@ Xw
 Xw
 Xw
 Xw
-Pj
-Pj
-Pj
-Pj
-Pj
-qz
-Pj
+Xw
+Xw
+Xw
+Xw
+Xw
+Xw
+Xw
 Xw
 Xw
 Xw
@@ -26525,13 +26607,13 @@ Xw
 Xw
 Xw
 Xw
-Pj
-Vb
-uo
-uo
-Pj
-qz
-Pj
+Xw
+Xw
+Xw
+Xw
+Xw
+Xw
+Xw
 Xw
 Xw
 Xw
@@ -26727,13 +26809,13 @@ Xw
 Xw
 Xw
 Xw
-Pj
-Vb
-uo
-uo
-Pj
-qz
-Pj
+Xw
+Xw
+Xw
+Xw
+Xw
+Xw
+Xw
 Xw
 Xw
 Xw
@@ -26929,13 +27011,13 @@ Xw
 Xw
 Xw
 Xw
-Pj
-BR
-sq
-uo
-Pj
-qz
-Pj
+Xw
+Xw
+Xw
+Xw
+Xw
+Xw
+Xw
 Xw
 Xw
 Xw
@@ -27131,13 +27213,13 @@ Xw
 Xw
 Xw
 Xw
-Pj
-uo
-uo
-dH
-Pj
-qz
-Pj
+Xw
+Xw
+Xw
+Xw
+Xw
+Xw
+Xw
 Xw
 Xw
 Xw
@@ -27333,13 +27415,13 @@ Xw
 Xw
 Xw
 Xw
-Pj
-ax
-uo
-uo
-Pj
-qz
-Pj
+Xw
+Xw
+Xw
+Xw
+Xw
+Xw
+Xw
 Xw
 Xw
 Xw
@@ -27535,13 +27617,13 @@ Xw
 Xw
 Xw
 Xw
-Pj
-zv
-uo
-uo
-qQ
-Dl
-Pj
+Xw
+Xw
+Xw
+Xw
+Xw
+Xw
+Xw
 Xw
 Xw
 Xw
@@ -27737,13 +27819,13 @@ Xw
 Xw
 Xw
 Xw
-Pj
-zv
-uo
-uo
-Pj
-qz
-Pj
+Xw
+Xw
+Xw
+Xw
+Xw
+Xw
+Xw
 Xw
 Xw
 Xw
@@ -27939,13 +28021,13 @@ Xw
 Xw
 Xw
 Xw
-Pj
-Pj
-Pj
-Pj
-Pj
-qz
-Pj
+Xw
+Xw
+Xw
+Xw
+Xw
+Xw
+Xw
 Xw
 Xw
 Xw
@@ -28141,13 +28223,13 @@ Xw
 Xw
 Xw
 Xw
-Pj
-uo
-uo
-uo
-Pj
-qz
-Pj
+Xw
+Xw
+Xw
+Xw
+Xw
+Xw
+Xw
 Xw
 Xw
 Xw
@@ -28343,13 +28425,13 @@ Xw
 Xw
 Xw
 Xw
-Pj
-sq
-uo
-ZO
-Pj
-qz
-Pj
+Xw
+Xw
+Xw
+Xw
+Xw
+Xw
+Xw
 Xw
 Xw
 Xw
@@ -28545,13 +28627,13 @@ Xw
 Xw
 Xw
 Xw
-Pj
-uo
-uo
-uo
-uo
-qz
-Pj
+Xw
+Xw
+Xw
+Xw
+Xw
+Xw
+Xw
 Xw
 Xw
 Xw
@@ -28747,13 +28829,13 @@ Xw
 Xw
 Xw
 Xw
-Pj
-QQ
-uo
-uo
-uo
-Dl
-Pj
+Xw
+Xw
+Xw
+Xw
+Xw
+Xw
+Xw
 Xw
 Xw
 Xw
@@ -28949,13 +29031,13 @@ Xw
 Xw
 Xw
 Xw
-Pj
-uo
-uo
-uo
-Pj
-qz
-Pj
+Xw
+Xw
+Xw
+Xw
+Xw
+Xw
+Xw
 Xw
 Xw
 Xw
@@ -29151,13 +29233,13 @@ Xw
 Xw
 Xw
 Xw
-Pj
-uo
-uo
-sq
-Pj
-qz
-Pj
+Xw
+Xw
+Xw
+Xw
+Xw
+Xw
+Xw
 Xw
 Xw
 Xw
@@ -29353,13 +29435,6 @@ Xw
 Xw
 Xw
 Xw
-Pj
-Ma
-uo
-uo
-Pj
-qz
-Pj
 Xw
 Xw
 Xw
@@ -29371,11 +29446,18 @@ Xw
 Xw
 Xw
 Xw
-Xw
-Xw
-Xw
-Xw
-Xw
+of
+of
+of
+of
+of
+of
+of
+of
+of
+of
+of
+of
 Xw
 Xw
 Xw
@@ -29555,13 +29637,6 @@ Xw
 Xw
 Xw
 Xw
-Pj
-Pj
-Pj
-Pj
-Pj
-Pj
-Pj
 Xw
 Xw
 Xw
@@ -29573,11 +29648,18 @@ Xw
 Xw
 Xw
 Xw
-Xw
-Xw
-Xw
-Xw
-Xw
+of
+br
+BY
+qQ
+Ym
+qG
+wX
+jO
+pu
+ww
+BY
+of
 Xw
 Xw
 Xw
@@ -29768,18 +29850,18 @@ Xw
 Xw
 Xw
 Xw
-Xw
-Xw
-Xw
-Xw
-Xw
-Xw
-Xw
-Xw
-Xw
-Xw
-Xw
-Xw
+of
+du
+pC
+pC
+pC
+pC
+br
+pC
+pC
+pC
+jj
+of
 Xw
 Xw
 Xw
@@ -29970,18 +30052,18 @@ Xw
 Xw
 Xw
 Xw
-Xw
-Xw
-Xw
-Xw
-Xw
-Xw
-Xw
-Xw
-Xw
-Xw
-Xw
-Xw
+of
+gY
+pC
+pC
+MR
+pC
+pC
+pC
+pC
+pC
+Vy
+of
 Xw
 Xw
 Xw
@@ -30172,18 +30254,18 @@ Xw
 Xw
 Xw
 Xw
-Xw
-Xw
-Xw
-Xw
-Xw
-Xw
-Xw
-Xw
-Xw
-Xw
-Xw
-Xw
+of
+ax
+pC
+pC
+pC
+pC
+pC
+pC
+pC
+pC
+Ma
+of
 Xw
 Xw
 Xw
@@ -30374,18 +30456,18 @@ Xw
 Xw
 Xw
 Xw
-Xw
-Xw
-Xw
-Xw
-Xw
-Xw
-Xw
-Xw
-Xw
-Xw
-Xw
-Xw
+of
+zn
+br
+pC
+pC
+Dt
+zv
+pC
+pC
+pC
+CG
+of
 Xw
 Xw
 Xw
@@ -30576,18 +30658,18 @@ Xw
 Xw
 Xw
 Xw
-Xw
-Xw
-Xw
-Xw
-Xw
-Xw
-Xw
-Xw
-Xw
-Xw
-Xw
-Xw
+of
+of
+of
+gr
+gr
+of
+of
+gr
+gr
+of
+of
+of
 Xw
 Xw
 Xw
@@ -30779,16 +30861,16 @@ Xw
 Xw
 Xw
 Xw
-Xw
-Xw
-Xw
-Xw
-Xw
-Xw
-Xw
-Xw
-Xw
-Xw
+of
+rd
+pC
+pC
+IP
+BR
+pC
+pC
+CG
+of
 Xw
 Xw
 Xw
@@ -30981,16 +31063,16 @@ Xw
 Xw
 Xw
 Xw
-Xw
-Xw
-Xw
-Xw
-Xw
-Xw
-Xw
-Xw
-Xw
-Xw
+of
+dH
+pC
+pC
+pC
+pC
+hA
+pC
+Az
+of
 Xw
 Xw
 Xw
@@ -31183,16 +31265,16 @@ Xw
 Xw
 Xw
 Xw
-Xw
-Xw
-Xw
-Xw
-Xw
-Xw
-Xw
-Xw
-Xw
-Xw
+of
+hY
+hY
+pC
+pC
+pC
+pC
+pC
+UB
+of
 Xw
 Xw
 Xw
@@ -31385,16 +31467,16 @@ Xw
 Xw
 Xw
 Xw
-Xw
-Xw
-Xw
-Xw
-Xw
-Xw
-Xw
-Xw
-Xw
-Xw
+of
+pb
+pb
+sq
+pC
+of
+wH
+pC
+Lb
+of
 Xw
 Xw
 Xw
@@ -31586,18 +31668,18 @@ Xw
 Xw
 Xw
 Xw
-Xw
-Xw
-Xw
-Xw
-Xw
-Xw
-Xw
-Xw
-Xw
-Xw
-Xw
-Xw
+of
+of
+of
+of
+of
+of
+of
+of
+FX
+of
+of
+of
 Xw
 Xw
 Xw
@@ -31788,18 +31870,18 @@ Xw
 Xw
 Xw
 Xw
-Xw
-Xw
-Xw
-Xw
-Xw
-Xw
-Xw
-Xw
-Xw
-Xw
-Xw
-Xw
+of
+Ia
+Rs
+pC
+Az
+uo
+of
+jv
+pC
+pC
+Pj
+of
 Xw
 Xw
 Xw
@@ -31990,18 +32072,18 @@ Xw
 Xw
 Xw
 Xw
-Xw
-Xw
-Xw
-Xw
-Xw
-Xw
-Xw
-Xw
-Xw
-Xw
-Xw
-Xw
+of
+ok
+pC
+pC
+pC
+pC
+of
+pC
+pC
+pC
+QQ
+of
 Xw
 Xw
 Xw
@@ -32192,18 +32274,18 @@ Xw
 Xw
 Xw
 Xw
-Xw
-Xw
-Xw
-Xw
-Xw
-Xw
-Xw
-Xw
-Xw
-Xw
-Xw
-Xw
+of
+Ns
+pC
+pC
+pC
+pC
+Dl
+pC
+pC
+pC
+UB
+of
 Xw
 Xw
 Xw
@@ -32394,18 +32476,18 @@ Xw
 Xw
 Xw
 Xw
-Xw
-Xw
-Xw
-Xw
-Xw
-Xw
-Xw
-Xw
-Xw
-Xw
-Xw
-Xw
+of
+XA
+Rs
+pC
+pC
+pC
+of
+wH
+pC
+pC
+pC
+of
 Xw
 Xw
 Xw
@@ -32596,18 +32678,18 @@ Xw
 Xw
 Xw
 Xw
-Xw
-Xw
-Xw
-Xw
-Xw
-Xw
-Xw
-Xw
-Xw
-Xw
-Xw
-Xw
+of
+ok
+pC
+pC
+ww
+BY
+of
+tI
+Jq
+Ag
+tI
+of
 Xw
 Xw
 Xw
@@ -32798,18 +32880,18 @@ Xw
 Xw
 Xw
 Xw
-Xw
-Xw
-Xw
-Xw
-Xw
-Xw
-Xw
-Xw
-Xw
-Xw
-Xw
-Xw
+of
+of
+of
+of
+of
+of
+of
+of
+of
+of
+of
+of
 Xw
 Xw
 Xw

--- a/_maps/map_files/Drought/Drought_below.dmm
+++ b/_maps/map_files/Drought/Drought_below.dmm
@@ -31069,7 +31069,7 @@ pC
 pC
 pC
 pC
-hA
+pC
 pC
 Az
 of


### PR DESCRIPTION
Added a Car Jankyard on a Drought.
Three levels with some little quest.
The algorythm is:
Go to main building, clear it, open a storage using a terminal, go through a maze, go down, fight protectrons, get your loot.

1st floor (there's a three desert radscorpions in a yard, I just don't want to make a new screenshot for it)

![image](https://user-images.githubusercontent.com/19852466/211163386-d11e5204-44f2-43d3-ad77-5bce833dcf7e.png)

2nd floor.

![image](https://user-images.githubusercontent.com/19852466/211163397-8dcb1c29-2983-4166-ae06-9558ab6ed62d.png)


Basement.

![image](https://user-images.githubusercontent.com/19852466/211163405-fa4be180-9c01-4931-9a76-0241efaff8a0.png)


I'll remake a yard in a maze later, when I'll get a comressed car walls.