### PR TITLE
Fixes wielding inhand icon reset

### DIFF
--- a/code/datums/components/twohanded.dm
+++ b/code/datums/components/twohanded.dm
@@ -214,6 +214,8 @@
 		parent_item.force -= sharpened_increase
 	if(force_multiplier)
 		parent_item.force /= force_multiplier
+	if(icon_wielded)
+		parent_item.inhand_icon_state = "[initial(parent_item.inhand_icon_state)]"
 	else if(force_unwielded)
 		parent_item.force = force_unwielded
 


### PR DESCRIPTION

## About The Pull Request

Makes it so that your inhand icon resets after un-wielding your item. This is cool, because before you'd wield it, it'd give you the new icon, and then you'd have that forever! 

## Why It's Good For The Game

It makes our wielding work 🥳 🎈 

