### PR TITLE
Respawn timer observer

### DIFF
--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -128,6 +128,7 @@
 		observer.client.init_verbs()
 	observer.update_appearance()
 	observer.stop_sound_channel(CHANNEL_LOBBYMUSIC)
+	observer.respawn_timeofdeath = world.time
 	deadchat_broadcast(" has observed.", "<b>[observer.real_name]</b>", follow_target = observer, turf_target = get_turf(observer), message_type = DEADCHAT_DEATHRATTLE)
 	QDEL_NULL(mind)
 	qdel(src)

--- a/code/modules/mob/living/death.dm
+++ b/code/modules/mob/living/death.dm
@@ -72,7 +72,7 @@
 	set_stat(DEAD)
 	unset_machine()
 	timeofdeath = world.time
-	respawn_timeofdeath = timeofdeath
+	respawn_timeofdeath = world.time
 	tod = station_time_timestamp()
 	var/turf/T = get_turf(src)
 	if(mind && mind.name && mind.active && !istype(T.loc, /area/ctf))

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -695,7 +695,7 @@
 		return
 
 	if(world.time - src.respawn_timeofdeath < CONFIG_GET(number/respawn_time))
-		to_chat(usr, span_boldnotice("Respawn timer: [(CONFIG_GET(number/respawn_time) - (world.time - src.respawn_timeofdeath)) / 10] seconds remaining."))
+		to_chat(usr, span_boldnotice("Respawn timer: [round((CONFIG_GET(number/respawn_time) - (world.time - src.respawn_timeofdeath)) / 10)] seconds remaining."))
 		return
 
 	log_game("[key_name(usr)] used the respawn button.")

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -694,7 +694,7 @@
 		to_chat(usr, span_boldnotice("You must be dead to use this!"))
 		return
 
-	if(world.time - src.respawn_timeofdeath < CONFIG_GET(number/respawn_time))
+	if(world.time - src.respawn_timeofdeath < CONFIG_GET(number/respawn_time) || !check_rights_for(usr.client, R_ADMIN))
 		to_chat(usr, span_boldnotice("Respawn timer: [round((CONFIG_GET(number/respawn_time) - (world.time - src.respawn_timeofdeath)) / 10)] seconds remaining."))
 		return
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Forgot to properly add a respawn timer for observers.  It'll use the same respawn time as dead players, but we can separate them at some point if needed.

Also rounded the respawn time notification to make it look a bit nicer.  Admins are also excepted from the timer.  They can just send themselves back to the login screen to get around it, but this makes it a bit easier.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
No observing to check for loot then instantly respawning.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Respawn timer for observers
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
