### PR TITLE
Adds a wielded check to automatic fire component

### DIFF
--- a/code/datums/components/fullauto.dm
+++ b/code/datums/components/fullauto.dm
@@ -117,6 +117,13 @@
 	if(get_dist(source.mob, _target) < 2) //Adjacent clicking.
 		return
 
+	// MOJAVE SUN EDIT BEGIN
+	if(isgun(parent))
+		var/obj/item/gun/strapazine = parent
+		if(strapazine.weapon_weight == WEAPON_HEAVY && !HAS_TRAIT(parent, TRAIT_WIELDED))
+			to_chat(src, span_warning("You need to wield [src] with two hands!"))
+			return
+	// MOJAVE SUN EDIT END
 	if(isnull(location) || control == ("mapwindow.hud")) //MOJAVE EDIT Clicking on a screen object.
 		if(_target.plane != CLICKCATCHER_PLANE) //The clickcatcher is a special case. We want the click to trigger then, under it.
 			return //If we click and drag on our worn backpack, for example, we want it to open instead.


### PR DESCRIPTION
This PR fixes automatic weapons! It now has a check that CHECKS if you need to wield the weapon or not. 

Automatic fire component was bypassing the usual check fire wielded check, so this has one of its own now.