### PR TITLE
Fixes PA buckling

### DIFF
--- a/mojave/code/modules/clothing/spacesuits/power_armor.dm
+++ b/mojave/code/modules/clothing/spacesuits/power_armor.dm
@@ -136,7 +136,7 @@
 	if((damage > 10) && prob(35)) //SPARK
 		do_sparks(2, FALSE, src)
 
-/obj/item/clothing/suit/space/hardsuit/ms13/power_armor/equipped(mob/user, slot)
+/obj/item/clothing/suit/space/hardsuit/ms13/power_armor/equipped(mob/living/carbon/human/user, slot)
 	. = ..()
 	if(slot != ITEM_SLOT_OCLOTHING)
 		if(listeningTo)
@@ -146,6 +146,8 @@
 		UnregisterSignal(listeningTo, COMSIG_MOVABLE_MOVED)
 	RegisterSignal(user, COMSIG_MOVABLE_MOVED, .proc/on_mob_move)
 	listeningTo = user
+	// How do you buckle a suit of power armor to something?
+	user.can_buckle_to = FALSE
 	user.base_pixel_y = user.base_pixel_y + 6
 	user.pixel_y = user.base_pixel_y
 	ADD_TRAIT(user, TRAIT_FORCED_STANDING, "power_armor") //It's a suit of armor, it ain't going to fall over just because the pilot is dead
@@ -155,8 +157,10 @@
 	ADD_TRAIT(user, TRAIT_PUSHIMMUNE, "power_armor")
 	RegisterSignal(user, COMSIG_ATOM_CAN_BE_PULLED, .proc/reject_pulls)
 
-/obj/item/clothing/suit/space/hardsuit/ms13/power_armor/dropped(mob/user)
+/obj/item/clothing/suit/space/hardsuit/ms13/power_armor/dropped(mob/living/carbon/human/user)
 	. = ..()
+	// So that you can be buckled again on leaving the suit of armor.
+	user.can_buckle_to = TRUE
 	user.base_pixel_y = user.base_pixel_y - 6
 	user.pixel_y = user.base_pixel_y
 	if(listeningTo)


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes it so someone in power armor can't be buckled, because why the hell would you be able to buckle a massive suit of powered armor to a chair or bed? This also prevents people doing surgery on people underneath layers of steel and composite armor.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Buckling power armor is fucking stupid.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: power armor being buckled
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
