### PR TITLE
Fixes some mapping errors. Removes ability to dig up desert, spawn TG sand and make the entire tile black

### DIFF
--- a/_maps/map_files/Drought/Drought.dmm
+++ b/_maps/map_files/Drought/Drought.dmm
@@ -1465,10 +1465,10 @@
 /area/ms13/town)
 "bSc" = (
 /obj/structure/sink/ms13{
-	dir = 4
+	pixel_y = 14
 	},
-/turf/open/floor/plating/ms13/ground/desertalt,
-/area/ms13/legioncamp)
+/turf/open/floor/ms13/concrete/industrial,
+/area/ms13/legioncamp/building)
 "bSi" = (
 /obj/structure/fluff/ms13/barrel/single/flammable/two,
 /turf/open/floor/wood/ms13/wide,
@@ -3542,8 +3542,10 @@
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "ezu" = (
-/obj/structure/ms13/pipes/horizontal/end,
-/turf/closed/wall/ms13/concrete,
+/obj/structure/ms13/pipes/horizontal/down/single{
+	dir = 1
+	},
+/turf/open/floor/ms13/concrete,
 /area/ms13/town)
 "eAT" = (
 /turf/open/floor/ms13/metal/plate,
@@ -12702,6 +12704,9 @@
 /area/ms13/water_baron/interior)
 "qzs" = (
 /obj/effect/spawner/random/ms13/guaranteed/medical/dbag,
+/obj/item/mop/ms13{
+	pixel_y = 19
+	},
 /turf/open/floor/ms13/tile/blue,
 /area/ms13/water_baron/interior)
 "qAd" = (
@@ -14469,8 +14474,8 @@
 /turf/open/floor/ms13/concrete/industrial/walkway,
 /area/ms13/factory)
 "sPZ" = (
-/obj/structure/ms13/pipes/horizontal/random,
-/turf/closed/wall/ms13/concrete,
+/obj/structure/ms13/pipes/horizontal/valve,
+/turf/open/floor/ms13/concrete,
 /area/ms13/town)
 "sQm" = (
 /obj/structure/ms13/storage/large/shelf{
@@ -16011,8 +16016,8 @@
 /turf/open/floor/ms13/concrete,
 /area/ms13/water_baron/interior)
 "uKh" = (
-/obj/structure/ms13/pipes/horizontal/valve,
-/turf/closed/wall/ms13/concrete,
+/obj/structure/ms13/pipes/horizontal/random,
+/turf/open/floor/ms13/concrete,
 /area/ms13/town)
 "uKm" = (
 /obj/machinery/vending/ms13/cigarettes,
@@ -16551,10 +16556,10 @@
 /turf/open/floor/ms13/concrete,
 /area/ms13/rangeroutpost/building)
 "vnA" = (
-/obj/structure/ms13/pipes/horizontal/down/single{
-	dir = 1
-	},
-/turf/closed/wall/ms13/concrete,
+/obj/structure/closet/ms13/metal,
+/obj/effect/spawner/random/ms13/clothing/under,
+/obj/structure/ms13/pipes/horizontal/end,
+/turf/open/floor/ms13/concrete,
 /area/ms13/town)
 "vnQ" = (
 /obj/structure/table/ms13/no_smooth/wood/square,
@@ -24359,8 +24364,8 @@ wIP
 wIP
 kTl
 wIP
-vnA
-ylS
+wIP
+ezu
 ylS
 ylS
 wIP
@@ -24561,8 +24566,8 @@ rXk
 ylS
 ylS
 rBm
-uKh
-ylS
+wIP
+sPZ
 ylS
 oUr
 wIP
@@ -24731,7 +24736,7 @@ oPv
 oPv
 oPv
 oPv
-jeR
+lHw
 ylS
 ylS
 ifb
@@ -24763,8 +24768,8 @@ vHL
 ylS
 ylS
 quv
-sPZ
-ylS
+wIP
+uKh
 ylS
 neK
 wIP
@@ -24965,8 +24970,8 @@ yhv
 ylS
 tEs
 wkh
-ezu
-thD
+wIP
+vnA
 thD
 neK
 wIP
@@ -27158,7 +27163,7 @@ oPv
 oPv
 oPv
 oPv
-ndC
+iAP
 clN
 clN
 clN
@@ -59490,7 +59495,7 @@ fnt
 kLw
 kLw
 ocZ
-ums
+qLX
 ums
 ums
 ums
@@ -59692,7 +59697,7 @@ fnt
 kLw
 kLw
 ocZ
-qLX
+bSc
 ums
 ums
 ums
@@ -60298,7 +60303,7 @@ cQL
 kLw
 kLw
 vSY
-bSc
+fnt
 kLw
 kLw
 ocZ

--- a/_maps/map_files/Drought/Drought.dmm
+++ b/_maps/map_files/Drought/Drought.dmm
@@ -18199,7 +18199,9 @@
 /turf/open/floor/ms13/concrete,
 /area/ms13/rangeroutpost/building)
 "xBe" = (
-/obj/structure/ms13/pipes/horizontal/random,
+/obj/structure/ms13/pipes/horizontal/random_alt{
+	dir = 8
+	},
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "xCd" = (

--- a/_maps/map_files/Drought/Drought.dmm
+++ b/_maps/map_files/Drought/Drought.dmm
@@ -8379,7 +8379,7 @@
 /obj/structure/ms13/foundation/wide/variantfive{
 	dir = 10
 	},
-/turf/open/floor/wood/ms13/wide,
+/turf/open/floor/ms13/concrete/bricks,
 /area/ms13/town)
 "kXm" = (
 /obj/structure/bed/ms13/bedframe/wire,
@@ -10256,7 +10256,7 @@
 /obj/effect/spawner/random/ms13/guaranteed/crafting/electrical,
 /obj/structure/closet/crate/ms13/red,
 /obj/effect/spawner/random/ms13/crafting/highrandom,
-/turf/open/floor/ms13/metal,
+/turf/open/floor/ms13/concrete,
 /area/ms13/water_baron/interior)
 "nzx" = (
 /obj/structure/ms13/storage/shelf/wood/alt,
@@ -15477,7 +15477,7 @@
 /obj/effect/spawner/random/ms13/guaranteed/crafting/lowrandom,
 /obj/effect/spawner/random/ms13/guaranteed/crafting/lowrandom,
 /obj/structure/closet/crate/ms13/aluminum,
-/turf/open/floor/ms13/metal,
+/turf/open/floor/ms13/concrete,
 /area/ms13/water_baron/interior)
 "tUB" = (
 /obj/structure/table/ms13/crafting/workbench,

--- a/_maps/map_files/Drought/Drought_above.dmm
+++ b/_maps/map_files/Drought/Drought_above.dmm
@@ -2509,10 +2509,9 @@
 /turf/closed/wall/ms13/concrete,
 /area/ms13/town)
 "jw" = (
-/obj/structure/lattice/catwalk/ms13,
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /obj/structure/chair/ms13/overlaypickup/plastic,
-/turf/open/openspace/ms13,
+/turf/open/floor/ms13/concrete,
 /area/ms13/desert)
 "jx" = (
 /obj/structure/chair/office/ms13/green/broken{
@@ -10614,12 +10613,11 @@
 /turf/open/openspace/ms13,
 /area/ms13/town)
 "Nl" = (
-/obj/structure/lattice/catwalk/ms13,
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /obj/structure/chair/ms13/overlaypickup/plastic{
 	dir = 4
 	},
-/turf/open/openspace/ms13,
+/turf/open/floor/ms13/concrete,
 /area/ms13/desert)
 "Nm" = (
 /obj/structure/table/ms13/no_smooth/wood/low,
@@ -23083,7 +23081,7 @@ qt
 qt
 wU
 AE
-qi
+ip
 qi
 qi
 Bb
@@ -23285,7 +23283,7 @@ qt
 qt
 OF
 AE
-qi
+ip
 qi
 qi
 Bb
@@ -23487,7 +23485,7 @@ dZ
 tG
 AE
 AE
-qi
+ip
 qi
 qi
 Qz
@@ -28615,7 +28613,7 @@ EC
 EC
 EC
 gO
-oK
+TN
 kE
 Mm
 qi
@@ -28817,7 +28815,7 @@ EC
 EC
 iy
 vw
-oK
+TN
 oK
 Mm
 qi
@@ -29019,7 +29017,7 @@ Yp
 EC
 EC
 kl
-oK
+TN
 fZ
 Mm
 qi

--- a/_maps/map_files/Drought/Drought_above.dmm
+++ b/_maps/map_files/Drought/Drought_above.dmm
@@ -4898,6 +4898,13 @@
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /turf/open/floor/ms13/tile/large/cream,
 /area/ms13/rangeroutpost/building)
+"sf" = (
+/obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
+/obj/machinery/light/ms13{
+	dir = 8
+	},
+/turf/open/floor/ms13/concrete,
+/area/ms13/town)
 "sh" = (
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /turf/open/floor/ms13/tile/fancy,
@@ -6927,6 +6934,13 @@
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /obj/machinery/door/unpowered/ms13/metal/mirrored/red,
 /turf/open/floor/ms13/concrete,
+/area/ms13/town)
+"zI" = (
+/obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
+/obj/machinery/light/ms13{
+	dir = 1
+	},
+/turf/open/openspace/ms13,
 /area/ms13/town)
 "zJ" = (
 /obj/structure/table/ms13/no_smooth/counter/wood{
@@ -15988,7 +16002,7 @@ qi
 qi
 qU
 nv
-nU
+sf
 fH
 Qn
 JU
@@ -17604,7 +17618,7 @@ qi
 qi
 qi
 qU
-Pw
+zI
 Pw
 qU
 tJ

--- a/_maps/map_files/Drought/Drought_below.dmm
+++ b/_maps/map_files/Drought/Drought_below.dmm
@@ -1577,6 +1577,10 @@
 /obj/effect/spawner/random/ms13/medical/highrandom,
 /turf/open/floor/ms13/tile/large/cream,
 /area/ms13/town)
+"pM" = (
+/obj/item/reagent_containers/glass/bucket/ms13,
+/turf/open/floor/ms13/tile/blue/long,
+/area/ms13/town)
 "pN" = (
 /obj/effect/spawner/random/ms13/gun/tier1,
 /obj/effect/spawner/random/ms13/ammo/tier1,
@@ -3142,6 +3146,9 @@
 	dir = 4
 	},
 /obj/structure/ms13/storage/vent,
+/obj/item/mop/ms13{
+	pixel_y = 19
+	},
 /turf/open/floor/ms13/tile/blue/long,
 /area/ms13/town)
 "HF" = (
@@ -7037,7 +7044,7 @@ uD
 uD
 uD
 xs
-Cn
+pM
 Cn
 Cn
 ZS

--- a/_maps/map_files/Drought/Drought_below.dmm
+++ b/_maps/map_files/Drought/Drought_below.dmm
@@ -168,10 +168,8 @@
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "cg" = (
-/obj/structure/table/ms13/no_smooth/counter/metal{
-	dir = 4
-	},
-/turf/open/floor/wood/ms13/wide,
+/obj/item/reagent_containers/glass/bucket/ms13,
+/turf/open/floor/ms13/tile/blue/long,
 /area/ms13/town)
 "cn" = (
 /obj/structure/table/ms13/metal/grate,
@@ -440,8 +438,8 @@
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "es" = (
-/obj/structure/table/ms13/no_smooth/counter/wood,
-/obj/effect/spawner/random/ms13/tools/hardware,
+/obj/structure/table/ms13/wood,
+/obj/effect/spawner/random/ms13/melee/lowrandom,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "ex" = (
@@ -788,16 +786,10 @@
 /turf/open/floor/plating/ms13/ground/mountain/drought,
 /area/ms13/underground/mountain)
 "hO" = (
-/obj/machinery/light/ms13{
-	dir = 1
-	},
-/obj/effect/spawner/random/ms13/food/produce_safe,
-/obj/effect/spawner/random/ms13/food/produce_safe,
-/obj/effect/spawner/random/ms13/food/produce_safe,
-/obj/effect/spawner/random/ms13/food/produce_safe,
-/obj/effect/spawner/random/ms13/food/produce_safe,
-/obj/effect/spawner/random/ms13/food/produce_safe,
-/obj/structure/closet/ms13/fridge,
+/obj/structure/table/ms13/wood,
+/obj/effect/spawner/random/ms13/seeds/random,
+/obj/effect/spawner/random/ms13/seeds/random,
+/obj/effect/spawner/random/ms13/seeds/random,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "hR" = (
@@ -906,9 +898,10 @@
 /turf/open/floor/plating/ms13/ground/mountain/drought,
 /area/ms13/underground/mountain)
 "jm" = (
-/obj/structure/ms13/storage/shelf{
-	dir = 8
-	},
+/obj/structure/closet/crate/ms13/woodcrate/compact,
+/obj/machinery/light/ms13,
+/obj/effect/spawner/random/ms13/seeds/random,
+/obj/effect/spawner/random/ms13/seeds/random,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "jn" = (
@@ -1105,8 +1098,8 @@
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "kP" = (
-/obj/structure/table/ms13/wood,
-/obj/effect/spawner/random/ms13/melee/lowrandom,
+/obj/structure/table/ms13/no_smooth/counter/wood,
+/obj/effect/spawner/random/ms13/tools/hardware,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "kT" = (
@@ -1577,10 +1570,6 @@
 /obj/effect/spawner/random/ms13/medical/highrandom,
 /turf/open/floor/ms13/tile/large/cream,
 /area/ms13/town)
-"pM" = (
-/obj/item/reagent_containers/glass/bucket/ms13,
-/turf/open/floor/ms13/tile/blue/long,
-/area/ms13/town)
 "pN" = (
 /obj/effect/spawner/random/ms13/gun/tier1,
 /obj/effect/spawner/random/ms13/ammo/tier1,
@@ -2025,7 +2014,10 @@
 /turf/open/floor/ms13/concrete,
 /area/ms13/town)
 "uC" = (
-/obj/structure/table/ms13/metal/grate,
+/obj/structure/railing/ms13/solo{
+	dir = 4
+	},
+/obj/structure/table/ms13/no_smooth/counter/wood,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "uD" = (
@@ -2037,10 +2029,10 @@
 /turf/open/floor/ms13/concrete,
 /area/ms13/underground/mountain_bunker)
 "uI" = (
-/obj/structure/closet/crate/ms13/woodcrate/compact,
-/obj/machinery/light/ms13,
-/obj/effect/spawner/random/ms13/seeds/random,
-/obj/effect/spawner/random/ms13/seeds/random,
+/obj/structure/table/ms13/no_smooth/counter/metal/bend{
+	dir = 4
+	},
+/obj/effect/spawner/random/ms13/tools/hardware,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "uJ" = (
@@ -2366,11 +2358,8 @@
 /turf/open/floor/ms13/tile/blue/long,
 /area/ms13/town)
 "yG" = (
-/obj/structure/table/ms13/no_smooth/counter/metal/bend{
-	dir = 4
-	},
-/obj/effect/spawner/random/ms13/tools/hardware,
-/turf/open/floor/wood/ms13/wide,
+/obj/structure/ms13/turfdecor/drought,
+/turf/open/floor/plating/ms13/ground/mountain/drought,
 /area/ms13/town)
 "yN" = (
 /obj/structure/table/ms13/metal/alt,
@@ -2743,8 +2732,10 @@
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "Dq" = (
-/obj/structure/ms13/turfdecor/drought,
-/turf/open/floor/plating/ms13/ground/mountain/drought,
+/obj/structure/ms13/storage/shelf{
+	dir = 8
+	},
+/turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "Dz" = (
 /obj/machinery/door/unpowered/ms13/metal/alt,
@@ -2873,10 +2864,7 @@
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/legioncamp/building)
 "Ew" = (
-/obj/structure/railing/ms13/solo{
-	dir = 4
-	},
-/obj/structure/table/ms13/no_smooth/counter/wood,
+/obj/structure/table/ms13/metal/grate,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "Ey" = (
@@ -2945,6 +2933,10 @@
 /obj/effect/spawner/random/ms13/medical/herbal,
 /turf/open/floor/plating/ms13/ground/mountain/drought,
 /area/ms13/underground/mountain)
+"Fo" = (
+/obj/structure/closet/crate/ms13/woodcrate/compact/sarsaparilla,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/town)
 "Ft" = (
 /obj/effect/spawner/random/ms13/gun/highunique,
 /turf/open/floor/plating/ms13/ground/mountain/drought,
@@ -3032,7 +3024,9 @@
 	},
 /area/ms13/legioncamp/building)
 "Gk" = (
-/obj/structure/closet/crate/ms13/woodcrate/compact/sarsaparilla,
+/obj/structure/table/ms13/no_smooth/counter/metal{
+	dir = 1
+	},
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "Gr" = (
@@ -3658,10 +3652,16 @@
 /turf/open/floor/ms13/metal/grate,
 /area/ms13/town)
 "NT" = (
-/obj/structure/table/ms13/wood,
-/obj/effect/spawner/random/ms13/seeds/random,
-/obj/effect/spawner/random/ms13/seeds/random,
-/obj/effect/spawner/random/ms13/seeds/random,
+/obj/machinery/light/ms13{
+	dir = 1
+	},
+/obj/effect/spawner/random/ms13/food/produce_safe,
+/obj/effect/spawner/random/ms13/food/produce_safe,
+/obj/effect/spawner/random/ms13/food/produce_safe,
+/obj/effect/spawner/random/ms13/food/produce_safe,
+/obj/effect/spawner/random/ms13/food/produce_safe,
+/obj/effect/spawner/random/ms13/food/produce_safe,
+/obj/structure/closet/ms13/fridge,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "NW" = (
@@ -3711,7 +3711,7 @@
 /area/ms13/underground/mountain_bunker)
 "Oq" = (
 /obj/structure/table/ms13/no_smooth/counter/metal{
-	dir = 1
+	dir = 4
 	},
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
@@ -7044,7 +7044,7 @@ uD
 uD
 uD
 xs
-pM
+cg
 Cn
 Cn
 ZS
@@ -41311,12 +41311,12 @@ uD
 uD
 uD
 uD
-HW
-HW
-HW
-HW
-HW
-HW
+uD
+uD
+uD
+uD
+uD
+uD
 uD
 uD
 uD
@@ -41513,18 +41513,18 @@ uD
 uD
 uD
 uD
-HW
-pC
-pC
-fP
-ZN
-HW
-HW
-HW
-HW
-HW
-HW
-HW
+uD
+uD
+uD
+uD
+uD
+uD
+uD
+uD
+uD
+uD
+uD
+uD
 uD
 uD
 uD
@@ -41716,17 +41716,17 @@ uD
 uD
 uD
 HW
-pC
-fP
-fP
-fP
 HW
-fP
-dw
-Zv
-cg
-yG
 HW
+HW
+HW
+HW
+uD
+uD
+uD
+uD
+uD
+uD
 uD
 uD
 uD
@@ -41918,16 +41918,16 @@ uD
 uD
 uD
 HW
-hO
+pC
+pC
 fP
-fP
-fP
-jB
-fP
-fP
-fP
-fP
-Oq
+ZN
+HW
+HW
+HW
+HW
+HW
+HW
 HW
 uD
 uD
@@ -42120,15 +42120,15 @@ uD
 uD
 uD
 HW
-kP
+pC
 fP
 fP
 fP
 HW
-cH
 fP
-fP
-fP
+dw
+Zv
+Oq
 uI
 HW
 uD
@@ -42323,11 +42323,11 @@ uD
 uD
 HW
 NT
-Lq
 fP
 fP
-HW
-cH
+fP
+jB
+fP
 fP
 fP
 fP
@@ -42524,15 +42524,15 @@ uD
 uD
 uD
 HW
+es
+fP
+fP
+fP
 HW
-HW
-HW
-fh
-HW
-HW
-jm
-uC
-uC
+cH
+fP
+fP
+fP
 jm
 HW
 uD
@@ -42725,17 +42725,17 @@ uD
 uD
 uD
 uD
-uD
 HW
-es
+hO
+Lq
+fP
+fP
+HW
+cH
 fP
 fP
 fP
-HW
-HW
-HW
-HW
-HW
+Fo
 HW
 uD
 uD
@@ -42927,18 +42927,18 @@ uD
 uD
 uD
 uD
-uD
 HW
+HW
+HW
+HW
+fh
+HW
+HW
+Dq
 Ew
-Hn
-fP
-Aq
+Ew
+Dq
 HW
-uD
-uD
-uD
-uD
-uD
 uD
 uD
 uD
@@ -43131,16 +43131,16 @@ uD
 uD
 uD
 HW
-id
-id
+kP
+fP
 fP
 fP
 HW
-uD
-uD
-uD
-uD
-uD
+HW
+HW
+HW
+HW
+HW
 uD
 uD
 uD
@@ -43333,10 +43333,10 @@ uD
 uD
 uD
 HW
-HW
-HW
-HW
-Dq
+uC
+Hn
+fP
+Aq
 HW
 uD
 uD
@@ -43534,12 +43534,12 @@ uD
 uD
 uD
 uD
-uD
-uD
-uD
-uD
-uz
-uD
+HW
+id
+id
+fP
+fP
+HW
 uD
 uD
 uD
@@ -43736,17 +43736,17 @@ uD
 uD
 uD
 uD
+HW
+HW
+HW
+HW
+yG
+HW
 uD
 uD
 uD
 uD
-uz
-uz
-uz
-uz
-uz
-uz
-uz
+uD
 uz
 uz
 uz

--- a/mojave/code/modules/reagents/consumables/drinks.dm
+++ b/mojave/code/modules/reagents/consumables/drinks.dm
@@ -8,8 +8,28 @@
 	taste_description = "water"
 	glass_name = "glass of clear liquid"
 	glass_desc = "A clear liquid with no smell. Nothing out of the ordinary."
+	var/clean_types = CLEAN_WASH
 
-/datum/reagent/consumable/ms13/unfiltered_water
+/datum/reagent/consumable/ms13/water/expose_turf(turf/open/exposed_turf, reac_volume) // easiest paste of my life
+	. = ..()
+	if(!istype(exposed_turf))
+		return
+
+	if(reac_volume >= 5)
+		exposed_turf.MakeSlippery(TURF_WET_WATER, 10 SECONDS, min(reac_volume*1.5 SECONDS, 60 SECONDS))
+	exposed_turf.wash(clean_types)
+	
+	for(var/mob/living/simple_animal/slime/exposed_slime in exposed_turf)
+		exposed_slime.apply_water()
+
+	var/obj/effect/hotspot/hotspot = (locate(/obj/effect/hotspot) in exposed_turf)
+	if(hotspot && !isspaceturf(exposed_turf))
+		if(exposed_turf.air)
+			var/datum/gas_mixture/air = exposed_turf.air
+			air.react(src)
+			qdel(hotspot)
+
+/datum/reagent/consumable/ms13/water/unfiltered
 	name = "Unfiltered Water"
 	description = "Water... Questionable water. Should run it through some filtering or something."
 	color = "#d8d3cfa1"
@@ -17,7 +37,7 @@
 	glass_name = "glass of clear liquid"
 	glass_desc = "A clear liquid with some stray particles seen floating around peacefully inside."
 
-/datum/reagent/consumable/ms13/dirty_water
+/datum/reagent/consumable/ms13/water/dirty
 	name = "Dirty Water"
 	description = "An ubiquitous chemical substance that is composed of hydrogen and oxygen, this one is impure and toxic to drink."
 	color = "#4439288c"

--- a/mojave/flora/agriculture.dm
+++ b/mojave/flora/agriculture.dm
@@ -520,7 +520,7 @@
 			to_chat(user, span_warning("[reagent_source] is empty!"))
 			return 1
 
-		if(reagents.total_volume >= reagents.maximum_volume && (!reagent_source.reagents.has_reagent(/datum/reagent/consumable/ms13/water) || !reagent_source.reagents.has_reagent(/datum/reagent/consumable/ms13/unfiltered_water) || !reagent_source.reagents.has_reagent(/datum/reagent/consumable/ms13/dirty_water)))
+		if(reagents.total_volume >= reagents.maximum_volume && (!reagent_source.reagents.has_reagent(/datum/reagent/consumable/ms13/water) || !reagent_source.reagents.has_reagent(/datum/reagent/consumable/ms13/water/unfiltered) || !reagent_source.reagents.has_reagent(/datum/reagent/consumable/ms13/water/dirty)))
 			to_chat(user, span_notice("[src] is full."))
 			return
 
@@ -545,14 +545,14 @@
 				var/water_amt = reagent_source.reagents.get_reagent_amount(/datum/reagent/consumable/ms13/water) * transfer_amount / reagent_source.reagents.total_volume
 				H.adjust_waterlevel(round(water_amt))
 				reagent_source.reagents.remove_reagent(/datum/reagent/consumable/ms13/water, water_amt)
-			if(reagent_source.reagents.has_reagent(/datum/reagent/consumable/ms13/unfiltered_water, 1))
-				var/water_amt = reagent_source.reagents.get_reagent_amount(/datum/reagent/consumable/ms13/unfiltered_water) * transfer_amount / reagent_source.reagents.total_volume
+			if(reagent_source.reagents.has_reagent(/datum/reagent/consumable/ms13/water/unfiltered, 1))
+				var/water_amt = reagent_source.reagents.get_reagent_amount(/datum/reagent/consumable/ms13/water/unfiltered) * transfer_amount / reagent_source.reagents.total_volume
 				H.adjust_waterlevel(round(water_amt))
-				reagent_source.reagents.remove_reagent(/datum/reagent/consumable/ms13/unfiltered_water, water_amt)
-			if(reagent_source.reagents.has_reagent(/datum/reagent/consumable/ms13/dirty_water, 1))
-				var/water_amt = reagent_source.reagents.get_reagent_amount(/datum/reagent/consumable/ms13/dirty_water) * transfer_amount / reagent_source.reagents.total_volume
+				reagent_source.reagents.remove_reagent(/datum/reagent/consumable/ms13/water/unfiltered, water_amt)
+			if(reagent_source.reagents.has_reagent(/datum/reagent/consumable/ms13/water/dirty, 1))
+				var/water_amt = reagent_source.reagents.get_reagent_amount(/datum/reagent/consumable/ms13/water/dirty) * transfer_amount / reagent_source.reagents.total_volume
 				H.adjust_waterlevel(round(water_amt))
-				reagent_source.reagents.remove_reagent(/datum/reagent/consumable/ms13/dirty_water, water_amt)
+				reagent_source.reagents.remove_reagent(/datum/reagent/consumable/ms13/water/dirty, water_amt)
 			reagent_source.reagents.trans_to(H.reagents, transfer_amount, transfered_by = user)
 			lastuser = WEAKREF(user)
 			if(IS_EDIBLE(reagent_source) || istype(reagent_source, /obj/item/reagent_containers/pill))

--- a/mojave/items/clothing/neck/neck.dm
+++ b/mojave/items/clothing/neck/neck.dm
@@ -14,8 +14,8 @@
 	icon_state = "shawl"
 
 /obj/item/clothing/neck/cloak/ms13/baron
-	name = "white half cloak"
-	desc = "A fine white half cloak, worn by the Baron, typically. It's made of a fine textile, smooth to the touch."
+	name = "dark cape"
+	desc = "A rough cloth cape. It screams authority while retaining brutish roots."
 	icon_state = "baron_cape"
 
 /obj/item/clothing/neck/cloak/ms13/legion

--- a/mojave/structures/plumbing_decorations.dm
+++ b/mojave/structures/plumbing_decorations.dm
@@ -25,7 +25,7 @@
 	icon = 'mojave/icons/structure/miscellaneous.dmi'
 	icon_state = "sink"
 	desc = "An old sink, typically dispensing clean water. Hard to really tell if it's the case anymore, though."
-	dispensedreagent = /datum/reagent/consumable/ms13/unfiltered_water
+	dispensedreagent = /datum/reagent/consumable/ms13/water/unfiltered
 	buildstacktype = /obj/item/stack/sheet/ms13/ceramic
 	has_water_reclaimer = TRUE
 	reclaim_rate = 0.1

--- a/mojave/turfs/plating.dm
+++ b/mojave/turfs/plating.dm
@@ -618,7 +618,7 @@
 	layer = TURF_LAYER_WATER_BASE
 	slowdown = 0.5
 	// What type of water it'll give you when you fill a container from it.
-	var/dispensedreagent = /datum/reagent/consumable/ms13/unfiltered_water
+	var/dispensedreagent = /datum/reagent/consumable/ms13/water/unfiltered
 	var/next_splash = 1
 	var/atom/watereffect = /obj/effect/overlay/ms13/water/medium
 	var/atom/watertop = /obj/effect/overlay/ms13/water/top/medium

--- a/mojave/turfs/plating.dm
+++ b/mojave/turfs/plating.dm
@@ -121,7 +121,7 @@
 			border_icon = 'mojave/icons/turf/64x/drought_3_border.dmi'
 
 	add_overlay(image(border_icon, icon_state, TURF_LAYER_DESERT_BORDER, pixel_x = -16, pixel_y = -16))
-
+/*
 /turf/open/floor/plating/ms13/ground/desert/attackby(obj/item/W, mob/user, params)
 	. = ..()
 	if(!.)
@@ -150,7 +150,7 @@
 	new digResult(src, 5)
 	icon_state = "[icon_state]_dug"
 	dug = TRUE
-
+*/
 //Pass PlantForce for admin stuff I guess?
 /turf/open/floor/plating/ms13/ground/proc/plantGrass(Plantforce = FALSE)
 	var/Weight = 0


### PR DESCRIPTION
title. speedmerge

This PR now also changes the pathing of MS13 water in order to function better. Mops now work again