### PR TITLE
Drought post test tweaks

### DIFF
--- a/_maps/map_files/Drought/Drought.dmm
+++ b/_maps/map_files/Drought/Drought.dmm
@@ -123,6 +123,10 @@
 	},
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/factory)
+"ajL" = (
+/obj/effect/spawner/random/ms13/food/trash,
+/turf/open/floor/ms13/tile/large/cafeteria,
+/area/ms13/town)
 "ajW" = (
 /obj/structure/ms13/barricade{
 	dir = 1
@@ -949,6 +953,13 @@
 "blm" = (
 /turf/closed/indestructible/rock/ms13/drought,
 /area/ms13/underground/mountain)
+"blq" = (
+/obj/structure/ms13/storage/shelf/wood/alt{
+	dir = 8
+	},
+/obj/effect/spawner/random/ms13/tools/lights,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/town)
 "bmF" = (
 /obj/machinery/door/unpowered/ms13/metal,
 /obj/machinery/door/poddoor/shutters/ms13/horizontal/red/solo/pre_open{
@@ -2101,6 +2112,7 @@
 "cIx" = (
 /obj/structure/table/ms13/wood,
 /obj/structure/ms13/wall_decor/flag/arizona,
+/obj/effect/spawner/random/ms13/tools/lights,
 /turf/open/floor/wood/ms13/common,
 /area/ms13/town)
 "cII" = (
@@ -2363,6 +2375,10 @@
 	},
 /turf/open/floor/plating/ms13/ground/road,
 /area/ms13/desert)
+"ddU" = (
+/obj/effect/spawner/random/ms13/food/trash,
+/turf/open/floor/plating/ms13/ground/sidewalk,
+/area/ms13/water_baron)
 "dec" = (
 /obj/structure/ms13/toilet,
 /turf/open/floor/ms13/concrete,
@@ -2482,6 +2498,7 @@
 /area/ms13/town)
 "diI" = (
 /obj/structure/table/ms13/no_smooth/cable_reel,
+/obj/effect/spawner/random/ms13/crafting/lowrandom,
 /turf/open/floor/plating/ms13/ground/desert,
 /area/ms13/desert)
 "diO" = (
@@ -2663,7 +2680,7 @@
 /area/ms13/town)
 "dqZ" = (
 /obj/structure/table/ms13/no_smooth/counter/metal,
-/obj/effect/spawner/random/ms13/crafting/lowrandom,
+/obj/effect/spawner/random/ms13/tools/lights,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "drc" = (
@@ -2984,6 +3001,7 @@
 /area/ms13/legioncamp/building)
 "dQt" = (
 /obj/structure/ms13/storage/store/metal,
+/obj/effect/spawner/random/ms13/tools/lights,
 /turf/open/floor/ms13/concrete,
 /area/ms13/town)
 "dQI" = (
@@ -3560,6 +3578,7 @@
 "eGP" = (
 /obj/structure/closet/ms13/metal,
 /obj/effect/spawner/random/ms13/medical/lowrandom,
+/obj/effect/spawner/random/ms13/tools/lights,
 /turf/open/floor/ms13/concrete,
 /area/ms13/town)
 "eHk" = (
@@ -3946,6 +3965,12 @@
 /obj/structure/ms13/road_barrier/concrete,
 /turf/open/floor/ms13/concrete,
 /area/ms13/desert)
+"fgc" = (
+/obj/structure/chair/ms13/overlaypickup/plastic{
+	dir = 8
+	},
+/turf/open/floor/plating/ms13/ground/desert,
+/area/ms13/desert)
 "fge" = (
 /obj/effect/landmark/start/ms13/ranger_recruit,
 /turf/open/floor/plating/ms13/ground/desertalt,
@@ -4224,6 +4249,10 @@
 /obj/effect/spawner/random/ms13/medical/bloodbag,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
+"fFJ" = (
+/obj/structure/bonfire/ms13/fire_barrel,
+/turf/open/floor/plating/ms13/ground/desert,
+/area/ms13/desert)
 "fGh" = (
 /obj/structure/table/ms13/low_wall/siding,
 /obj/structure/window/fulltile/ms13/glass,
@@ -4784,6 +4813,10 @@
 /obj/item/pen/ms13,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
+"gjl" = (
+/obj/structure/bed/ms13/bedframe/wood,
+/turf/open/floor/plating/ms13/ground/desert,
+/area/ms13/desert)
 "gjm" = (
 /obj/structure/ms13/storage/large/shelf/wood{
 	dir = 8
@@ -5028,8 +5061,7 @@
 /area/ms13/town)
 "gxf" = (
 /obj/structure/closet/crate/ms13/footlocker{
-	dir = 8;
-	pixel_x = 8
+	dir = 8
 	},
 /obj/item/clothing/under/ms13/legion/fatigues,
 /obj/effect/spawner/random/ms13/melee/lowrandom,
@@ -5790,6 +5822,11 @@
 /obj/structure/ms13/rug/rubber,
 /turf/open/floor/ms13/concrete/bricks,
 /area/ms13/water_baron/interior)
+"hCl" = (
+/obj/structure/table/ms13/metal/grate,
+/obj/effect/spawner/random/ms13/tools/lights,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/town)
 "hDb" = (
 /turf/open/floor/wood/ms13/carpet/shaggy/green,
 /area/ms13/town)
@@ -5936,6 +5973,10 @@
 /obj/effect/spawner/random/ms13/tools/tool,
 /turf/open/floor/wood/ms13/common,
 /area/ms13/town)
+"hMs" = (
+/obj/effect/spawner/random/ms13/food/trash,
+/turf/open/floor/plating/ms13/ground/sidewalk,
+/area/ms13/desert)
 "hMw" = (
 /obj/structure/bed/ms13/mattress/stale,
 /turf/open/floor/wood/ms13/carpet/shaggy/green,
@@ -6175,6 +6216,12 @@
 	},
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
+"iaS" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 10
+	},
+/turf/open/floor/plating/ms13/ground/desert,
+/area/ms13/desert)
 "iaV" = (
 /obj/structure/fluff/ms13/barrel/double/red/one,
 /turf/open/floor/plating/ms13/ground/desert,
@@ -6269,6 +6316,10 @@
 /obj/effect/spawner/random/ms13/crafting/lowrandom,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/factory)
+"ihN" = (
+/obj/effect/spawner/random/ms13/food/trash,
+/turf/open/floor/plating/ms13/ground/sidewalk,
+/area/ms13/town)
 "ihP" = (
 /obj/structure/table/ms13/low_wall/concrete,
 /obj/structure/window/reinforced/fulltile/ms13/glass,
@@ -6927,6 +6978,10 @@
 	},
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
+"jeX" = (
+/obj/effect/spawner/random/ms13/food/trash,
+/turf/open/floor/wood/ms13/carpet/shaggy/green,
+/area/ms13/town)
 "jgu" = (
 /mob/living/basic/ms13/hostile_animal/radroach,
 /turf/open/floor/ms13/tile/long,
@@ -7027,6 +7082,11 @@
 	},
 /turf/open/floor/plating/ms13/ground/desertalt,
 /area/ms13/desert)
+"jlu" = (
+/obj/structure/closet/ms13/metal,
+/obj/effect/spawner/random/ms13/tools/lights,
+/turf/open/floor/ms13/concrete,
+/area/ms13/town)
 "jlR" = (
 /obj/structure/chair/ms13/overlaypickup/plastic{
 	dir = 1
@@ -7167,6 +7227,10 @@
 /obj/item/pen/ms13,
 /turf/open/floor/wood/ms13/carpet/shaggy/blue,
 /area/ms13/town)
+"jyd" = (
+/obj/effect/spawner/random/ms13/tools/hardware,
+/turf/open/floor/plating/ms13/ground/desert,
+/area/ms13/desert)
 "jyQ" = (
 /obj/structure/ms13/vehicle_ruin,
 /turf/open/floor/plating/ms13/ground/desert,
@@ -7338,7 +7402,7 @@
 /obj/structure/table/ms13/no_smooth/counter/metal/bend{
 	dir = 1
 	},
-/obj/effect/spawner/random/ms13/guaranteed/crafting/lowrandom,
+/obj/effect/spawner/random/ms13/tools/lights,
 /turf/open/floor/ms13/concrete,
 /area/ms13/town)
 "jGW" = (
@@ -7638,8 +7702,13 @@
 "kgm" = (
 /obj/structure/table/ms13/metal/heavy,
 /obj/effect/spawner/random/ms13/gun/lowunique,
+/obj/effect/spawner/random/ms13/ammo/lowrandom,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
+"kgF" = (
+/obj/effect/spawner/random/ms13/crafting/highrandom,
+/turf/open/floor/plating/ms13/ground/desert,
+/area/ms13/desert)
 "kgR" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/plating/ms13/ground/desertalt,
@@ -7666,6 +7735,10 @@
 	},
 /turf/open/floor/ms13/concrete,
 /area/ms13/rangeroutpost/building)
+"kiY" = (
+/obj/effect/spawner/random/ms13/tools/lights,
+/turf/open/floor/plating/ms13/ground/road,
+/area/ms13/desert)
 "kjr" = (
 /obj/effect/turf_decal/trimline/yellow/line{
 	dir = 9
@@ -7975,8 +8048,7 @@
 /area/ms13/factory)
 "kCZ" = (
 /obj/structure/closet/crate/ms13/footlocker{
-	dir = 8;
-	pixel_x = 8
+	dir = 8
 	},
 /obj/effect/spawner/random/ms13/gun/lowrandom,
 /obj/effect/spawner/random/ms13/clothing/under,
@@ -8298,6 +8370,11 @@
 	},
 /turf/open/floor/ms13/concrete,
 /area/ms13/legioncamp)
+"kUX" = (
+/obj/structure/bed/ms13/sleepingbag/green,
+/obj/effect/spawner/random/ms13/currency/drought/lowrandom,
+/turf/open/floor/plating/ms13/ground/desert,
+/area/ms13/desert)
 "kVj" = (
 /obj/structure/ms13/fence/wire,
 /turf/open/floor/plating/ms13/ground/desertalt,
@@ -8895,6 +8972,10 @@
 /obj/effect/spawner/random/ms13/food/random,
 /turf/open/floor/wood/ms13/carpet/shaggy/blue,
 /area/ms13/town)
+"lHf" = (
+/obj/effect/spawner/random/ms13/tools/tool,
+/turf/open/floor/plating/ms13/ground/desert,
+/area/ms13/desert)
 "lHw" = (
 /obj/machinery/door/unpowered/ms13/metal/red{
 	dir = 1
@@ -9041,6 +9122,11 @@
 	},
 /turf/open/floor/ms13/tile/blue/long,
 /area/ms13/town)
+"lPk" = (
+/obj/effect/mob_spawn/corpse/human/ms13/nomad,
+/obj/effect/decal/cleanable/blood/splatter,
+/turf/open/floor/plating/ms13/ground/desert,
+/area/ms13/desert)
 "lPu" = (
 /obj/structure/ms13/storage/vent,
 /turf/open/floor/ms13/metal/grate/border/warning{
@@ -9889,8 +9975,7 @@
 /area/ms13/town)
 "ncd" = (
 /obj/structure/closet/crate/ms13/footlocker{
-	dir = 8;
-	pixel_x = 8
+	dir = 8
 	},
 /obj/effect/spawner/random/ms13/gun/lowrandom,
 /obj/effect/spawner/random/ms13/clothing/under,
@@ -10065,6 +10150,7 @@
 	},
 /obj/effect/spawner/random/ms13/crafting/lowrandom,
 /obj/effect/spawner/random/ms13/crafting/lowrandom,
+/obj/effect/spawner/random/ms13/guaranteed/crafting/lowrandom,
 /turf/open/floor/ms13/concrete,
 /area/ms13/town)
 "nnV" = (
@@ -10128,6 +10214,10 @@
 /obj/machinery/door/unpowered/ms13/metal,
 /turf/open/floor/ms13/tile/blue/long,
 /area/ms13/town)
+"nqz" = (
+/obj/effect/mob_spawn/corpse/human/ms13/nomad,
+/turf/open/floor/plating/ms13/ground/desert,
+/area/ms13/desert)
 "nqB" = (
 /obj/structure/table/ms13/low_wall/scrap/blue,
 /obj/structure/ms13/barricade{
@@ -10191,6 +10281,13 @@
 "nvU" = (
 /turf/open/floor/ms13/tile/large/black,
 /area/ms13/town)
+"nvY" = (
+/obj/structure/closet/crate/ms13/footlocker,
+/obj/effect/spawner/random/ms13/armor/lowrandom,
+/obj/effect/spawner/random/ms13/currency/drought/lowrandom,
+/obj/effect/spawner/random/ms13/ammo/lowrandom,
+/turf/open/floor/plating/ms13/ground/desert,
+/area/ms13/desert)
 "nwC" = (
 /obj/structure/ms13/storage/bookshelf,
 /turf/open/floor/wood/ms13/carpet/shaggy/blue,
@@ -10521,6 +10618,10 @@
 /obj/structure/table/ms13/wood/bar,
 /turf/open/floor/ms13/tile/large/cafeteria,
 /area/ms13/town)
+"nQT" = (
+/obj/effect/spawner/random/ms13/food/trash,
+/turf/open/floor/plating/ms13/ground/road,
+/area/ms13/desert)
 "nQZ" = (
 /obj/structure/table/ms13/no_smooth/counter/wood,
 /turf/open/floor/ms13/tile/fancy,
@@ -10719,6 +10820,14 @@
 /obj/effect/turf_decal/ms13/graffiti/camp_east,
 /turf/closed/wall/ms13/siding,
 /area/ms13/town)
+"oeG" = (
+/obj/effect/mob_spawn/corpse/human/ms13/nomad,
+/obj/effect/decal/cleanable/blood/splatter{
+	pixel_x = 5;
+	pixel_y = 6
+	},
+/turf/open/floor/plating/ms13/ground/desert,
+/area/ms13/desert)
 "ofI" = (
 /obj/structure/ms13/rug/rubber{
 	dir = 4
@@ -10735,6 +10844,10 @@
 	},
 /obj/effect/spawner/random/ms13/melee/lowrandom,
 /turf/open/floor/plating/ms13/ground/desertalt,
+/area/ms13/desert)
+"ogQ" = (
+/obj/effect/spawner/random/ms13/guaranteed/tools/tool,
+/turf/open/floor/plating/ms13/ground/desert,
 /area/ms13/desert)
 "ogS" = (
 /obj/structure/ms13/storage/bookshelf{
@@ -10978,6 +11091,10 @@
 	},
 /turf/open/floor/ms13/concrete,
 /area/ms13/town)
+"oyL" = (
+/obj/effect/spawner/random/ms13/food/trash,
+/turf/open/floor/plating/ms13/ground/desert,
+/area/ms13/water_baron)
 "oza" = (
 /obj/structure/chair/comfy/ms13/armchair,
 /turf/open/floor/wood/ms13/carpet/shaggy/green,
@@ -11259,6 +11376,8 @@
 /area/ms13/town)
 "oOD" = (
 /obj/structure/closet/crate/ms13/woodcrate,
+/obj/effect/spawner/random/ms13/crafting/lowrandom,
+/obj/effect/spawner/random/ms13/crafting/lowrandom,
 /turf/open/floor/plating/ms13/ground/mountain/drought,
 /area/ms13/underground/mountain)
 "oPc" = (
@@ -11537,6 +11656,10 @@
 /obj/effect/spawner/random/ms13/drink/soda,
 /turf/open/floor/ms13/tile/large/cafeteria,
 /area/ms13/town)
+"pfl" = (
+/obj/effect/spawner/random/ms13/tools/lights,
+/turf/open/floor/plating/ms13/ground/desert,
+/area/ms13/desert)
 "pfK" = (
 /obj/structure/closet/ms13/fridge,
 /obj/effect/spawner/random/ms13/food/random,
@@ -12456,6 +12579,12 @@
 	},
 /turf/open/floor/ms13/tile/long,
 /area/ms13/factory)
+"qpL" = (
+/obj/effect/spawner/random/ms13/melee/lowrandom,
+/obj/structure/bed/ms13/sleepingbag/green,
+/obj/structure/ms13/skeleton,
+/turf/open/floor/plating/ms13/ground/desert,
+/area/ms13/desert)
 "qqo" = (
 /obj/structure/table/ms13/metal/heavy,
 /obj/machinery/ms13/terminal/rusty{
@@ -12524,6 +12653,7 @@
 	dir = 4
 	},
 /obj/structure/table/ms13/no_smooth/metal,
+/obj/effect/spawner/random/ms13/drink/alcohol_beer,
 /turf/open/floor/ms13/concrete,
 /area/ms13/desert)
 "quv" = (
@@ -12706,8 +12836,8 @@
 /area/ms13/town)
 "qCa" = (
 /obj/effect/turf_decal/ms13/road/verticalline,
-/obj/effect/ai_node,
 /obj/effect/landmark/observer_start,
+/obj/effect/ai_node/wait,
 /turf/open/floor/plating/ms13/ground/road,
 /area/ms13/desert)
 "qCr" = (
@@ -12768,6 +12898,7 @@
 "qFT" = (
 /obj/structure/closet/crate/ms13/red,
 /obj/effect/spawner/random/ms13/armor/lowrandom,
+/obj/effect/spawner/random/ms13/tools/lights,
 /turf/open/floor/plating/ms13/ground/desertalt,
 /area/ms13/desert)
 "qFU" = (
@@ -13406,6 +13537,10 @@
 	},
 /turf/open/floor/plating/ms13/ground/mountain/drought,
 /area/ms13/town)
+"ruz" = (
+/obj/effect/spawner/random/ms13/crafting/lowrandom,
+/turf/open/floor/plating/ms13/ground/desert,
+/area/ms13/desert)
 "ruK" = (
 /obj/structure/table/ms13/no_smooth/counter/metal{
 	dir = 4
@@ -13481,6 +13616,10 @@
 /obj/effect/turf_decal/ms13/covering/paint/green,
 /turf/closed/wall/ms13/scrap/red,
 /area/ms13/town)
+"ryC" = (
+/obj/effect/spawner/random/ms13/melee/lowrandom,
+/turf/open/floor/plating/ms13/ground/desert,
+/area/ms13/desert)
 "rzo" = (
 /obj/machinery/light/ms13/bulb{
 	dir = 1
@@ -13994,6 +14133,10 @@
 /obj/structure/bed/ms13/mattress/stained,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
+"sgN" = (
+/obj/effect/spawner/random/ms13/currency/drought/lowrandom,
+/turf/open/floor/plating/ms13/ground/sidewalk,
+/area/ms13/desert)
 "shU" = (
 /obj/structure/table/ms13/no_smooth/counter/wood/crafted{
 	dir = 4
@@ -14279,6 +14422,10 @@
 /obj/machinery/light/ms13/bulb,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
+"sDy" = (
+/obj/effect/spawner/random/ms13/tools/radio,
+/turf/open/floor/plating/ms13/ground/desert,
+/area/ms13/desert)
 "sEa" = (
 /obj/effect/spawner/random/ms13/crafting/electrical,
 /turf/open/floor/wood/ms13/wide,
@@ -14368,6 +14515,10 @@
 	},
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
+"sJV" = (
+/obj/effect/spawner/random/ms13/food/trash,
+/turf/open/floor/wood/ms13/mosaic,
+/area/ms13/town)
 "sKa" = (
 /obj/structure/table/ms13/no_smooth/counter/wood/crafted,
 /obj/structure/ms13/wall_decor/clock{
@@ -14446,6 +14597,13 @@
 /obj/effect/spawner/random/ms13/tools/tool,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
+"sQB" = (
+/obj/effect/decal/cleanable/blood/splatter{
+	pixel_x = 10;
+	pixel_y = 4
+	},
+/turf/open/floor/plating/ms13/ground/desert,
+/area/ms13/desert)
 "sQG" = (
 /obj/structure/ms13/pipes/horizontal,
 /turf/open/floor/ms13/concrete/industrial,
@@ -14860,6 +15018,10 @@
 /obj/structure/dresser/ms13/torquise,
 /turf/open/floor/wood/ms13/carpet/shaggy/blue,
 /area/ms13/town)
+"tmQ" = (
+/mob/living/basic/ms13/ghoul/radioactive,
+/turf/open/floor/plating/ms13/ground/desertalt,
+/area/ms13/desert)
 "tmW" = (
 /obj/structure/table/ms13/no_smooth/counter/wood/crafted{
 	dir = 1
@@ -14995,8 +15157,7 @@
 /area/ms13/town)
 "txJ" = (
 /obj/structure/closet/crate/ms13/footlocker{
-	dir = 8;
-	pixel_x = 8
+	dir = 8
 	},
 /obj/effect/spawner/random/ms13/currency/drought/legion/lowrandom,
 /obj/item/clothing/under/ms13/legion/fatigues,
@@ -15457,6 +15618,13 @@
 /obj/effect/spawner/random/ms13/locked/guaranteed/random,
 /turf/open/floor/ms13/tile/full/navy,
 /area/ms13/town)
+"tXk" = (
+/obj/structure/chair/ms13/metal/broken{
+	dir = 4
+	},
+/obj/effect/spawner/random/ms13/gun/lowrandom,
+/turf/open/floor/plating/ms13/ground/desert,
+/area/ms13/desert)
 "tXT" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 4
@@ -15539,6 +15707,7 @@
 /area/ms13/desert)
 "udk" = (
 /obj/structure/table/ms13/wood/constructed/cobbled,
+/obj/effect/spawner/random/ms13/drugs/lowrandom,
 /turf/open/floor/wood/ms13/mosaic,
 /area/ms13/town)
 "udP" = (
@@ -15965,6 +16134,13 @@
 	},
 /turf/open/floor/ms13/concrete,
 /area/ms13/water_baron/interior)
+"uJX" = (
+/obj/effect/decal/cleanable/blood/splatter{
+	pixel_x = 5;
+	pixel_y = 6
+	},
+/turf/open/floor/plating/ms13/ground/desert,
+/area/ms13/desert)
 "uKh" = (
 /obj/structure/ms13/pipes/horizontal/random,
 /turf/open/floor/ms13/concrete,
@@ -16143,6 +16319,10 @@
 /obj/effect/spawner/random/ms13/guaranteed/crafting/electrical,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
+"uRM" = (
+/obj/effect/decal/cleanable/blood/tracks,
+/turf/open/floor/plating/ms13/ground/desert,
+/area/ms13/desert)
 "uSJ" = (
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/ms13/tile/large/cream,
@@ -16261,6 +16441,11 @@
 /obj/structure/ms13/wall_decor/clock,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/factory)
+"uZV" = (
+/obj/structure/table/ms13/metal/grate,
+/obj/effect/spawner/random/ms13/tools/radio,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/town)
 "uZW" = (
 /obj/machinery/ms13/fusion_generator,
 /turf/open/floor/ms13/concrete,
@@ -16920,6 +17105,13 @@
 	},
 /turf/open/floor/ms13/concrete,
 /area/ms13/water_baron/interior)
+"vQw" = (
+/obj/effect/decal/cleanable/blood/splatter{
+	pixel_x = 9;
+	pixel_y = -14
+	},
+/turf/open/floor/plating/ms13/ground/desert,
+/area/ms13/desert)
 "vQM" = (
 /mob/living/basic/ms13/robot/handy/saw,
 /turf/open/floor/ms13/tile/large/cream,
@@ -17149,6 +17341,11 @@
 /obj/item/ms13_small_flag/usa,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
+"wfn" = (
+/obj/structure/ms13/skeleton,
+/obj/effect/spawner/random/ms13/tools/tool,
+/turf/open/floor/plating/ms13/ground/desert,
+/area/ms13/desert)
 "wgj" = (
 /obj/effect/landmark/start/ms13/nomad,
 /turf/open/floor/plating/ms13/ground/desert,
@@ -17535,6 +17732,7 @@
 /area/ms13/underground/mountain)
 "wKx" = (
 /obj/effect/decal/cleanable/blood/drip,
+/obj/effect/spawner/random/ms13/food/trash,
 /turf/open/floor/plating/ms13/ground/desert,
 /area/ms13/water_baron)
 "wLF" = (
@@ -17549,6 +17747,10 @@
 /obj/structure/bed/ms13/mattress/old,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
+"wMm" = (
+/obj/effect/spawner/random/ms13/food/trash,
+/turf/open/floor/plating/ms13/ground/road,
+/area/ms13/water_baron)
 "wNR" = (
 /obj/machinery/door/unpowered/ms13/wood/red{
 	dir = 8
@@ -17917,8 +18119,7 @@
 /area/ms13/rangeroutpost/building)
 "xhY" = (
 /obj/structure/closet/crate/ms13/footlocker{
-	dir = 8;
-	pixel_x = 8
+	dir = 8
 	},
 /obj/effect/spawner/random/ms13/gun/lowrandom,
 /obj/effect/spawner/random/ms13/clothing/under,
@@ -18007,11 +18208,14 @@
 /obj/structure/ms13/lamp/mining_lamp{
 	pixel_y = 30
 	},
-/obj/effect/spawner/random/ms13/crafting/lowrandom,
+/obj/effect/spawner/random/ms13/tools/lights,
+/obj/effect/spawner/random/ms13/tools/lights,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "xrK" = (
 /obj/structure/closet/crate/ms13/woodcrate,
+/obj/effect/spawner/random/ms13/tools/lights,
+/obj/effect/spawner/random/ms13/tools/tool,
 /turf/open/floor/wood/ms13/mosaic,
 /area/ms13/town)
 "xrP" = (
@@ -18591,6 +18795,15 @@
 /obj/structure/ms13/rug/rubber,
 /turf/open/floor/ms13/tile/blue,
 /area/ms13/water_baron/interior)
+"yll" = (
+/obj/structure/closet/crate/ms13/footlocker{
+	dir = 8
+	},
+/obj/effect/spawner/random/ms13/guaranteed/crafting/precious,
+/obj/effect/spawner/random/ms13/crafting/precious,
+/obj/effect/spawner/random/ms13/crafting/precious,
+/turf/open/floor/plating/ms13/ground/desert,
+/area/ms13/desert)
 "ylK" = (
 /obj/structure/table/ms13/no_smooth/metal,
 /turf/open/floor/wood/ms13/wide,
@@ -19537,7 +19750,7 @@ oSs
 oSs
 oSs
 oSs
-oSs
+qpL
 oSs
 oSs
 oSs
@@ -19941,8 +20154,8 @@ oSs
 oSs
 oSs
 oSs
-oSs
-oSs
+yeX
+jlR
 oSs
 oSs
 oSs
@@ -20917,7 +21130,7 @@ umP
 cqc
 jxH
 rFN
-hgp
+wIw
 hgp
 hgp
 hgp
@@ -21549,7 +21762,7 @@ oSs
 oSs
 oSs
 oSs
-oSs
+wDd
 oSs
 oSs
 oSs
@@ -23138,7 +23351,7 @@ oSs
 oSs
 oSs
 oSs
-oSs
+moW
 hgp
 hgp
 hgp
@@ -28395,7 +28608,7 @@ jAt
 jAt
 gnk
 gnk
-gnk
+wMm
 jAt
 jAt
 jAt
@@ -29624,10 +29837,10 @@ oSs
 oSs
 oSs
 oSs
-oSs
-oSs
-oSs
-oSs
+gwb
+gwb
+gwb
+gwb
 oSs
 oSs
 oSs
@@ -29826,10 +30039,10 @@ oSs
 oSs
 oSs
 oSs
+gwb
+gjl
 oSs
-oSs
-oSs
-oSs
+pfl
 oSs
 oSs
 oSs
@@ -30028,9 +30241,9 @@ oSs
 oSs
 oSs
 oSs
-oSs
-oSs
-oSs
+gwb
+nvY
+fFJ
 oSs
 oSs
 oSs
@@ -30230,9 +30443,9 @@ oSs
 oSs
 oSs
 oSs
-oSs
-oSs
-oSs
+gwb
+gjl
+nqz
 oSs
 oSs
 oSs
@@ -30432,10 +30645,10 @@ oSs
 oSs
 oSs
 oSs
-oSs
-oSs
-oSs
-oSs
+gwb
+gwb
+gwb
+gwb
 oSs
 oSs
 oSs
@@ -31423,7 +31636,7 @@ aKh
 qSd
 wcq
 jAt
-gnk
+wMm
 jGl
 gnk
 jAt
@@ -31975,7 +32188,7 @@ oSs
 oSs
 oSs
 kVL
-ouh
+jlu
 ylS
 ylS
 ylS
@@ -33793,7 +34006,7 @@ oSs
 oSs
 hgp
 kVL
-ouh
+jlu
 ylS
 ylS
 ylS
@@ -34511,7 +34724,7 @@ ilf
 ilf
 wIP
 wIP
-jJD
+hMs
 hQa
 wHx
 hQa
@@ -35849,7 +36062,7 @@ aKJ
 kME
 aKJ
 vYq
-jAt
+oyL
 aKh
 aKh
 ctp
@@ -36680,7 +36893,7 @@ jGl
 gnk
 oMv
 jAt
-jAt
+oyL
 jAt
 wIP
 wIP
@@ -36947,7 +37160,7 @@ wIP
 wIP
 wIP
 wIP
-jJD
+hMs
 hQa
 hQa
 hQa
@@ -37074,7 +37287,7 @@ jAt
 jAt
 oTd
 jAt
-jAt
+oyL
 uaL
 wuf
 jAt
@@ -38086,7 +38299,7 @@ jAt
 cVn
 jAt
 jAt
-jAt
+oyL
 jAt
 aKh
 gnk
@@ -39305,7 +39518,7 @@ gnk
 gnk
 gnk
 oMv
-oMv
+ddU
 oMv
 oMv
 oMv
@@ -39996,7 +40209,7 @@ jJD
 jJD
 ckW
 jJD
-jJD
+hMs
 jJD
 jJD
 bNs
@@ -40536,7 +40749,7 @@ hQa
 jJD
 xwt
 uMw
-uAb
+sJV
 rtE
 uAb
 uAb
@@ -41962,7 +42175,7 @@ eyk
 abv
 cXR
 tFN
-jJD
+sgN
 jJD
 jJD
 bSz
@@ -42571,7 +42784,7 @@ tMN
 xCY
 bvh
 lsn
-oSs
+ryC
 oSs
 oSs
 oSs
@@ -42762,7 +42975,7 @@ uAb
 uAb
 mMR
 uAb
-uAb
+sJV
 uAb
 tsz
 uDP
@@ -42773,10 +42986,10 @@ mTU
 gWr
 vTg
 qiT
-oSs
-oSs
-oSs
-oSs
+uRM
+uRM
+uRM
+iaS
 oSs
 oSs
 oSs
@@ -42978,7 +43191,7 @@ cXR
 oSs
 oSs
 oSs
-oSs
+lPk
 oSs
 oSs
 oSs
@@ -43381,10 +43594,10 @@ oSs
 oSs
 oSs
 oSs
+cuI
+sDy
 oSs
-oSs
-oSs
-oSs
+cvP
 oSs
 oSs
 oSs
@@ -43405,7 +43618,7 @@ hQa
 hQa
 hQa
 hQa
-hQa
+nQT
 hQa
 hQa
 hQa
@@ -43584,9 +43797,9 @@ oSs
 oSs
 oSs
 oSs
+yeX
 oSs
-oSs
-oSs
+cvP
 oSs
 oSs
 oSs
@@ -43785,10 +43998,10 @@ oSs
 oSs
 oSs
 oSs
+pfl
 oSs
-oSs
-oSs
-oSs
+tXk
+cvP
 oSs
 oSs
 oSs
@@ -43987,10 +44200,10 @@ oSs
 oSs
 oSs
 oSs
-oSs
-oSs
-oSs
-oSs
+cvP
+cvP
+cvP
+cvP
 oSs
 oSs
 oSs
@@ -44435,7 +44648,7 @@ oSs
 oSs
 oSs
 hgp
-hgp
+wIw
 hgp
 hgp
 hgp
@@ -45567,7 +45780,7 @@ oSs
 oSs
 oSs
 ggZ
-crx
+iOX
 gov
 ewu
 crx
@@ -46030,7 +46243,7 @@ hQa
 oSs
 oSs
 hgp
-hgp
+wIw
 qsf
 cvP
 hQa
@@ -46476,7 +46689,7 @@ jUa
 tmC
 tmC
 iNr
-oSs
+ruz
 hgp
 oSs
 blm
@@ -46870,7 +47083,7 @@ oSs
 oSs
 hgp
 hgp
-hgp
+wIw
 hgp
 qgL
 iNr
@@ -47028,9 +47241,9 @@ iNR
 puZ
 oSs
 kBh
-oSs
+ogQ
 aar
-jJD
+hMs
 jJD
 hQa
 hQa
@@ -47082,7 +47295,7 @@ pDY
 tmC
 miY
 iNr
-oSs
+ruz
 hgp
 blm
 blm
@@ -47220,14 +47433,14 @@ oSs
 oSs
 oSs
 hgp
-hgp
+ktX
 hgp
 oSs
 oSs
 oSs
 oSs
 iNR
-oSs
+ruz
 oSs
 hgp
 hgp
@@ -47261,7 +47474,7 @@ oSs
 oSs
 oSs
 qgL
-hgp
+pPd
 hgp
 aJA
 hgp
@@ -47276,7 +47489,7 @@ hgp
 oSs
 oSs
 oSs
-oSs
+ruz
 iNr
 tmC
 tmC
@@ -47569,7 +47782,7 @@ hQa
 wHx
 hQa
 jJD
-jJD
+hMs
 jJD
 jJD
 jJD
@@ -47607,7 +47820,7 @@ jJD
 oSs
 euF
 nFb
-oSs
+lHf
 bwL
 cXR
 kST
@@ -47632,9 +47845,9 @@ oSs
 oSs
 iNR
 oSs
-hgp
+pPd
 kyd
-hgp
+tmQ
 hgp
 oSs
 oSs
@@ -48035,7 +48248,7 @@ oSs
 oSs
 oSs
 iNR
-oSs
+kgF
 hgp
 hgp
 hgp
@@ -48227,11 +48440,11 @@ iWz
 cXR
 oSs
 oSs
-oSs
-oSs
-oSs
-oSs
 lFz
+oSs
+oSs
+oSs
+oSs
 oSs
 oSs
 oSs
@@ -48481,7 +48694,7 @@ wIP
 wIP
 oSs
 oSs
-oSs
+wDd
 oSs
 oSs
 oSs
@@ -48536,7 +48749,7 @@ tPj
 tPj
 fML
 crx
-crx
+iOX
 lQg
 sZC
 fML
@@ -50704,13 +50917,13 @@ oSs
 oSs
 oSs
 oSs
+wDd
 oSs
 oSs
 oSs
 oSs
 oSs
-oSs
-oSs
+dRM
 oSs
 oSs
 oSs
@@ -50829,7 +51042,7 @@ fcN
 hop
 cXR
 cgf
-hQa
+kiY
 wxU
 hQa
 jJD
@@ -50913,7 +51126,7 @@ oSs
 oSs
 oSs
 oSs
-oSs
+wfn
 oSs
 oSs
 oSs
@@ -51050,7 +51263,7 @@ jJD
 oSs
 quS
 uKm
-hDb
+jeX
 hDb
 hDb
 vNq
@@ -51100,7 +51313,7 @@ oSs
 oSs
 oSs
 oSs
-oSs
+dfe
 oSs
 oSs
 oSs
@@ -51115,7 +51328,7 @@ oSs
 oSs
 oSs
 oSs
-oSs
+jyd
 oSs
 oSs
 oSs
@@ -51242,7 +51455,7 @@ fYk
 wFS
 eaj
 cKM
-cKM
+ajL
 uUq
 cXR
 cXR
@@ -52029,7 +52242,7 @@ cXR
 cXR
 cXR
 cXR
-bKj
+cXR
 oSs
 jVU
 fVt
@@ -52078,11 +52291,11 @@ oSs
 oSs
 oSs
 oSs
-oSs
-oSs
-oSs
-oSs
 lFz
+oSs
+oSs
+oSs
+oSs
 oSs
 oSs
 oSs
@@ -52231,7 +52444,7 @@ kqA
 wjc
 wjc
 vZq
-bKj
+cXR
 oSs
 kxG
 kKJ
@@ -52249,7 +52462,7 @@ hQa
 jJD
 fYk
 jAu
-uui
+hCl
 cXR
 fYk
 lxa
@@ -52282,7 +52495,7 @@ oSs
 oSs
 oSs
 oSs
-oSs
+oeG
 oSs
 oSs
 oSs
@@ -52433,7 +52646,7 @@ vZq
 vZq
 vZq
 pAv
-bKj
+cXR
 oSs
 jVU
 crx
@@ -52450,7 +52663,7 @@ wHx
 hQa
 jJD
 fYk
-uui
+uZV
 crx
 crx
 bEx
@@ -52483,7 +52696,7 @@ oSs
 oSs
 oSs
 oSs
-oSs
+sQB
 oSs
 oSs
 oSs
@@ -52635,7 +52848,7 @@ sXQ
 vZq
 vZq
 vZq
-bKj
+cXR
 oSs
 cXR
 cXR
@@ -52684,7 +52897,7 @@ oSs
 oSs
 oSs
 oSs
-oSs
+uJX
 oSs
 oSs
 oSs
@@ -52837,7 +53050,7 @@ cXR
 cXR
 cXR
 cXR
-bKj
+cXR
 oSs
 jAm
 cXR
@@ -52931,7 +53144,7 @@ blm
 oSs
 oSs
 oSs
-oSs
+byK
 oSs
 oSs
 oSs
@@ -53242,7 +53455,7 @@ hgp
 hgp
 oqM
 hgp
-pVf
+snA
 ftS
 cXR
 cXR
@@ -53335,7 +53548,7 @@ oSs
 oSs
 oSs
 oSs
-oSs
+dfe
 oSs
 oSs
 oSs
@@ -53643,7 +53856,7 @@ cXR
 cXR
 cXR
 bWX
-pVf
+snA
 mfh
 hgp
 hgp
@@ -54727,7 +54940,7 @@ oSs
 hQa
 hQa
 rXA
-hQa
+nQT
 hQa
 hgp
 hgp
@@ -55044,7 +55257,7 @@ vZq
 vZq
 cXR
 tLn
-jJD
+hMs
 hQa
 hQa
 hQa
@@ -56297,12 +56510,12 @@ oSs
 oSs
 oSs
 oSs
+byK
 oSs
 oSs
 oSs
 oSs
-oSs
-oSs
+moW
 oSs
 oSs
 oSs
@@ -56503,9 +56716,9 @@ oSs
 oSs
 oSs
 oSs
-oSs
-oSs
-oSs
+gkH
+yeX
+jlR
 oSs
 oSs
 oSs
@@ -56706,9 +56919,9 @@ oSs
 oSs
 oSs
 oSs
+fgc
+kUX
 oSs
-oSs
-djf
 oSs
 oSs
 oSs
@@ -56908,8 +57121,8 @@ oSs
 oSs
 oSs
 oSs
-oSs
-oSs
+vQw
+lPk
 oSs
 oSs
 oSs
@@ -57109,7 +57322,7 @@ oSs
 oSs
 oSs
 oSs
-oSs
+byK
 oSs
 oSs
 oSs
@@ -59675,7 +59888,7 @@ hqN
 hqN
 hqN
 hqN
-hqN
+ihN
 hqN
 hqN
 hqN
@@ -60088,7 +60301,7 @@ hqN
 hqN
 hqN
 hqN
-hqN
+ihN
 hqN
 hqN
 hqN
@@ -60411,7 +60624,7 @@ rFN
 ucA
 cKJ
 hio
-vvB
+blq
 rFN
 blm
 blm
@@ -60721,7 +60934,7 @@ qIn
 qIn
 kLc
 crx
-crx
+iOX
 crx
 crx
 lrq
@@ -62720,7 +62933,7 @@ oSs
 oSs
 oSs
 oSs
-oSs
+lFz
 oSs
 oSs
 oSs
@@ -63332,7 +63545,7 @@ oSs
 oSs
 oSs
 oSs
-oSs
+eli
 oSs
 oSs
 oSs
@@ -63533,8 +63746,8 @@ oSs
 oSs
 oSs
 oSs
-oSs
-oSs
+dQI
+yll
 oSs
 oSs
 oSs

--- a/_maps/map_files/Drought/Drought_above.dmm
+++ b/_maps/map_files/Drought/Drought_above.dmm
@@ -8890,6 +8890,7 @@
 /obj/structure/closet/crate/ms13/footlocker{
 	dir = 1
 	},
+/obj/effect/spawner/random/ms13/tools/lights,
 /turf/open/floor/wood/ms13/carpet/shaggy/green,
 /area/ms13/town)
 "Hb" = (

--- a/_maps/map_files/Drought/Drought_below.dmm
+++ b/_maps/map_files/Drought/Drought_below.dmm
@@ -736,6 +736,7 @@
 	dir = 4
 	},
 /obj/effect/spawner/random/ms13/tools/lights,
+/obj/effect/spawner/random/ms13/tools/lights,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "hs" = (
@@ -2023,6 +2024,7 @@
 	dir = 4
 	},
 /obj/structure/table/ms13/no_smooth/counter/wood,
+/obj/effect/spawner/random/ms13/tools/lights,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "uD" = (
@@ -2491,6 +2493,13 @@
 /obj/structure/table/rolling/ms13,
 /turf/open/floor/ms13/tile/large/cream,
 /area/ms13/town)
+"Aj" = (
+/obj/structure/ms13/storage/store/metal{
+	dir = 8
+	},
+/obj/effect/spawner/random/ms13/tools/lights,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/town)
 "Ak" = (
 /obj/structure/sink/ms13{
 	dir = 8
@@ -2613,6 +2622,8 @@
 /area/ms13/town)
 "BC" = (
 /obj/structure/closet/crate/ms13/woodcrate/compact,
+/obj/effect/spawner/random/ms13/tools/lights,
+/obj/effect/spawner/random/ms13/tools/lights,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "BG" = (
@@ -4532,6 +4543,13 @@
 	},
 /turf/open/floor/ms13/tile/blue,
 /area/ms13/town)
+"WA" = (
+/obj/structure/ms13/storage/large/shelf{
+	dir = 8
+	},
+/obj/effect/spawner/random/ms13/tools/lights,
+/turf/open/floor/ms13/concrete,
+/area/ms13/town)
 "WB" = (
 /turf/closed/wall/ms13/bunker,
 /area/ms13/underground/mountain)
@@ -4713,6 +4731,11 @@
 /mob/living/basic/ms13/hostile_animal/molerat,
 /turf/open/floor/plating/ms13/ground/mountain/drought,
 /area/ms13/underground/mountain)
+"Zc" = (
+/obj/structure/table/ms13/metal/grate,
+/obj/effect/spawner/random/ms13/tools/lights,
+/turf/open/floor/ms13/concrete/industrial,
+/area/ms13/town)
 "Ze" = (
 /obj/machinery/ms13/fusion_generator,
 /turf/open/floor/ms13/metal/grate/border{
@@ -33929,7 +33952,7 @@ lh
 dy
 aq
 WC
-WC
+Aj
 kx
 lh
 VU
@@ -34878,7 +34901,7 @@ uD
 uD
 uD
 vu
-QE
+Zc
 VU
 VU
 jG
@@ -38867,7 +38890,7 @@ uD
 uD
 uD
 fp
-uz
+tp
 uz
 uD
 uD
@@ -39627,7 +39650,7 @@ uD
 uD
 vu
 GN
-wr
+WA
 GN
 GN
 GN

--- a/mojave/jobs/job_types/wasteland/nomad.dm
+++ b/mojave/jobs/job_types/wasteland/nomad.dm
@@ -77,21 +77,21 @@
 		/obj/item/clothing/under/ms13/wasteland/roving,\
 		/obj/item/clothing/under/ms13/wasteland/mechanicprewar/mechanicgrey,\
 		/obj/item/clothing/under/ms13/wasteland/mechanicprewar/mechanicgreen)
-	if(prob(25))
-		suit = pick(
-			/obj/item/clothing/suit/ms13/vest/brown,\
-			/obj/item/clothing/suit/ms13/vest/black,\
-			/obj/item/clothing/suit/ms13/vest,\
-			/obj/item/clothing/suit/ms13/ljacket/moleskin,\
-			/obj/item/clothing/suit/ms13/ljacket/wanderer,\
-			/obj/item/clothing/suit/ms13/ljacket/military,\
-			/obj/item/clothing/suit/ms13/ljacket/musty,\
-			/obj/item/clothing/suit/ms13/ljacket/biker,\
-			/obj/item/clothing/suit/ms13/ljacket/bomber, \
-			/obj/item/clothing/suit/ms13/ljacket, \
-			/obj/item/clothing/suit/ms13/trench/leather, \
-			/obj/item/clothing/suit/ms13/trench/brown, \
-			/obj/item/clothing/suit/ms13/trench)
+
+	suit = pick(
+		/obj/item/clothing/suit/ms13/vest/brown,\
+		/obj/item/clothing/suit/ms13/vest/black,\
+		/obj/item/clothing/suit/ms13/vest,\
+		/obj/item/clothing/suit/ms13/ljacket/moleskin,\
+		/obj/item/clothing/suit/ms13/ljacket/wanderer,\
+		/obj/item/clothing/suit/ms13/ljacket/military,\
+		/obj/item/clothing/suit/ms13/ljacket/musty,\
+		/obj/item/clothing/suit/ms13/ljacket/biker,\
+		/obj/item/clothing/suit/ms13/ljacket/bomber, \
+		/obj/item/clothing/suit/ms13/ljacket, \
+		/obj/item/clothing/suit/ms13/trench/leather, \
+		/obj/item/clothing/suit/ms13/trench/brown, \
+		/obj/item/clothing/suit/ms13/trench)
 	else
 		suit = null
 

--- a/mojave/jobs/job_types/wasteland/nomad.dm
+++ b/mojave/jobs/job_types/wasteland/nomad.dm
@@ -92,8 +92,6 @@
 		/obj/item/clothing/suit/ms13/trench/leather, \
 		/obj/item/clothing/suit/ms13/trench/brown, \
 		/obj/item/clothing/suit/ms13/trench)
-	else
-		suit = null
 
 	suit_store = pick(
 		/obj/item/gun/ballistic/automatic/pistol/ms13/m9mm, \


### PR DESCRIPTION
## About The Pull Request

A little tweaker PR. Removes the prob 25 from Nomad suit on spawn to bring it in line with Mammoth Wastelander, and frankly they should _at least_ be guaranteed a shitty suit of some kind. Also fleshes out some very empty spots on the map not with full buildings but just with little camps and other small stuff. Adds more lighting tool spawners on the map per request and otherwise only minorly tweaks some things on the map. 

## Why It's Good For The Game

Tweaking after a test is awesome, I love tweaking!!