### PR TITLE
Mammoth Gloop Eater House

### DIFF
--- a/_maps/map_files/Mammoth/Mammoth_below.dmm
+++ b/_maps/map_files/Mammoth/Mammoth_below.dmm
@@ -12271,6 +12271,10 @@
 	},
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
+"bhR" = (
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/underground/mountain)
 "biD" = (
 /obj/structure/ms13/storage/large/shelf{
 	dir = 8
@@ -12382,6 +12386,10 @@
 /obj/structure/bed/ms13/sleepingbag/green,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/underground/underground_town)
+"bzK" = (
+/obj/machinery/light/ms13/bulb/industrial/broken,
+/turf/open/floor/plating/ms13/ground/mountain,
+/area/ms13/underground/mountain)
 "bzR" = (
 /obj/structure/table/ms13/no_smooth/counter/wood/crafted{
 	dir = 4
@@ -12484,6 +12492,16 @@
 	},
 /turf/open/floor/ms13/metal,
 /area/ms13/town)
+"bPr" = (
+/obj/structure/table/ms13/no_smooth/large/wood/desk{
+	dir = 4
+	},
+/obj/item/pen/ms13,
+/obj/machinery/light/ms13/bulb{
+	dir = 8
+	},
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/underground/mountain)
 "bPM" = (
 /obj/structure/ms13/storage/shelf{
 	dir = 8
@@ -12535,6 +12553,16 @@
 /obj/effect/spawner/random/ms13/seeds/unique,
 /turf/open/floor/ms13/metal/plate,
 /area/ms13/underground/military_crypt)
+"bXc" = (
+/obj/structure/closet/crate/ms13/footlocker{
+	dir = 8
+	},
+/obj/effect/spawner/random/ms13/drink/alcohol,
+/obj/effect/spawner/random/ms13/drink/alcohol,
+/obj/effect/spawner/random/ms13/guaranteed/drink/alcohol,
+/obj/effect/spawner/random/ms13/guaranteed/drink/alcohol,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/underground/mountain)
 "bXK" = (
 /obj/effect/spawner/random/ms13/tools/lights,
 /turf/open/floor/ms13/concrete,
@@ -12735,6 +12763,10 @@
 	},
 /turf/open/floor/ms13/sewer,
 /area/ms13/underground/underground_town)
+"cyk" = (
+/obj/effect/spawner/random/ms13/crafting/lowrandom,
+/turf/open/floor/plating/ms13/ground/mountain,
+/area/ms13/underground/mountain)
 "cyt" = (
 /obj/structure/fluff/ms13/trash/papers,
 /mob/living/basic/ms13/ghoul/radioactive,
@@ -12766,6 +12798,11 @@
 	},
 /turf/open/floor/ms13/tile/large/cafeteria,
 /area/ms13/underground/sewer)
+"cAT" = (
+/obj/structure/ms13/storage/shelf/wood,
+/obj/effect/spawner/random/ms13/medical/tier1,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/underground/mountain)
 "cAW" = (
 /obj/effect/spawner/random/ms13/clothing/under,
 /obj/structure/closet/crate/ms13/footlocker{
@@ -13613,6 +13650,10 @@
 /obj/item/clothing/head/hardhat/ms13/mining,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/underground/underground_town)
+"fcy" = (
+/obj/structure/ms13/rug/mat/vulgar/fuckoff,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/underground/mountain)
 "ffl" = (
 /obj/structure/closet/ms13/metal,
 /obj/item/clothing/under/ms13/wasteland/mechanicprewar/mechanicgrey,
@@ -13792,6 +13833,13 @@
 /obj/effect/spawner/random/ms13/clothing/under,
 /turf/open/floor/wood/ms13/carpet/blue,
 /area/ms13/town)
+"fQn" = (
+/obj/item/ms13_small_flag/usa,
+/obj/machinery/light/ms13/bulb{
+	dir = 1
+	},
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/underground/mountain)
 "fQG" = (
 /obj/structure/table/ms13/metal/grate,
 /obj/effect/spawner/random/ms13/guaranteed/drugs/prewar,
@@ -13806,6 +13854,10 @@
 /obj/effect/spawner/random/ms13/drugs/highrandom,
 /turf/open/floor/wood/ms13/common,
 /area/ms13/underground/underground_town)
+"fSs" = (
+/obj/structure/fluff/ms13/barrel/single/toxic/four,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/underground/mountain)
 "fSL" = (
 /obj/structure/closet/crate/ms13/woodcrate/compact,
 /obj/effect/spawner/random/ms13/crafting/electrical,
@@ -13836,6 +13888,10 @@
 /obj/item/ammo_casing/ms13/c10mm,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
+"fTT" = (
+/obj/item/paper_bin/ms13,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/underground/mountain)
 "fUq" = (
 /obj/structure/closet/ms13/metal,
 /obj/effect/spawner/random/ms13/clothing/backpack,
@@ -13849,6 +13905,10 @@
 /obj/effect/spawner/random/ms13/crafting/highrandom,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
+"fXm" = (
+/obj/machinery/light/ms13/bulb,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/underground/mountain)
 "gaN" = (
 /obj/structure/table/ms13/metal/grate,
 /obj/structure/ms13/rug/mat/rubber,
@@ -14003,6 +14063,10 @@
 /obj/structure/table/ms13/crafting/workbench,
 /turf/open/floor/ms13/metal,
 /area/ms13/underground/vault_atrium_lower)
+"gxh" = (
+/mob/living/basic/ms13/hostile_animal/radroach/glowie,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/underground/mountain)
 "gyC" = (
 /obj/structure/closet/crate/ms13/footlocker{
 	dir = 1
@@ -14052,6 +14116,13 @@
 	},
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
+"gCG" = (
+/obj/structure/ms13/foundation/wide/variantsix{
+	dir = 1
+	},
+/obj/structure/ms13/skeleton,
+/turf/open/floor/plating/ms13/ground/mountain,
+/area/ms13/underground/mountain)
 "gCZ" = (
 /obj/structure/ms13/medical_curtain,
 /turf/open/floor/ms13/tile/navy,
@@ -14124,6 +14195,16 @@
 	},
 /turf/open/floor/plating/ms13/ground/mountain,
 /area/ms13/underground/mountain)
+"gRn" = (
+/obj/structure/table/ms13/no_smooth/counter/wood/crafted{
+	dir = 4
+	},
+/obj/structure/ms13/foundation/wide/variantfour{
+	dir = 9
+	},
+/obj/effect/spawner/random/ms13/medical/lowrandom,
+/turf/open/floor/plating/ms13/ground/mountain,
+/area/ms13/underground/mountain)
 "gRq" = (
 /obj/structure/ms13/foundation/wide/variantfive{
 	dir = 1
@@ -14173,6 +14254,15 @@
 /obj/effect/spawner/random/ms13/armor/lowrandom,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/underground/underground_town)
+"hcd" = (
+/obj/structure/ms13/foundation/wide/variantfive{
+	dir = 8
+	},
+/obj/structure/chair/ms13/overlaypickup/plastic{
+	dir = 8
+	},
+/turf/open/floor/plating/ms13/ground/mountain,
+/area/ms13/underground/mountain)
 "hfx" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/ms13/concrete,
@@ -14403,6 +14493,12 @@
 /obj/structure/ms13/rug/rubber,
 /turf/open/floor/ms13/metal/grate/border,
 /area/ms13/underground/underground_town)
+"hOW" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 6
+	},
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/underground/mountain)
 "hQB" = (
 /obj/effect/turf_decal/trimline/yellow/line{
 	dir = 4
@@ -14424,6 +14520,11 @@
 /obj/structure/bed/ms13/bedframe/metal,
 /turf/open/floor/ms13/concrete/bricks,
 /area/ms13/underground/underground_town)
+"hTe" = (
+/obj/item/chair/ms13/plastic,
+/obj/item/ms13/brick,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/underground/mountain)
 "hVp" = (
 /obj/structure/fluff/ms13/barrel/quadruple/red/two,
 /turf/open/floor/plating/ms13/ground/mountain,
@@ -14544,6 +14645,16 @@
 /obj/effect/spawner/random/ms13/guaranteed/medical/lowrandom,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/underground/underground_town)
+"ikE" = (
+/obj/structure/fluff/ms13/trash/papers{
+	dir = 5
+	},
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/underground/mountain)
+"ilb" = (
+/obj/structure/fluff/ms13/barrel/single/toxic/two,
+/turf/open/floor/plating/ms13/ground/mountain,
+/area/ms13/underground/mountain)
 "ilz" = (
 /mob/living/basic/ms13/ghoul,
 /turf/open/floor/ms13/tile/blue,
@@ -14576,6 +14687,17 @@
 /obj/structure/ms13/rug/mat/rubber/single,
 /turf/open/floor/ms13/tile/fancy,
 /area/ms13/town)
+"iqc" = (
+/obj/structure/ms13/foundation/wide/variantfive{
+	dir = 9
+	},
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 8;
+	pixel_y = 6
+	},
+/mob/living/basic/ms13/ghoul/radioactive,
+/turf/open/floor/plating/ms13/ground/mountain,
+/area/ms13/underground/mountain)
 "iqP" = (
 /obj/effect/spawner/random/ms13/food/packaged,
 /obj/effect/spawner/random/ms13/food/packaged,
@@ -14637,6 +14759,11 @@
 /obj/effect/spawner/random/ms13/tools/hardware,
 /turf/open/floor/ms13/concrete,
 /area/ms13/underground/underground_town)
+"iFO" = (
+/obj/item/paper/ms13/paperslip,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plating/ms13/ground/mountain,
+/area/ms13/underground/mountain)
 "iHn" = (
 /obj/structure/table/ms13/crafting/weaponbench,
 /turf/open/floor/ms13/metal,
@@ -14998,6 +15125,12 @@
 /obj/machinery/light/ms13/bulb,
 /turf/open/floor/ms13/concrete,
 /area/ms13/town)
+"kaY" = (
+/obj/effect/decal/cleanable/blood{
+	icon_state = "floor3"
+	},
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/underground/mountain)
 "kcz" = (
 /obj/structure/flora/grass/jungle/b,
 /obj/structure/flora/grass/jungle/b,
@@ -15127,6 +15260,10 @@
 /obj/structure/ms13/wall_decor/flag/california,
 /turf/open/floor/ms13/concrete,
 /area/ms13/town)
+"kAH" = (
+/obj/structure/ms13/foundation/wide/varianttwo,
+/turf/open/floor/plating/ms13/ground/mountain,
+/area/ms13/underground/mountain)
 "kBx" = (
 /obj/machinery/porta_turret/ms13/ballistic{
 	dir = 9
@@ -15247,6 +15384,12 @@
 /obj/structure/table/ms13/wood,
 /turf/open/floor/wood/ms13/carpet/blue,
 /area/ms13/town)
+"kQB" = (
+/obj/machinery/light/ms13/bulb{
+	dir = 8
+	},
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/underground/mountain)
 "kRk" = (
 /obj/structure/ms13/fence/wire,
 /obj/structure/ms13/foundation/common/variantfour{
@@ -15418,6 +15561,12 @@
 /obj/effect/spawner/random/ms13/drink/alcohol,
 /turf/open/floor/ms13/concrete,
 /area/ms13/underground/underground_town)
+"liT" = (
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 1
+	},
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/underground/mountain)
 "llr" = (
 /obj/structure/ms13/storage/shelf{
 	dir = 4
@@ -15438,6 +15587,10 @@
 	},
 /turf/open/floor/plating/ms13/ground/mountain,
 /area/ms13/underground/mountain)
+"loM" = (
+/obj/structure/fluff/ms13/barrel/single/toxic/three,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/underground/mountain)
 "lpN" = (
 /obj/machinery/light/ms13,
 /turf/open/floor/ms13/metal,
@@ -15453,6 +15606,10 @@
 "luy" = (
 /obj/effect/turf_decal/ms13/graffiti/moyai,
 /turf/closed/indestructible/rock/ms13/mammoth,
+/area/ms13/underground/mountain)
+"luN" = (
+/obj/structure/ms13/pot/plant,
+/turf/open/floor/wood/ms13/wide,
 /area/ms13/underground/mountain)
 "luP" = (
 /obj/effect/decal/cleanable/blood/old,
@@ -15514,6 +15671,13 @@
 /obj/effect/spawner/random/ms13/gun/highunique,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/underground/army_bunker)
+"lEj" = (
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 8;
+	pixel_y = 6
+	},
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/underground/mountain)
 "lET" = (
 /obj/item/shovel/ms13,
 /obj/structure/ms13/skeleton,
@@ -15945,6 +16109,12 @@
 /obj/effect/spawner/random/ms13/ammo/tier2,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/underground/underground_town)
+"mXh" = (
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 8
+	},
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/underground/mountain)
 "mYl" = (
 /obj/effect/spawner/random/ms13/ammo/tier1,
 /turf/open/floor/wood/ms13/wide,
@@ -16033,6 +16203,15 @@
 	},
 /turf/open/floor/plating/ms13/ground/mountain,
 /area/ms13/underground/mountain)
+"niz" = (
+/obj/structure/closet/ms13/fridge,
+/obj/effect/spawner/random/ms13/drink/alcohol_beer,
+/obj/effect/spawner/random/ms13/drink/alcohol_beer,
+/obj/effect/spawner/random/ms13/drink/alcohol_beer,
+/obj/effect/spawner/random/ms13/drink/alcohol_uncommon,
+/obj/effect/spawner/random/ms13/guaranteed/drink/alcohol_beer,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/underground/mountain)
 "nji" = (
 /obj/structure/ms13/storage/shelf{
 	dir = 4
@@ -16104,6 +16283,14 @@
 /obj/structure/railing/ms13/sewer,
 /turf/open/floor/ms13/concrete,
 /area/ms13/underground/underground_town)
+"nxN" = (
+/obj/structure/ms13/foundation/wide/variantthree,
+/obj/structure/fluff/ms13/trash/papers{
+	dir = 9
+	},
+/obj/item/clothing/head/helmet/ms13/sailor,
+/turf/open/floor/plating/ms13/ground/mountain,
+/area/ms13/underground/mountain)
 "nxW" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/spawner/random/ms13/crafting/lowrandom,
@@ -16405,12 +16592,28 @@
 	},
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/underground/underground_town)
+"ora" = (
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 4
+	},
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/underground/mountain)
 "oro" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 5
 	},
 /turf/open/floor/ms13/concrete,
 /area/ms13/underground/underground_town)
+"osv" = (
+/obj/structure/ms13/foundation/wide/varianttwo{
+	dir = 10
+	},
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 4
+	},
+/mob/living/basic/ms13/hostile_animal/radroach/glowie,
+/turf/open/floor/plating/ms13/ground/mountain,
+/area/ms13/underground/mountain)
 "otb" = (
 /obj/structure/ms13/skeleton,
 /obj/effect/decal/cleanable/blood/splatter,
@@ -16469,6 +16672,13 @@
 /obj/structure/fluff/ms13/barrel/triple/yellow/one,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
+"oFx" = (
+/obj/structure/ms13/foundation/wide/variantfour{
+	dir = 8
+	},
+/mob/living/basic/ms13/hostile_animal/radroach/glowie,
+/turf/open/floor/plating/ms13/ground/mountain,
+/area/ms13/underground/mountain)
 "oHf" = (
 /obj/structure/ms13/celldoor/rusty{
 	dir = 1
@@ -16673,6 +16883,12 @@
 	},
 /turf/open/floor/ms13/sewer,
 /area/ms13/underground/underground_town)
+"pdr" = (
+/obj/structure/chair/ms13/overlaypickup/plastic{
+	dir = 8
+	},
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/underground/mountain)
 "pfl" = (
 /obj/structure/ms13/barricade,
 /turf/open/floor/plating/ms13/ground/mountain,
@@ -16930,6 +17146,22 @@
 /obj/effect/spawner/random/ms13/medical/lowrandom,
 /turf/open/floor/ms13/concrete,
 /area/ms13/town)
+"pSP" = (
+/obj/structure/table/ms13/no_smooth/counter/wood/crafted{
+	dir = 8
+	},
+/obj/structure/ms13/foundation/wide/variantfour{
+	dir = 6
+	},
+/obj/effect/spawner/random/ms13/crafting/household,
+/turf/open/floor/plating/ms13/ground/mountain,
+/area/ms13/underground/mountain)
+"pTh" = (
+/obj/machinery/door/unpowered/ms13/metal/red{
+	dir = 4
+	},
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/underground/mountain)
 "pTy" = (
 /obj/effect/spawner/random/ms13/drugs/lowrandom,
 /turf/open/floor/ms13/concrete,
@@ -16978,6 +17210,14 @@
 /obj/effect/spawner/random/ms13/clothing/gloves,
 /turf/open/floor/ms13/concrete,
 /area/ms13/underground/underground_town)
+"pXE" = (
+/obj/structure/ms13/foundation/wide/variantthree{
+	dir = 6
+	},
+/obj/effect/spawner/random/ms13/melee/lowrandom,
+/mob/living/basic/ms13/hostile_animal/radroach/glowie,
+/turf/open/floor/plating/ms13/ground/mountain,
+/area/ms13/underground/mountain)
 "pZP" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/cleanable/blood/tracks{
@@ -17151,6 +17391,13 @@
 /obj/effect/spawner/random/ms13/crafting/highrandom,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/underground/underground_town)
+"qDh" = (
+/obj/item/paper/ms13/paperslip,
+/obj/machinery/light/ms13/bulb/industrial{
+	dir = 1
+	},
+/turf/open/floor/plating/ms13/ground/mountain,
+/area/ms13/underground/mountain)
 "qEs" = (
 /obj/machinery/door/airlock/ms13,
 /turf/open/floor/ms13/concrete/industrial,
@@ -17170,6 +17417,10 @@
 /obj/effect/spawner/random/ms13/medical/lowrandom,
 /turf/open/floor/ms13/tile/long,
 /area/ms13/town)
+"qGS" = (
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plating/ms13/ground/mountain,
+/area/ms13/underground/mountain)
 "qHV" = (
 /obj/effect/spawner/random/ms13/guaranteed/food/packaged,
 /obj/structure/ms13/storage/large/shelf{
@@ -17237,6 +17488,12 @@
 	},
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/underground/sewer)
+"qRr" = (
+/obj/machinery/door/unpowered/ms13/metal/red{
+	dir = 1
+	},
+/turf/open/floor/plating/ms13/ground/mountain,
+/area/ms13/underground/mountain)
 "qUC" = (
 /obj/structure/fluff/ms13/barrel/single/redalt,
 /turf/open/floor/plating/ms13/ground/mountain,
@@ -17301,6 +17558,10 @@
 /obj/effect/spawner/random/ms13/locked/guaranteed/random,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/ncr)
+"rlh" = (
+/obj/structure/fluff/ms13/barrel/triple/waste,
+/turf/open/floor/plating/ms13/ground/mountain,
+/area/ms13/underground/mountain)
 "rmf" = (
 /obj/item/shovel/ms13/rake,
 /obj/item/shovel/ms13/spade,
@@ -17319,6 +17580,13 @@
 /mob/living/basic/ms13/robot/handy,
 /turf/open/floor/ms13/metal,
 /area/ms13/underground/enclave_base)
+"rsK" = (
+/obj/structure/fluff/ms13/trash/papers,
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 9
+	},
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/underground/mountain)
 "rtS" = (
 /obj/structure/table/ms13/metal,
 /obj/effect/spawner/random/ms13/medical/lowrandom,
@@ -17451,6 +17719,13 @@
 /obj/effect/spawner/random/ms13/crafting/lowrandom,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/underground/underground_town)
+"rKW" = (
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 1;
+	pixel_x = -5
+	},
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/underground/mountain)
 "rLz" = (
 /obj/structure/table/ms13/metal/heavy,
 /obj/effect/spawner/random/ms13/crafting/electrical,
@@ -17499,6 +17774,10 @@
 	},
 /turf/open/ms13/water/sewer/medium,
 /area/ms13/underground/sewer)
+"rPy" = (
+/obj/machinery/door/unpowered/ms13/metal/red,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/underground/mountain)
 "rPH" = (
 /obj/structure/ms13/skeleton,
 /obj/item/clothing/head/helmet/ms13/fedora/yellow,
@@ -17772,6 +18051,15 @@
 /obj/machinery/iv_drip/ms13,
 /turf/open/floor/ms13/tile/navy,
 /area/ms13/underground/enclave_base)
+"sGY" = (
+/obj/structure/table/ms13/no_smooth/large/wood/desk{
+	dir = 4
+	},
+/obj/machinery/ms13/terminal/wasteland{
+	dir = 4
+	},
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/underground/mountain)
 "sHf" = (
 /obj/machinery/button/ms13{
 	dir = 8;
@@ -17999,6 +18287,18 @@
 	},
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
+"tna" = (
+/obj/structure/ms13/foundation/wide/variantfour{
+	dir = 6
+	},
+/obj/effect/spawner/random/ms13/gun/tier2,
+/obj/effect/spawner/random/ms13/currency/mammoth/prewar/lowrandom,
+/obj/effect/spawner/random/ms13/clothing/gloves,
+/obj/machinery/light/ms13/bulb{
+	dir = 8
+	},
+/turf/open/floor/plating/ms13/ground/mountain,
+/area/ms13/underground/mountain)
 "tnM" = (
 /obj/structure/table/ms13/crafting/armorbench,
 /turf/open/floor/wood/ms13/wide,
@@ -18040,6 +18340,20 @@
 /obj/structure/rustic_extractor,
 /turf/open/floor/plating/ms13/ground/mountain,
 /area/ms13/underground/vault_atrium_lower)
+"txO" = (
+/obj/structure/ms13/foundation/wide/variantfive{
+	dir = 6
+	},
+/obj/structure/closet/crate/ms13/footlocker{
+	dir = 8
+	},
+/obj/effect/spawner/random/ms13/currency/mammoth/prewar/lowrandom,
+/obj/item/clothing/under/ms13/wasteland/navy,
+/obj/item/clothing/head/helmet/ms13/sailor,
+/obj/effect/spawner/random/ms13/clothing/under,
+/obj/effect/spawner/random/ms13/clothing/shoe,
+/turf/open/floor/plating/ms13/ground/mountain,
+/area/ms13/underground/mountain)
 "tzs" = (
 /obj/structure/closet/crate/ms13/woodcrate/compact,
 /obj/effect/spawner/random/ms13/crafting/household,
@@ -18202,6 +18516,10 @@
 	},
 /turf/open/floor/ms13/metal,
 /area/ms13/underground/vault_atrium_lower)
+"tWD" = (
+/obj/structure/fluff/ms13/barrel/triple/waste/two,
+/turf/open/floor/plating/ms13/ground/mountain,
+/area/ms13/underground/mountain)
 "tWL" = (
 /obj/effect/decal/cleanable/blood,
 /obj/structure/dresser/ms13/orange/tall,
@@ -18295,11 +18613,23 @@
 	},
 /turf/open/floor/plating/ms13/ground/mountain,
 /area/ms13/underground/mountain)
+"ugo" = (
+/obj/structure/table/ms13/no_smooth/cable_reel,
+/obj/item/paper/ms13/paperslip,
+/obj/effect/spawner/random/ms13/crafting/lowrandom,
+/turf/open/floor/plating/ms13/ground/mountain,
+/area/ms13/underground/mountain)
 "ugt" = (
 /obj/structure/table/ms13/metal/heavy,
 /obj/effect/spawner/random/ms13/crafting/electrical,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/underground/underground_town)
+"ugO" = (
+/obj/structure/ms13/foundation/wide/varianttwo{
+	dir = 9
+	},
+/turf/open/floor/plating/ms13/ground/mountain,
+/area/ms13/underground/mountain)
 "ukv" = (
 /obj/structure/bed/ms13/bedframe/wire,
 /turf/open/floor/ms13/concrete,
@@ -18308,6 +18638,15 @@
 /obj/structure/ms13/rug/rubber,
 /turf/open/floor/ms13/concrete,
 /area/ms13/underground/military_crypt)
+"umv" = (
+/obj/structure/ms13/foundation/wide/variantfive{
+	dir = 10
+	},
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 4
+	},
+/turf/open/floor/plating/ms13/ground/mountain,
+/area/ms13/underground/mountain)
 "unc" = (
 /obj/effect/decal/cleanable/blood/drip{
 	pixel_x = -7;
@@ -18315,6 +18654,11 @@
 	},
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/underground/underground_town)
+"unQ" = (
+/obj/structure/table/ms13/no_smooth/wood,
+/obj/effect/spawner/random/ms13/drink/alcohol,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/underground/mountain)
 "unX" = (
 /obj/structure/table/ms13/wood,
 /obj/effect/spawner/random/ms13/ammo/lowrandom,
@@ -18502,6 +18846,11 @@
 /obj/item/clothing/suit/ms13/ljacket/military,
 /turf/open/floor/ms13/sewer,
 /area/ms13/underground/underground_town)
+"uSt" = (
+/obj/structure/bed/ms13/mattress/yellowed,
+/obj/structure/bed/ms13/bedframe/wood,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/underground/mountain)
 "uUD" = (
 /obj/effect/spawner/random/ms13/guaranteed/ammo/tier1,
 /obj/structure/closet/crate/ms13/footlocker{
@@ -18702,6 +19051,10 @@
 /obj/effect/spawner/random/ms13/clothing/mask,
 /turf/open/floor/ms13/concrete,
 /area/ms13/underground/underground_town)
+"vtV" = (
+/obj/structure/ms13/tv/wooden,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/underground/mountain)
 "vtW" = (
 /obj/structure/table/ms13/metal/grate,
 /obj/effect/spawner/random/ms13/tools/lights,
@@ -18721,6 +19074,15 @@
 /obj/structure/chair/ms13/metal/stool,
 /turf/open/floor/ms13/tile,
 /area/ms13/town)
+"vuS" = (
+/obj/structure/ms13/foundation/wide/variantsix{
+	dir = 5
+	},
+/obj/machinery/door/unpowered/ms13/metal/red{
+	dir = 1
+	},
+/turf/open/floor/plating/ms13/ground/mountain,
+/area/ms13/underground/mountain)
 "vwv" = (
 /obj/effect/spawner/random/ms13/tools/tool,
 /turf/open/floor/ms13/concrete,
@@ -18760,6 +19122,11 @@
 	},
 /turf/open/floor/plating/ms13/ground/mountain,
 /area/ms13/underground/underground_town)
+"vFk" = (
+/obj/structure/bed/ms13/bedframe/wood,
+/obj/structure/bed/ms13/mattress/stained,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/underground/mountain)
 "vIg" = (
 /obj/structure/ms13/bars/rusty,
 /turf/open/ms13/water/sewer/medium,
@@ -19109,6 +19476,12 @@
 	},
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
+"xiO" = (
+/obj/structure/ms13/foundation/wide/varianttwo{
+	dir = 4
+	},
+/turf/open/floor/plating/ms13/ground/mountain,
+/area/ms13/underground/mountain)
 "xjg" = (
 /obj/machinery/light/ms13{
 	dir = 1
@@ -19283,6 +19656,10 @@
 	},
 /turf/open/floor/ms13/concrete,
 /area/ms13/town)
+"xPs" = (
+/obj/structure/fluff/ms13/barrel/single/waste/one,
+/turf/open/floor/plating/ms13/ground/mountain,
+/area/ms13/underground/mountain)
 "xRo" = (
 /obj/machinery/light/ms13/bulb{
 	dir = 4
@@ -19338,6 +19715,16 @@
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/open/floor/ms13/concrete,
 /area/ms13/underground/underground_town)
+"ydx" = (
+/obj/structure/closet/crate/ms13/footlocker{
+	dir = 8
+	},
+/obj/effect/spawner/random/ms13/currency/mammoth/prewar/lowrandom,
+/obj/item/clothing/under/ms13/wasteland/navy,
+/obj/effect/spawner/random/ms13/clothing/under,
+/obj/effect/spawner/random/ms13/clothing/shoe,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/underground/mountain)
 "yem" = (
 /obj/structure/table/ms13/crafting/armorbench,
 /turf/open/floor/ms13/metal,
@@ -82377,11 +82764,11 @@ afU
 afU
 afU
 afU
-afU
-afU
-afU
-afU
-afU
+aRy
+aRy
+aRy
+aRy
+aRy
 afU
 afU
 afU
@@ -82679,11 +83066,11 @@ afU
 afU
 afU
 afU
-afU
-afU
-afU
-afU
-afU
+aRy
+fSs
+tna
+sGY
+aRy
 afU
 afU
 afU
@@ -82981,11 +83368,11 @@ afU
 afU
 afU
 afU
-afU
-afU
-afU
-afU
-afU
+aRy
+bhR
+umv
+hcd
+aRy
 afU
 afU
 afU
@@ -83283,13 +83670,13 @@ afU
 afU
 afU
 afU
-afU
-afU
-afU
-afU
-afU
-afU
-afU
+aRy
+loM
+iqc
+txO
+aRy
+rlh
+ilb
 afU
 afU
 afU
@@ -83585,14 +83972,14 @@ afU
 afU
 afU
 afU
-afU
-afU
-afU
-afU
-afU
-afU
-afU
-afU
+aRy
+lEj
+mXh
+vFk
+aRy
+cyk
+qGS
+akx
 afU
 afU
 afU
@@ -83886,16 +84273,16 @@ afU
 afU
 afU
 afU
-afU
-afU
-afU
-afU
-afU
-afU
-afU
-afU
-afU
-afU
+aRy
+aRy
+pTh
+aRy
+aRy
+aRy
+qDh
+ugo
+akx
+aiP
 afU
 afU
 afU
@@ -84188,16 +84575,16 @@ afU
 afU
 afU
 afU
-afU
-afU
-afU
-afU
-afU
-afU
-afU
-afU
-afU
-afU
+aRy
+luN
+mXh
+kQB
+gxh
+rPy
+cyk
+iFO
+tWD
+xPs
 afU
 afU
 afU
@@ -84484,22 +84871,22 @@ aRM
 aSH
 aZW
 afU
+abd
+abd
+abd
+abd
+abd
 afU
-afU
-afU
-afU
-afU
-afU
-afU
-afU
-afU
-afU
-afU
-afU
-afU
-afU
-afU
-afU
+aRy
+vtV
+aOV
+ora
+unQ
+aRy
+aRy
+aRy
+aRy
+aRy
 afU
 afU
 afU
@@ -84785,23 +85172,23 @@ aqI
 aqI
 aLH
 aZW
-afU
-afU
-afU
-afU
-afU
-afU
-afU
-afU
-afU
-afU
-afU
-afU
-afU
-afU
-afU
-afU
-afU
+abd
+abd
+abd
+abd
+abd
+akx
+aRy
+aRy
+cAT
+osv
+kAH
+pdr
+aRy
+ikE
+fTT
+bPr
+aRy
 afU
 afU
 afU
@@ -85086,24 +85473,24 @@ atl
 aRM
 aRM
 aSH
-aZW
-afU
-afU
-afU
-afU
-afU
-afU
-afU
-afU
-afU
-afU
-afU
-afU
-afU
-afU
-afU
-afU
-afU
+aPL
+akx
+abd
+abd
+abd
+akx
+bzK
+aRy
+fQn
+aOV
+ugO
+xiO
+mXh
+aRy
+nxN
+rsK
+kaY
+aRy
 afU
 afU
 afU
@@ -85389,23 +85776,23 @@ aRM
 aRM
 aLH
 aZW
-afU
-afU
-afU
-afU
-afU
-afU
-afU
-afU
-afU
-afU
-afU
-afU
-afU
-afU
-afU
-afU
-afU
+akx
+akx
+abd
+akx
+akx
+akx
+qRr
+fcy
+aOV
+aOV
+liT
+rKW
+vuS
+gCG
+hOW
+ydx
+aRy
 afU
 afU
 afU
@@ -85692,22 +86079,22 @@ aRM
 aLH
 aZW
 afU
+akx
+akx
+akx
+akx
 afU
-afU
-afU
-afU
-afU
-afU
-afU
-afU
-afU
-afU
-afU
-afU
-afU
-afU
-afU
-afU
+aRy
+aRy
+aOV
+bbA
+oFx
+fXm
+aRy
+pXE
+hTe
+uSt
+aRy
 afU
 afU
 afU
@@ -85995,21 +86382,21 @@ aLH
 aZW
 afU
 afU
+akx
+akx
 afU
 afU
 afU
-afU
-afU
-afU
-afU
-afU
-afU
-afU
-afU
-afU
-afU
-afU
-afU
+aRy
+bXc
+gRn
+pSP
+niz
+aRy
+aRy
+aRy
+aRy
+aRy
 afU
 afU
 afU
@@ -86302,12 +86689,12 @@ afU
 afU
 afU
 afU
-afU
-afU
-afU
-afU
-afU
-afU
+aRy
+aRy
+aRy
+aRy
+aRy
+aRy
 afU
 afU
 afU

--- a/_maps/map_files/Mammoth/Mammoth_below.dmm
+++ b/_maps/map_files/Mammoth/Mammoth_below.dmm
@@ -14707,7 +14707,7 @@
 "ipo" = (
 /obj/structure/table/ms13/no_smooth/cable_reel,
 /obj/item/paper/ms13/paperslip,
-/obj/effect/spawner/random/ms13/crafting/lowrandom,
+/obj/effect/spawner/random/ms13/gun/lowunique,
 /turf/open/floor/plating/ms13/ground/mountain,
 /area/ms13/underground/mountain)
 "iqP" = (
@@ -17005,10 +17005,9 @@
 	dir = 8
 	},
 /obj/effect/spawner/random/ms13/currency/mammoth/prewar/lowrandom,
-/obj/item/clothing/under/ms13/wasteland/navy,
-/obj/item/clothing/head/helmet/ms13/sailor,
 /obj/effect/spawner/random/ms13/clothing/under,
 /obj/effect/spawner/random/ms13/clothing/shoe,
+/obj/effect/spawner/random/ms13/armor/headgear,
 /turf/open/floor/plating/ms13/ground/mountain,
 /area/ms13/underground/underground_town)
 "prV" = (

--- a/_maps/map_files/Mammoth/Mammoth_below.dmm
+++ b/_maps/map_files/Mammoth/Mammoth_below.dmm
@@ -12252,11 +12252,6 @@
 /obj/structure/ms13/barricade,
 /turf/open/floor/plating/ms13/ground/mountain,
 /area/ms13/underground/mountain)
-"bfL" = (
-/obj/structure/ms13/storage/shelf/wood,
-/obj/effect/spawner/random/ms13/medical/tier1,
-/turf/open/floor/wood/ms13/wide,
-/area/ms13/underground/underground_town)
 "bfV" = (
 /obj/structure/ms13/foundation/wide/variantfour,
 /turf/open/floor/plating/ms13/ground/mountain,
@@ -12294,6 +12289,10 @@
 	},
 /turf/open/ms13/water/sewer/medium,
 /area/ms13/underground/sewer)
+"blW" = (
+/obj/structure/fluff/ms13/barrel/triple/waste,
+/turf/open/floor/plating/ms13/ground/mountain,
+/area/ms13/underground/underground_town)
 "bmE" = (
 /obj/structure/ms13/storage/shelf,
 /obj/effect/spawner/random/ms13/crafting/highrandom,
@@ -12367,6 +12366,11 @@
 /obj/machinery/light/ms13,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/underground/sewer)
+"buE" = (
+/obj/structure/bed/ms13/mattress/yellowed,
+/obj/structure/bed/ms13/bedframe/wood,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/underground/underground_town)
 "buP" = (
 /obj/structure/ms13/cave_decor/support/beams,
 /turf/open/floor/plating/ms13/ground/mountain,
@@ -12489,6 +12493,10 @@
 	},
 /turf/open/floor/ms13/metal,
 /area/ms13/town)
+"bPt" = (
+/obj/structure/fluff/ms13/barrel/triple/waste/two,
+/turf/open/floor/plating/ms13/ground/mountain,
+/area/ms13/underground/underground_town)
 "bPM" = (
 /obj/structure/ms13/storage/shelf{
 	dir = 8
@@ -12515,19 +12523,6 @@
 	},
 /turf/open/floor/ms13/concrete,
 /area/ms13/underground/underground_town)
-"bSL" = (
-/obj/machinery/door/unpowered/ms13/metal/red,
-/turf/open/floor/wood/ms13/wide,
-/area/ms13/underground/underground_town)
-"bSR" = (
-/obj/structure/ms13/foundation/wide/variantsix{
-	dir = 5
-	},
-/obj/machinery/door/unpowered/ms13/metal/red{
-	dir = 1
-	},
-/turf/open/floor/plating/ms13/ground/mountain,
-/area/ms13/underground/underground_town)
 "bUc" = (
 /obj/structure/closet/ms13/wall/firstaid,
 /obj/effect/spawner/random/ms13/medical/tier2,
@@ -12553,11 +12548,6 @@
 /obj/effect/spawner/random/ms13/seeds/unique,
 /turf/open/floor/ms13/metal/plate,
 /area/ms13/underground/military_crypt)
-"bXj" = (
-/obj/structure/bed/ms13/bedframe/wood,
-/obj/structure/bed/ms13/mattress/stained,
-/turf/open/floor/wood/ms13/wide,
-/area/ms13/underground/underground_town)
 "bXK" = (
 /obj/effect/spawner/random/ms13/tools/lights,
 /turf/open/floor/ms13/concrete,
@@ -12613,6 +12603,12 @@
 /obj/item/restraints/handcuffs/ms13,
 /turf/open/floor/ms13/tile/navy,
 /area/ms13/town)
+"cfy" = (
+/obj/structure/fluff/ms13/trash/papers{
+	dir = 5
+	},
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/underground/underground_town)
 "cfC" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 4
@@ -12643,6 +12639,11 @@
 /obj/machinery/door/unpowered/ms13/seethrough/metal,
 /turf/open/floor/ms13/tile/long,
 /area/ms13/town)
+"ciU" = (
+/obj/structure/table/ms13/no_smooth/wood,
+/obj/effect/spawner/random/ms13/drink/alcohol,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/underground/underground_town)
 "cjX" = (
 /obj/machinery/door/unpowered/ms13/seethrough/fence/wire/barb,
 /obj/effect/spawner/random/ms13/locked/random/medchance,
@@ -12702,12 +12703,6 @@
 /obj/structure/table/ms13/metal,
 /obj/item/radio/ms13/ham,
 /turf/open/floor/ms13/concrete,
-/area/ms13/underground/underground_town)
-"cqv" = (
-/obj/machinery/door/unpowered/ms13/metal/red{
-	dir = 4
-	},
-/turf/open/floor/wood/ms13/wide,
 /area/ms13/underground/underground_town)
 "crj" = (
 /obj/structure/chair/ms13/metal/unfinished{
@@ -12806,6 +12801,12 @@
 /obj/structure/stairs/south,
 /turf/open/floor/ms13/tile/full/green,
 /area/ms13/town)
+"cEG" = (
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 4
+	},
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/underground/underground_town)
 "cGh" = (
 /obj/structure/ms13/storage/shelf{
 	dir = 4
@@ -12879,10 +12880,6 @@
 /obj/effect/spawner/random/ms13/guaranteed/seeds/random,
 /turf/open/floor/plating/ms13/ground/mountain,
 /area/ms13/underground/mountain)
-"cQs" = (
-/obj/structure/fluff/ms13/barrel/triple/waste/two,
-/turf/open/floor/plating/ms13/ground/mountain,
-/area/ms13/underground/underground_town)
 "cRg" = (
 /obj/machinery/light/ms13{
 	dir = 1
@@ -12940,6 +12937,11 @@
 /obj/machinery/door/unpowered/ms13/seethrough/fence/wire,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/underground/underground_town)
+"cVc" = (
+/obj/item/paper/ms13/paperslip,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plating/ms13/ground/mountain,
+/area/ms13/underground/underground_town)
 "cVz" = (
 /obj/structure/ms13/rug/rubber,
 /turf/open/floor/ms13/concrete/industrial,
@@ -12988,15 +12990,17 @@
 	},
 /turf/open/floor/plating/ms13/ground/mountain,
 /area/ms13/underground/underground_town)
+"ddI" = (
+/obj/structure/ms13/foundation/wide/varianttwo{
+	dir = 9
+	},
+/turf/open/floor/plating/ms13/ground/mountain,
+/area/ms13/underground/underground_town)
 "ddT" = (
 /obj/structure/ms13/cave_decor/support/wall,
 /obj/structure/ms13/cave_decor/sign_left,
 /turf/open/floor/plating/ms13/ground/mountain,
 /area/ms13/underground/mountain)
-"dfM" = (
-/obj/structure/ms13/pot/plant,
-/turf/open/floor/wood/ms13/wide,
-/area/ms13/underground/underground_town)
 "dgu" = (
 /obj/machinery/server,
 /turf/open/floor/ms13/concrete/industrial,
@@ -13061,6 +13065,10 @@
 /obj/effect/spawner/random/ms13/locked/random/highchance,
 /turf/open/floor/ms13/tile/navy,
 /area/ms13/town)
+"dnB" = (
+/obj/machinery/light/ms13/bulb,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/underground/underground_town)
 "doj" = (
 /obj/structure/table/ms13/metal/grate,
 /obj/machinery/light/ms13,
@@ -13096,12 +13104,6 @@
 	},
 /turf/open/ms13/water/sewer/medium,
 /area/ms13/underground/mountain)
-"dqg" = (
-/obj/machinery/door/unpowered/ms13/metal/red{
-	dir = 1
-	},
-/turf/open/floor/plating/ms13/ground/mountain,
-/area/ms13/underground/underground_town)
 "dqv" = (
 /obj/structure/toilet,
 /obj/structure/closet/ms13/wall/firstaid,
@@ -13154,6 +13156,11 @@
 /obj/effect/spawner/random/ms13/drink/alcohol,
 /turf/open/floor/ms13/concrete,
 /area/ms13/underground/underground_town)
+"dBO" = (
+/obj/item/chair/ms13/plastic,
+/obj/item/ms13/brick,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/underground/underground_town)
 "dCb" = (
 /obj/structure/closet/crate/ms13/army,
 /obj/effect/spawner/random/ms13/ammo/tier1,
@@ -13191,13 +13198,6 @@
 	dir = 4
 	},
 /turf/open/floor/plating/ms13/ground/mountain,
-/area/ms13/underground/underground_town)
-"dFE" = (
-/obj/item/ms13_small_flag/usa,
-/obj/machinery/light/ms13/bulb{
-	dir = 1
-	},
-/turf/open/floor/wood/ms13/wide,
 /area/ms13/underground/underground_town)
 "dHb" = (
 /obj/structure/stairs/north,
@@ -13237,15 +13237,6 @@
 /obj/effect/spawner/random/ms13/crafting/lowrandom,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
-"dMI" = (
-/obj/structure/ms13/foundation/wide/variantfive{
-	dir = 8
-	},
-/obj/structure/chair/ms13/overlaypickup/plastic{
-	dir = 8
-	},
-/turf/open/floor/plating/ms13/ground/mountain,
-/area/ms13/underground/underground_town)
 "dOc" = (
 /obj/structure/ms13/skeleton,
 /obj/machinery/light/ms13/bulb/industrial{
@@ -13312,6 +13303,10 @@
 	},
 /turf/open/floor/ms13/concrete,
 /area/ms13/underground/subway)
+"dTu" = (
+/obj/structure/fluff/ms13/barrel/single/waste/one,
+/turf/open/floor/plating/ms13/ground/mountain,
+/area/ms13/underground/underground_town)
 "dTJ" = (
 /obj/structure/ms13/celldoor/rusty,
 /turf/open/floor/ms13/concrete,
@@ -13379,6 +13374,10 @@
 "ecO" = (
 /obj/effect/spawner/random/ms13/guaranteed/medical/lowrandom,
 /turf/open/floor/ms13/concrete/industrial,
+/area/ms13/underground/underground_town)
+"edM" = (
+/obj/structure/fluff/ms13/barrel/single/toxic/three,
+/turf/open/floor/wood/ms13/wide,
 /area/ms13/underground/underground_town)
 "een" = (
 /obj/effect/spawner/random/ms13/crafting/lowrandom,
@@ -13471,6 +13470,15 @@
 /obj/effect/spawner/random/ms13/currency/mammoth/lowrandom,
 /turf/open/floor/plating/ms13/ground/mountain,
 /area/ms13/underground/mountain)
+"eqY" = (
+/obj/structure/table/ms13/no_smooth/large/wood/desk{
+	dir = 4
+	},
+/obj/machinery/ms13/terminal/wasteland{
+	dir = 4
+	},
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/underground/underground_town)
 "erm" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -13522,23 +13530,6 @@
 /mob/living/basic/ms13/ghoul/radioactive,
 /turf/open/floor/ms13/metal,
 /area/ms13/town)
-"eBT" = (
-/obj/structure/ms13/foundation/wide/variantthree{
-	dir = 6
-	},
-/obj/effect/spawner/random/ms13/melee/lowrandom,
-/mob/living/basic/ms13/hostile_animal/radroach/glowie,
-/turf/open/floor/plating/ms13/ground/mountain,
-/area/ms13/underground/underground_town)
-"eCq" = (
-/obj/structure/closet/ms13/fridge,
-/obj/effect/spawner/random/ms13/drink/alcohol_beer,
-/obj/effect/spawner/random/ms13/drink/alcohol_beer,
-/obj/effect/spawner/random/ms13/drink/alcohol_beer,
-/obj/effect/spawner/random/ms13/drink/alcohol_uncommon,
-/obj/effect/spawner/random/ms13/guaranteed/drink/alcohol_beer,
-/turf/open/floor/wood/ms13/wide,
-/area/ms13/underground/underground_town)
 "eCV" = (
 /obj/item/clothing/head/helmet/ms13/tall/cone,
 /turf/open/floor/wood/ms13/carpet/shaggy,
@@ -13556,6 +13547,16 @@
 	pixel_y = 15
 	},
 /turf/open/floor/ms13/concrete,
+/area/ms13/underground/underground_town)
+"eEZ" = (
+/obj/structure/table/ms13/no_smooth/large/wood/desk{
+	dir = 4
+	},
+/obj/item/pen/ms13,
+/obj/machinery/light/ms13/bulb{
+	dir = 8
+	},
+/turf/open/floor/wood/ms13/wide,
 /area/ms13/underground/underground_town)
 "eGY" = (
 /obj/structure/chair/ms13/wood,
@@ -13675,12 +13676,6 @@
 /obj/structure/ms13/skeleton,
 /turf/open/floor/ms13/concrete,
 /area/ms13/underground/underground_town)
-"eYy" = (
-/obj/effect/decal/cleanable/blood{
-	icon_state = "floor3"
-	},
-/turf/open/floor/wood/ms13/wide,
-/area/ms13/underground/underground_town)
 "eZM" = (
 /obj/machinery/light/ms13,
 /turf/open/floor/ms13/concrete,
@@ -13763,24 +13758,23 @@
 /obj/effect/spawner/random/ms13/tools/lights,
 /turf/open/floor/plating/ms13/ground/mountain,
 /area/ms13/underground/mountain)
-"fnh" = (
-/mob/living/basic/ms13/hostile_animal/radroach/glowie,
-/turf/open/floor/wood/ms13/wide,
-/area/ms13/underground/underground_town)
 "fpY" = (
 /obj/structure/closet/crate/ms13/woodcrate/compact,
 /obj/effect/spawner/random/ms13/tools/tool,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
+"frr" = (
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 8;
+	pixel_y = 6
+	},
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/underground/underground_town)
 "fry" = (
 /obj/structure/flora/rock/jungle,
 /obj/structure/ms13/cave_decor/support/wall,
 /turf/open/floor/plating/ms13/ground/mountain,
 /area/ms13/underground/mountain)
-"fuR" = (
-/obj/structure/ms13/tv/wooden,
-/turf/open/floor/wood/ms13/wide,
-/area/ms13/underground/underground_town)
 "fvr" = (
 /obj/structure/table/ms13/metal/small,
 /obj/item/ms13/fluff/ashtray,
@@ -13795,11 +13789,6 @@
 	},
 /turf/open/floor/ms13/concrete,
 /area/ms13/town)
-"fwH" = (
-/obj/item/chair/ms13/plastic,
-/obj/item/ms13/brick,
-/turf/open/floor/wood/ms13/wide,
-/area/ms13/underground/underground_town)
 "fxo" = (
 /obj/structure/table/ms13/crafting/weaponbench,
 /turf/open/floor/ms13/concrete,
@@ -13807,6 +13796,10 @@
 "fxZ" = (
 /obj/structure/table/ms13/crafting/workbench,
 /turf/open/floor/ms13/sewer,
+/area/ms13/underground/underground_town)
+"fAd" = (
+/obj/effect/spawner/random/ms13/crafting/lowrandom,
+/turf/open/floor/plating/ms13/ground/mountain,
 /area/ms13/underground/underground_town)
 "fBS" = (
 /obj/structure/closet/crate/ms13/woodcrate,
@@ -13867,15 +13860,6 @@
 /obj/item/clothing/shoes/ms13/military,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/underground/army_bunker)
-"fMe" = (
-/obj/structure/table/ms13/no_smooth/large/wood/desk{
-	dir = 4
-	},
-/obj/machinery/ms13/terminal/wasteland{
-	dir = 4
-	},
-/turf/open/floor/wood/ms13/wide,
-/area/ms13/underground/underground_town)
 "fMu" = (
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/ms13/sewer,
@@ -13953,6 +13937,12 @@
 /obj/effect/spawner/random/ms13/crafting/highrandom,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
+"gaw" = (
+/obj/machinery/door/unpowered/ms13/metal/red{
+	dir = 4
+	},
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/underground/underground_town)
 "gaN" = (
 /obj/structure/table/ms13/metal/grate,
 /obj/structure/ms13/rug/mat/rubber,
@@ -13974,10 +13964,6 @@
 	},
 /obj/structure/ms13/rug/mat/rubber,
 /turf/open/floor/wood/ms13/wide,
-/area/ms13/underground/underground_town)
-"geq" = (
-/obj/machinery/light/ms13/bulb/industrial/broken,
-/turf/open/floor/plating/ms13/ground/mountain,
 /area/ms13/underground/underground_town)
 "geJ" = (
 /obj/machinery/server/alt,
@@ -14029,6 +14015,13 @@
 /obj/structure/bonfire/ms13/fire_barrel,
 /turf/open/floor/ms13/concrete,
 /area/ms13/underground/underground_town)
+"glQ" = (
+/obj/structure/ms13/foundation/wide/variantfour{
+	dir = 8
+	},
+/mob/living/basic/ms13/hostile_animal/radroach/glowie,
+/turf/open/floor/plating/ms13/ground/mountain,
+/area/ms13/underground/underground_town)
 "glR" = (
 /obj/structure/table/ms13/no_smooth/large/metal/desk,
 /obj/effect/spawner/random/ms13/guaranteed/crafting/electrical,
@@ -14068,6 +14061,13 @@
 /obj/machinery/door/airlock/ms13/town/all,
 /turf/open/floor/ms13/metal/grate/border,
 /area/ms13/underground/vault_atrium_lower)
+"gri" = (
+/obj/item/paper/ms13/paperslip,
+/obj/machinery/light/ms13/bulb/industrial{
+	dir = 1
+	},
+/turf/open/floor/plating/ms13/ground/mountain,
+/area/ms13/underground/underground_town)
 "gsd" = (
 /obj/machinery/door/unpowered/ms13/seethrough/fence/wire,
 /turf/open/floor/ms13/concrete/industrial,
@@ -14160,19 +14160,16 @@
 	},
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
-"gAG" = (
-/obj/structure/bed/ms13/mattress/yellowed,
-/obj/structure/bed/ms13/bedframe/wood,
+"gAC" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 6
+	},
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/underground/underground_town)
 "gCZ" = (
 /obj/structure/ms13/medical_curtain,
 /turf/open/floor/ms13/tile/navy,
 /area/ms13/town)
-"gDG" = (
-/mob/living/basic/ms13/ghoul/radioactive,
-/turf/open/floor/plating/ms13/ground/mountain,
-/area/ms13/underground/underground_town)
 "gEh" = (
 /obj/effect/decal/cleanable/blood/drip{
 	pixel_x = -7;
@@ -14182,6 +14179,13 @@
 	pixel_x = 6
 	},
 /turf/open/floor/ms13/sewer,
+/area/ms13/underground/underground_town)
+"gFD" = (
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 1;
+	pixel_x = -5
+	},
+/turf/open/floor/wood/ms13/wide,
 /area/ms13/underground/underground_town)
 "gGs" = (
 /mob/living/basic/ms13/hostile_animal/molerat,
@@ -14247,6 +14251,10 @@
 	},
 /turf/open/floor/plating/ms13/ground/mountain,
 /area/ms13/underground/mountain)
+"gSg" = (
+/mob/living/basic/ms13/hostile_animal/radroach/glowie,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/underground/underground_town)
 "gSj" = (
 /obj/structure/sink{
 	dir = 8;
@@ -14265,12 +14273,6 @@
 /obj/effect/spawner/random/ms13/crafting/lowrandom,
 /turf/open/floor/ms13/tile/full/green,
 /area/ms13/underground/army_bunker)
-"gVX" = (
-/obj/structure/fluff/ms13/trash/papers{
-	dir = 5
-	},
-/turf/open/floor/wood/ms13/wide,
-/area/ms13/underground/underground_town)
 "gWH" = (
 /obj/structure/table/ms13/no_smooth/counter/wood/bend{
 	dir = 8
@@ -14295,10 +14297,6 @@
 	},
 /obj/effect/spawner/random/ms13/armor/lowrandom,
 /turf/open/floor/wood/ms13/wide,
-/area/ms13/underground/underground_town)
-"gZL" = (
-/obj/structure/fluff/ms13/barrel/single/toxic/two,
-/turf/open/floor/plating/ms13/ground/mountain,
 /area/ms13/underground/underground_town)
 "hfx" = (
 /obj/effect/decal/cleanable/blood/old,
@@ -14455,6 +14453,16 @@
 	},
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/underground/sewer)
+"hFE" = (
+/obj/structure/ms13/foundation/wide/varianttwo{
+	dir = 10
+	},
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 4
+	},
+/mob/living/basic/ms13/hostile_animal/radroach/glowie,
+/turf/open/floor/plating/ms13/ground/mountain,
+/area/ms13/underground/underground_town)
 "hFF" = (
 /obj/structure/ms13/storage/bookshelf,
 /obj/effect/spawner/random/ms13/guaranteed/drink/alcohol,
@@ -14511,10 +14519,6 @@
 /obj/effect/spawner/random/ms13/medical/bloodbag,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/underground/underground_town)
-"hNz" = (
-/obj/structure/ms13/rug/mat/vulgar/fuckoff,
-/turf/open/floor/wood/ms13/wide,
-/area/ms13/underground/underground_town)
 "hNG" = (
 /obj/structure/window/fulltile/ms13/glass,
 /obj/structure/table/ms13/low_wall/sewer,
@@ -14566,6 +14570,10 @@
 /mob/living/simple_animal/hostile/ms13/robot/robobrain,
 /turf/open/floor/ms13/metal,
 /area/ms13/underground/enclave_base)
+"hWg" = (
+/obj/structure/fluff/ms13/barrel/single/toxic/four,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/underground/underground_town)
 "hWG" = (
 /obj/structure/table/ms13/no_smooth/wood/end,
 /obj/machinery/ms13/coffee{
@@ -14707,6 +14715,12 @@
 /obj/structure/ms13/rug/mat/rubber/single,
 /turf/open/floor/ms13/tile/fancy,
 /area/ms13/town)
+"ipo" = (
+/obj/structure/table/ms13/no_smooth/cable_reel,
+/obj/item/paper/ms13/paperslip,
+/obj/effect/spawner/random/ms13/crafting/lowrandom,
+/turf/open/floor/plating/ms13/ground/mountain,
+/area/ms13/underground/underground_town)
 "iqP" = (
 /obj/effect/spawner/random/ms13/food/packaged,
 /obj/effect/spawner/random/ms13/food/packaged,
@@ -14717,29 +14731,18 @@
 /obj/effect/spawner/random/ms13/medical/tier1,
 /turf/open/floor/ms13/sewer,
 /area/ms13/underground/underground_town)
-"itS" = (
-/obj/structure/table/ms13/no_smooth/large/wood/desk{
-	dir = 4
-	},
-/obj/item/pen/ms13,
-/obj/machinery/light/ms13/bulb{
-	dir = 8
-	},
+"isp" = (
+/obj/structure/closet/ms13/fridge,
+/obj/effect/spawner/random/ms13/drink/alcohol_beer,
+/obj/effect/spawner/random/ms13/drink/alcohol_beer,
+/obj/effect/spawner/random/ms13/drink/alcohol_beer,
+/obj/effect/spawner/random/ms13/drink/alcohol_uncommon,
+/obj/effect/spawner/random/ms13/guaranteed/drink/alcohol_beer,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/underground/underground_town)
 "iuv" = (
 /obj/structure/ms13/rug/mat/rubber,
 /turf/open/floor/ms13/concrete,
-/area/ms13/underground/underground_town)
-"iuZ" = (
-/obj/structure/table/ms13/no_smooth/counter/wood/crafted{
-	dir = 4
-	},
-/obj/structure/ms13/foundation/wide/variantfour{
-	dir = 9
-	},
-/obj/effect/spawner/random/ms13/medical/lowrandom,
-/turf/open/floor/plating/ms13/ground/mountain,
 /area/ms13/underground/underground_town)
 "iwb" = (
 /obj/structure/stairs{
@@ -14763,17 +14766,19 @@
 /obj/effect/spawner/random/ms13/guaranteed/crafting/household,
 /turf/open/floor/ms13/concrete/bricks,
 /area/ms13/underground/mountain)
+"iyi" = (
+/obj/item/paper_bin/ms13,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/underground/underground_town)
+"iyo" = (
+/obj/machinery/door/unpowered/ms13/metal/red,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/underground/underground_town)
 "izq" = (
 /obj/effect/spawner/random/ms13/seeds/random,
 /obj/effect/spawner/random/ms13/seeds/random,
 /turf/open/floor/ms13/concrete,
 /area/ms13/underground/mountain)
-"iAl" = (
-/obj/structure/chair/ms13/overlaypickup/plastic{
-	dir = 8
-	},
-/turf/open/floor/wood/ms13/wide,
-/area/ms13/underground/underground_town)
 "iBj" = (
 /obj/machinery/light/ms13{
 	dir = 1
@@ -14784,6 +14789,12 @@
 /obj/structure/table/ms13/wood/constructed,
 /obj/structure/ms13/rug/fancy,
 /turf/open/floor/wood/ms13/wide,
+/area/ms13/underground/underground_town)
+"iCN" = (
+/obj/structure/ms13/foundation/wide/variantfour{
+	dir = 10
+	},
+/turf/open/floor/plating/ms13/ground/mountain,
 /area/ms13/underground/underground_town)
 "iDj" = (
 /obj/structure/bed/roller/ms13,
@@ -14918,6 +14929,16 @@
 /obj/effect/spawner/random/ms13/guaranteed/tools/tool,
 /turf/open/floor/ms13/concrete/bricks,
 /area/ms13/underground/underground_town)
+"jaN" = (
+/obj/structure/table/ms13/no_smooth/counter/wood/crafted{
+	dir = 4
+	},
+/obj/structure/ms13/foundation/wide/variantfour{
+	dir = 9
+	},
+/obj/effect/spawner/random/ms13/medical/lowrandom,
+/turf/open/floor/plating/ms13/ground/mountain,
+/area/ms13/underground/underground_town)
 "jbl" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/ms13/storage/shelf{
@@ -14944,6 +14965,14 @@
 	},
 /turf/open/floor/ms13/concrete,
 /area/ms13/town)
+"jfx" = (
+/obj/structure/ms13/foundation/wide/variantthree,
+/obj/structure/fluff/ms13/trash/papers{
+	dir = 9
+	},
+/obj/item/clothing/head/helmet/ms13/sailor,
+/turf/open/floor/plating/ms13/ground/mountain,
+/area/ms13/underground/underground_town)
 "jif" = (
 /obj/machinery/light/ms13/bulb,
 /obj/structure/bed/ms13/bedframe/cot,
@@ -14956,13 +14985,6 @@
 /obj/structure/ms13/pipes/horizontal/end,
 /turf/closed/wall/ms13/sewer,
 /area/ms13/town)
-"joB" = (
-/obj/structure/ms13/foundation/wide/variantsix{
-	dir = 1
-	},
-/obj/structure/ms13/skeleton,
-/turf/open/floor/plating/ms13/ground/mountain,
-/area/ms13/underground/underground_town)
 "jpK" = (
 /obj/structure/ms13/skeleton,
 /obj/effect/decal/cleanable/blood/splatter,
@@ -14990,10 +15012,6 @@
 /obj/structure/flora/grass/jungle/b,
 /turf/open/floor/plating/ms13/ground/mountain,
 /area/ms13/town)
-"jtd" = (
-/obj/machinery/light/ms13/bulb,
-/turf/open/floor/wood/ms13/wide,
-/area/ms13/underground/underground_town)
 "jvv" = (
 /obj/item/pickaxe/ms13,
 /turf/open/floor/plating/ms13/ground/mountain,
@@ -15101,14 +15119,6 @@
 	},
 /turf/open/floor/plating/ms13/ground/mountain,
 /area/ms13/underground/mountain)
-"jLe" = (
-/obj/structure/ms13/foundation/wide/variantthree,
-/obj/structure/fluff/ms13/trash/papers{
-	dir = 9
-	},
-/obj/item/clothing/head/helmet/ms13/sailor,
-/turf/open/floor/plating/ms13/ground/mountain,
-/area/ms13/underground/underground_town)
 "jOl" = (
 /obj/effect/spawner/random/ms13/food/packaged,
 /obj/effect/spawner/random/ms13/food/packaged,
@@ -15232,14 +15242,20 @@
 /obj/structure/ms13/rug/rubber,
 /turf/open/floor/ms13/metal,
 /area/ms13/underground/vault_atrium_lower)
-"klm" = (
-/obj/structure/fluff/ms13/barrel/single/waste/one,
-/turf/open/floor/plating/ms13/ground/mountain,
-/area/ms13/underground/underground_town)
 "kmd" = (
 /obj/structure/ms13/storage/shelf,
 /obj/effect/spawner/random/ms13/tools/tool,
 /turf/open/floor/ms13/concrete,
+/area/ms13/underground/underground_town)
+"koy" = (
+/obj/structure/closet/crate/ms13/footlocker{
+	dir = 8
+	},
+/obj/effect/spawner/random/ms13/drink/alcohol,
+/obj/effect/spawner/random/ms13/drink/alcohol,
+/obj/effect/spawner/random/ms13/guaranteed/drink/alcohol,
+/obj/effect/spawner/random/ms13/guaranteed/drink/alcohol,
+/turf/open/floor/wood/ms13/wide,
 /area/ms13/underground/underground_town)
 "kpj" = (
 /obj/structure/closet/crate/ms13/woodcrate/compact,
@@ -15571,6 +15587,17 @@
 	},
 /turf/open/floor/plating/ms13/ground/mountain,
 /area/ms13/underground/underground_town)
+"lfU" = (
+/obj/structure/ms13/foundation/wide/variantfive{
+	dir = 9
+	},
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 8;
+	pixel_y = 6
+	},
+/mob/living/basic/ms13/ghoul/radioactive,
+/turf/open/floor/plating/ms13/ground/mountain,
+/area/ms13/underground/underground_town)
 "lgg" = (
 /obj/structure/closet/crate/ms13/footlocker{
 	dir = 1
@@ -15685,20 +15712,6 @@
 /obj/effect/spawner/random/ms13/melee/lowrandom,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/underground/sewer)
-"lBW" = (
-/obj/structure/ms13/foundation/wide/variantfive{
-	dir = 6
-	},
-/obj/structure/closet/crate/ms13/footlocker{
-	dir = 8
-	},
-/obj/effect/spawner/random/ms13/currency/mammoth/prewar/lowrandom,
-/obj/item/clothing/under/ms13/wasteland/navy,
-/obj/item/clothing/head/helmet/ms13/sailor,
-/obj/effect/spawner/random/ms13/clothing/under,
-/obj/effect/spawner/random/ms13/clothing/shoe,
-/turf/open/floor/plating/ms13/ground/mountain,
-/area/ms13/underground/underground_town)
 "lCa" = (
 /obj/structure/table/ms13/metal/grate,
 /obj/item/radio/ms13/ham/receiver/radioking,
@@ -15890,6 +15903,15 @@
 /obj/effect/spawner/random/ms13/crafting/precious,
 /turf/open/floor/ms13/concrete/bricks,
 /area/ms13/underground/underground_town)
+"mgd" = (
+/obj/structure/ms13/foundation/wide/variantsix{
+	dir = 5
+	},
+/obj/machinery/door/unpowered/ms13/metal/red{
+	dir = 1
+	},
+/turf/open/floor/plating/ms13/ground/mountain,
+/area/ms13/underground/underground_town)
 "mgl" = (
 /obj/structure/ms13/rug/fancy{
 	dir = 4
@@ -15906,6 +15928,18 @@
 	},
 /obj/machinery/ms13/terminal/rusty{
 	dir = 8
+	},
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/underground/underground_town)
+"mhT" = (
+/obj/structure/bed/ms13/bedframe/wood,
+/obj/structure/bed/ms13/mattress/stained,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/underground/underground_town)
+"miz" = (
+/obj/structure/fluff/ms13/trash/papers,
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 9
 	},
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/underground/underground_town)
@@ -16070,11 +16104,6 @@
 	},
 /turf/open/floor/wood/ms13/carpet/blue,
 /area/ms13/town)
-"mLe" = (
-/obj/structure/table/ms13/no_smooth/wood,
-/obj/effect/spawner/random/ms13/drink/alcohol,
-/turf/open/floor/wood/ms13/wide,
-/area/ms13/underground/underground_town)
 "mLi" = (
 /obj/machinery/light/ms13/bulb/industrial{
 	dir = 1
@@ -16265,12 +16294,6 @@
 "nnR" = (
 /turf/closed/wall/ms13/scrap/white,
 /area/ms13/underground/sewer)
-"nrC" = (
-/obj/effect/decal/cleanable/blood/footprints{
-	dir = 1
-	},
-/turf/open/floor/wood/ms13/wide,
-/area/ms13/underground/underground_town)
 "ntK" = (
 /obj/structure/lattice/catwalk/ms13,
 /obj/structure/railing/ms13/sewer,
@@ -16373,16 +16396,6 @@
 /obj/structure/chair/sofa/corp/corner,
 /turf/open/floor/wood/ms13/carpet,
 /area/ms13/underground/underground_town)
-"nKH" = (
-/obj/structure/closet/crate/ms13/footlocker{
-	dir = 8
-	},
-/obj/effect/spawner/random/ms13/drink/alcohol,
-/obj/effect/spawner/random/ms13/drink/alcohol,
-/obj/effect/spawner/random/ms13/guaranteed/drink/alcohol,
-/obj/effect/spawner/random/ms13/guaranteed/drink/alcohol,
-/turf/open/floor/wood/ms13/wide,
-/area/ms13/underground/underground_town)
 "nLa" = (
 /obj/structure/bed/ms13/bedframe/metal,
 /obj/structure/bed/ms13/mattress/yellowed,
@@ -16449,6 +16462,12 @@
 /obj/effect/spawner/random/ms13/armor/tier3,
 /turf/open/floor/ms13/concrete/bricks,
 /area/ms13/underground/underground_town)
+"nTK" = (
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 8
+	},
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/underground/underground_town)
 "nTQ" = (
 /obj/structure/ms13/foundation/common/variantsix,
 /obj/structure/ms13/fence/vertical/wire/west,
@@ -16482,6 +16501,10 @@
 	},
 /turf/open/floor/plating/ms13/ground/mountain,
 /area/ms13/underground/mountain)
+"nZk" = (
+/mob/living/basic/ms13/ghoul/radioactive,
+/turf/open/floor/plating/ms13/ground/mountain,
+/area/ms13/underground/underground_town)
 "nZq" = (
 /turf/closed/wall/ms13/concrete,
 /area/ms13/underground/underground_town)
@@ -16626,17 +16649,6 @@
 	},
 /turf/open/floor/ms13/concrete,
 /area/ms13/underground/underground_town)
-"osa" = (
-/obj/item/paper/ms13/paperslip,
-/obj/effect/decal/cleanable/greenglow,
-/turf/open/floor/plating/ms13/ground/mountain,
-/area/ms13/underground/underground_town)
-"osR" = (
-/obj/effect/decal/cleanable/blood/footprints{
-	dir = 4
-	},
-/turf/open/floor/wood/ms13/wide,
-/area/ms13/underground/underground_town)
 "otb" = (
 /obj/structure/ms13/skeleton,
 /obj/effect/decal/cleanable/blood/splatter,
@@ -16667,16 +16679,6 @@
 /obj/structure/ms13/rug/rubber,
 /turf/open/floor/ms13/metal,
 /area/ms13/town)
-"oAK" = (
-/obj/structure/table/ms13/no_smooth/counter/wood/crafted{
-	dir = 8
-	},
-/obj/structure/ms13/foundation/wide/variantfour{
-	dir = 6
-	},
-/obj/effect/spawner/random/ms13/crafting/household,
-/turf/open/floor/plating/ms13/ground/mountain,
-/area/ms13/underground/underground_town)
 "oAP" = (
 /obj/effect/spawner/random/ms13/tools/tool,
 /turf/open/floor/ms13/concrete,
@@ -16851,13 +16853,6 @@
 /obj/machinery/griddle,
 /turf/open/floor/ms13/tile,
 /area/ms13/town)
-"oXh" = (
-/obj/effect/decal/cleanable/blood/footprints{
-	dir = 8;
-	pixel_y = 6
-	},
-/turf/open/floor/wood/ms13/wide,
-/area/ms13/underground/underground_town)
 "oXm" = (
 /obj/structure/closet/ms13/fridge,
 /obj/effect/spawner/random/ms13/food/produce_random,
@@ -17008,6 +17003,20 @@
 /obj/effect/spawner/random/ms13/guaranteed/medical/highrandom,
 /turf/open/floor/ms13/concrete,
 /area/ms13/underground/military_crypt)
+"prc" = (
+/obj/structure/ms13/foundation/wide/variantfive{
+	dir = 6
+	},
+/obj/structure/closet/crate/ms13/footlocker{
+	dir = 8
+	},
+/obj/effect/spawner/random/ms13/currency/mammoth/prewar/lowrandom,
+/obj/item/clothing/under/ms13/wasteland/navy,
+/obj/item/clothing/head/helmet/ms13/sailor,
+/obj/effect/spawner/random/ms13/clothing/under,
+/obj/effect/spawner/random/ms13/clothing/shoe,
+/turf/open/floor/plating/ms13/ground/mountain,
+/area/ms13/underground/underground_town)
 "prV" = (
 /obj/structure/table/ms13/metal/grate,
 /obj/effect/spawner/random/ms13/guaranteed/crafting/electrical,
@@ -17221,10 +17230,6 @@
 /obj/effect/spawner/random/ms13/clothing/gloves,
 /turf/open/floor/ms13/concrete,
 /area/ms13/underground/underground_town)
-"pXB" = (
-/obj/structure/fluff/ms13/barrel/single/toxic/four,
-/turf/open/floor/wood/ms13/wide,
-/area/ms13/underground/underground_town)
 "pZP" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/cleanable/blood/tracks{
@@ -17313,6 +17318,13 @@
 /obj/structure/ms13/fence/wire/end/east,
 /turf/closed/indestructible/rock/ms13/mammoth,
 /area/ms13/underground/mountain)
+"qne" = (
+/obj/structure/ms13/foundation/wide/variantsix{
+	dir = 1
+	},
+/obj/structure/ms13/skeleton,
+/turf/open/floor/plating/ms13/ground/mountain,
+/area/ms13/underground/underground_town)
 "qni" = (
 /obj/structure/table/rolling/ms13,
 /obj/effect/spawner/random/ms13/medical/bloodbag,
@@ -17326,6 +17338,15 @@
 	},
 /turf/open/floor/ms13/concrete,
 /area/ms13/town)
+"qok" = (
+/obj/structure/ms13/foundation/wide/variantfive{
+	dir = 8
+	},
+/obj/structure/chair/ms13/overlaypickup/plastic{
+	dir = 8
+	},
+/turf/open/floor/plating/ms13/ground/mountain,
+/area/ms13/underground/underground_town)
 "qoS" = (
 /obj/structure/table/ms13/metal,
 /obj/effect/spawner/random/ms13/drink/alcohol_beer,
@@ -17337,10 +17358,6 @@
 	},
 /turf/open/floor/ms13/metal,
 /area/ms13/town)
-"qqm" = (
-/obj/structure/fluff/ms13/barrel/single/toxic/three,
-/turf/open/floor/wood/ms13/wide,
-/area/ms13/underground/underground_town)
 "qtd" = (
 /obj/structure/ms13/storage/large/shelf{
 	dir = 8
@@ -17357,6 +17374,10 @@
 /obj/structure/railing/ms13/sewer,
 /turf/open/ms13/water/sewer/medium,
 /area/ms13/underground/sewer)
+"qtM" = (
+/obj/machinery/light/ms13/bulb/industrial/broken,
+/turf/open/floor/plating/ms13/ground/mountain,
+/area/ms13/underground/underground_town)
 "qtS" = (
 /obj/structure/table/ms13/crafting/tinkerbench,
 /turf/open/floor/ms13/metal,
@@ -17482,10 +17503,6 @@
 /obj/structure/ms13/storage/shelf,
 /turf/open/floor/ms13/concrete,
 /area/ms13/underground/subway)
-"qQz" = (
-/obj/effect/decal/cleanable/greenglow,
-/turf/open/floor/wood/ms13/wide,
-/area/ms13/underground/underground_town)
 "qQW" = (
 /obj/structure/fluff/ms13/trash/papers{
 	dir = 4
@@ -17574,16 +17591,6 @@
 /mob/living/basic/ms13/robot/handy,
 /turf/open/floor/ms13/metal,
 /area/ms13/underground/enclave_base)
-"rsj" = (
-/obj/structure/ms13/foundation/wide/varianttwo{
-	dir = 10
-	},
-/obj/effect/decal/cleanable/blood/footprints{
-	dir = 4
-	},
-/mob/living/basic/ms13/hostile_animal/radroach/glowie,
-/turf/open/floor/plating/ms13/ground/mountain,
-/area/ms13/underground/underground_town)
 "rtS" = (
 /obj/structure/table/ms13/metal,
 /obj/effect/spawner/random/ms13/medical/lowrandom,
@@ -17623,6 +17630,12 @@
 	dir = 4
 	},
 /turf/open/floor/ms13/sewer,
+/area/ms13/underground/underground_town)
+"rwP" = (
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 1
+	},
+/turf/open/floor/wood/ms13/wide,
 /area/ms13/underground/underground_town)
 "rCq" = (
 /obj/effect/turf_decal/stripes/line{
@@ -17703,12 +17716,6 @@
 	},
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/underground/underground_town)
-"rHY" = (
-/obj/structure/table/ms13/no_smooth/cable_reel,
-/obj/item/paper/ms13/paperslip,
-/obj/effect/spawner/random/ms13/crafting/lowrandom,
-/turf/open/floor/plating/ms13/ground/mountain,
-/area/ms13/underground/underground_town)
 "rJe" = (
 /obj/structure/chair/office/ms13/red{
 	dir = 1
@@ -17764,11 +17771,8 @@
 /obj/effect/spawner/random/ms13/crafting/lowrandom,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
-"rOg" = (
-/obj/item/paper/ms13/paperslip,
-/obj/machinery/light/ms13/bulb/industrial{
-	dir = 1
-	},
+"rOt" = (
+/obj/structure/ms13/foundation/wide/varianttwo,
 /turf/open/floor/plating/ms13/ground/mountain,
 /area/ms13/underground/underground_town)
 "rOY" = (
@@ -17800,9 +17804,6 @@
 /obj/effect/spawner/random/ms13/tools/tool,
 /obj/effect/spawner/random/ms13/tools/tool,
 /turf/open/floor/ms13/concrete/industrial,
-/area/ms13/underground/underground_town)
-"rUY" = (
-/turf/open/ms13/water/sewer/medium,
 /area/ms13/underground/underground_town)
 "rXp" = (
 /obj/machinery/door/unpowered/ms13/seethrough/grate{
@@ -17865,6 +17866,10 @@
 	},
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/underground/army_bunker)
+"sdh" = (
+/obj/structure/fluff/ms13/barrel/single/toxic/two,
+/turf/open/floor/plating/ms13/ground/mountain,
+/area/ms13/underground/underground_town)
 "seC" = (
 /obj/effect/decal/cleanable/blood/old{
 	pixel_x = 10
@@ -17930,17 +17935,6 @@
 /obj/structure/ms13/storage/shelf,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/underground/underground_town)
-"slr" = (
-/obj/structure/ms13/foundation/wide/variantfive{
-	dir = 9
-	},
-/obj/effect/decal/cleanable/blood/footprints{
-	dir = 8;
-	pixel_y = 6
-	},
-/mob/living/basic/ms13/ghoul/radioactive,
-/turf/open/floor/plating/ms13/ground/mountain,
-/area/ms13/underground/underground_town)
 "sls" = (
 /obj/effect/spawner/random/ms13/ammo/lowrandom,
 /obj/structure/table/ms13/wood/bar,
@@ -17966,6 +17960,28 @@
 	},
 /turf/open/floor/ms13/concrete,
 /area/ms13/underground/mountain)
+"sox" = (
+/obj/structure/ms13/foundation/wide/variantfour{
+	dir = 6
+	},
+/obj/effect/spawner/random/ms13/gun/tier2,
+/obj/effect/spawner/random/ms13/currency/mammoth/prewar/lowrandom,
+/obj/effect/spawner/random/ms13/clothing/gloves,
+/obj/machinery/light/ms13/bulb{
+	dir = 8
+	},
+/turf/open/floor/plating/ms13/ground/mountain,
+/area/ms13/underground/underground_town)
+"soy" = (
+/obj/structure/table/ms13/no_smooth/counter/wood/crafted{
+	dir = 8
+	},
+/obj/structure/ms13/foundation/wide/variantfour{
+	dir = 6
+	},
+/obj/effect/spawner/random/ms13/crafting/household,
+/turf/open/floor/plating/ms13/ground/mountain,
+/area/ms13/underground/underground_town)
 "soB" = (
 /obj/structure/chair/ms13/overlaypickup/plastic{
 	dir = 8
@@ -17991,10 +18007,6 @@
 /obj/structure/filingcabinet/ms13,
 /turf/open/floor/ms13/concrete,
 /area/ms13/underground/subway)
-"srq" = (
-/obj/structure/fluff/ms13/barrel/triple/waste,
-/turf/open/floor/plating/ms13/ground/mountain,
-/area/ms13/underground/underground_town)
 "ssh" = (
 /obj/structure/railing/ms13/sewer{
 	dir = 4
@@ -18012,13 +18024,6 @@
 /obj/effect/turf_decal/ms13/graffiti/no_way,
 /turf/open/floor/plating/ms13/ground/mountain,
 /area/ms13/underground/mountain)
-"stJ" = (
-/obj/structure/ms13/foundation/wide/variantfour{
-	dir = 8
-	},
-/mob/living/basic/ms13/hostile_animal/radroach/glowie,
-/turf/open/floor/plating/ms13/ground/mountain,
-/area/ms13/underground/underground_town)
 "svg" = (
 /obj/effect/spawner/random/ms13/tools/lights,
 /obj/effect/spawner/random/ms13/tools/lights,
@@ -18090,18 +18095,6 @@
 /obj/structure/bonfire/ms13/fire_barrel,
 /turf/open/floor/ms13/concrete,
 /area/ms13/town)
-"sIr" = (
-/obj/structure/ms13/foundation/wide/variantfour{
-	dir = 6
-	},
-/obj/effect/spawner/random/ms13/gun/tier2,
-/obj/effect/spawner/random/ms13/currency/mammoth/prewar/lowrandom,
-/obj/effect/spawner/random/ms13/clothing/gloves,
-/obj/machinery/light/ms13/bulb{
-	dir = 8
-	},
-/turf/open/floor/plating/ms13/ground/mountain,
-/area/ms13/underground/underground_town)
 "sIs" = (
 /obj/structure/chair/ms13/metal/blue/broken,
 /turf/open/floor/ms13/tile/navy,
@@ -18454,14 +18447,6 @@
 /obj/structure/table/ms13/no_smooth/counter/metal,
 /turf/open/floor/ms13/concrete,
 /area/ms13/underground/underground_town)
-"tOL" = (
-/obj/item/paper_bin/ms13,
-/turf/open/floor/wood/ms13/wide,
-/area/ms13/underground/underground_town)
-"tPX" = (
-/obj/structure/ms13/foundation/wide/varianttwo,
-/turf/open/floor/plating/ms13/ground/mountain,
-/area/ms13/underground/underground_town)
 "tQq" = (
 /obj/structure/chair/ms13/wood/padded{
 	dir = 8
@@ -18491,6 +18476,10 @@
 /obj/effect/spawner/random/ms13/food/produce_random,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/underground/underground_town)
+"tSL" = (
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/underground/underground_town)
 "tTk" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 4
@@ -18514,6 +18503,10 @@
 	},
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/underground/sewer)
+"tUc" = (
+/obj/structure/ms13/rug/mat/vulgar/fuckoff,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/underground/underground_town)
 "tUm" = (
 /obj/structure/table/ms13/crafting/workbench,
 /turf/open/floor/ms13/concrete,
@@ -18656,6 +18649,15 @@
 /obj/effect/spawner/random/ms13/food/produce_random,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/underground/underground_town)
+"upY" = (
+/obj/structure/ms13/foundation/wide/variantfive{
+	dir = 10
+	},
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 4
+	},
+/turf/open/floor/plating/ms13/ground/mountain,
+/area/ms13/underground/underground_town)
 "uqT" = (
 /obj/structure/ms13/storage/large/shelf{
 	dir = 8
@@ -18686,22 +18688,18 @@
 /obj/structure/ms13/smelter,
 /turf/open/floor/ms13/concrete,
 /area/ms13/underground/underground_town)
-"uvU" = (
-/obj/structure/closet/crate/ms13/footlocker{
-	dir = 8
-	},
-/obj/effect/spawner/random/ms13/currency/mammoth/prewar/lowrandom,
-/obj/item/clothing/under/ms13/wasteland/navy,
-/obj/effect/spawner/random/ms13/clothing/under,
-/obj/effect/spawner/random/ms13/clothing/shoe,
-/turf/open/floor/wood/ms13/wide,
-/area/ms13/underground/underground_town)
 "uAU" = (
 /obj/machinery/button/ms13{
 	dir = 4;
 	id = "vague-sewer-lockup"
 	},
 /turf/open/ms13/water/sewer/deep,
+/area/ms13/underground/underground_town)
+"uBf" = (
+/obj/machinery/door/unpowered/ms13/metal/red{
+	dir = 1
+	},
+/turf/open/floor/plating/ms13/ground/mountain,
 /area/ms13/underground/underground_town)
 "uBk" = (
 /obj/machinery/light/ms13/bulb/broken{
@@ -18727,12 +18725,6 @@
 "uEh" = (
 /obj/structure/table/ms13/wood/constructed,
 /obj/effect/spawner/random/ms13/drink/soda,
-/turf/open/floor/wood/ms13/wide,
-/area/ms13/underground/underground_town)
-"uFa" = (
-/obj/effect/decal/cleanable/blood/tracks{
-	dir = 6
-	},
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/underground/underground_town)
 "uFf" = (
@@ -18816,10 +18808,6 @@
 /obj/effect/spawner/random/ms13/crafting/lowrandom,
 /turf/open/floor/ms13/concrete,
 /area/ms13/underground/underground_town)
-"uNH" = (
-/obj/effect/spawner/random/ms13/crafting/lowrandom,
-/turf/open/floor/plating/ms13/ground/mountain,
-/area/ms13/underground/underground_town)
 "uNL" = (
 /obj/structure/ms13/rug/rubber,
 /turf/open/floor/ms13/concrete,
@@ -18884,6 +18872,14 @@
 	},
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
+"uYo" = (
+/obj/structure/ms13/foundation/wide/variantthree{
+	dir = 6
+	},
+/obj/effect/spawner/random/ms13/melee/lowrandom,
+/mob/living/basic/ms13/hostile_animal/radroach/glowie,
+/turf/open/floor/plating/ms13/ground/mountain,
+/area/ms13/underground/underground_town)
 "uYX" = (
 /obj/structure/ms13/storage/shelf{
 	dir = 1
@@ -18956,15 +18952,6 @@
 /obj/machinery/ms13/terminal,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/underground/sewer)
-"vhZ" = (
-/obj/structure/ms13/foundation/wide/variantfive{
-	dir = 10
-	},
-/obj/effect/decal/cleanable/blood/footprints{
-	dir = 4
-	},
-/turf/open/floor/plating/ms13/ground/mountain,
-/area/ms13/underground/underground_town)
 "vji" = (
 /obj/machinery/light/ms13/bulb/industrial{
 	dir = 8
@@ -19073,12 +19060,6 @@
 /obj/structure/chair/ms13/metal/stool,
 /turf/open/floor/ms13/tile,
 /area/ms13/town)
-"vvV" = (
-/obj/structure/ms13/foundation/wide/varianttwo{
-	dir = 9
-	},
-/turf/open/floor/plating/ms13/ground/mountain,
-/area/ms13/underground/underground_town)
 "vwv" = (
 /obj/effect/spawner/random/ms13/tools/tool,
 /turf/open/floor/ms13/concrete,
@@ -19117,12 +19098,6 @@
 	dir = 1
 	},
 /turf/open/floor/plating/ms13/ground/mountain,
-/area/ms13/underground/underground_town)
-"vHs" = (
-/obj/effect/decal/cleanable/blood/footprints{
-	dir = 8
-	},
-/turf/open/floor/wood/ms13/wide,
 /area/ms13/underground/underground_town)
 "vIg" = (
 /obj/structure/ms13/bars/rusty,
@@ -19219,6 +19194,13 @@
 	},
 /turf/open/floor/ms13/concrete/bricks,
 /area/ms13/underground/underground_town)
+"wdM" = (
+/obj/structure/ms13/tv/wooden,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/underground/underground_town)
+"wfx" = (
+/turf/open/ms13/water/sewer/medium,
+/area/ms13/underground/underground_town)
 "wfy" = (
 /obj/structure/table/ms13/no_smooth/large/metal/desk{
 	dir = 4
@@ -19242,6 +19224,12 @@
 /obj/structure/fluff/ms13/trash/papers,
 /turf/open/floor/ms13/concrete,
 /area/ms13/town)
+"wkQ" = (
+/obj/structure/chair/ms13/overlaypickup/plastic{
+	dir = 8
+	},
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/underground/underground_town)
 "wmE" = (
 /obj/structure/ms13/jukebox,
 /turf/open/floor/wood/ms13/common,
@@ -19296,16 +19284,15 @@
 "wyy" = (
 /turf/closed/wall/ms13/concrete/alt,
 /area/ms13/underground/mountain)
+"wzX" = (
+/obj/structure/ms13/storage/shelf/wood,
+/obj/effect/spawner/random/ms13/medical/tier1,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/underground/underground_town)
 "wBq" = (
 /obj/structure/table/ms13/no_smooth/wood/low,
 /obj/item/radio/ms13/ham/receiver/radioking/wood,
 /turf/open/floor/wood/ms13/wide,
-/area/ms13/underground/underground_town)
-"wCy" = (
-/obj/structure/ms13/foundation/wide/variantfour{
-	dir = 10
-	},
-/turf/open/floor/plating/ms13/ground/mountain,
 /area/ms13/underground/underground_town)
 "wDi" = (
 /obj/structure/fluff/ms13/barrel/triple/yellow/two,
@@ -19432,13 +19419,6 @@
 /obj/structure/bed/ms13/bedframe/metal,
 /turf/open/floor/ms13/concrete,
 /area/ms13/underground/underground_town)
-"wVE" = (
-/obj/structure/fluff/ms13/trash/papers,
-/obj/effect/decal/cleanable/blood/tracks{
-	dir = 9
-	},
-/turf/open/floor/wood/ms13/wide,
-/area/ms13/underground/underground_town)
 "wVV" = (
 /obj/structure/ms13/tank/pipe,
 /turf/open/floor/ms13/concrete/industrial,
@@ -19470,6 +19450,12 @@
 /obj/effect/spawner/random/ms13/drink/alcohol_uncommon,
 /turf/open/floor/ms13/tile,
 /area/ms13/town)
+"xgm" = (
+/obj/machinery/light/ms13/bulb{
+	dir = 8
+	},
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/underground/underground_town)
 "xhY" = (
 /obj/machinery/light/ms13,
 /turf/open/floor/ms13/concrete/industrial,
@@ -19511,6 +19497,10 @@
 	},
 /turf/open/floor/plating/ms13/ground/mountain,
 /area/ms13/underground/mountain)
+"xpA" = (
+/obj/structure/ms13/pot/plant,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/underground/underground_town)
 "xpQ" = (
 /obj/effect/turf_decal/ms13/covering/paint/gray,
 /turf/closed/wall/ms13/sewer,
@@ -19525,6 +19515,16 @@
 	},
 /turf/open/ms13/water/sewer/medium,
 /area/ms13/underground/sewer)
+"xtq" = (
+/obj/structure/closet/crate/ms13/footlocker{
+	dir = 8
+	},
+/obj/effect/spawner/random/ms13/currency/mammoth/prewar/lowrandom,
+/obj/item/clothing/under/ms13/wasteland/navy,
+/obj/effect/spawner/random/ms13/clothing/under,
+/obj/effect/spawner/random/ms13/clothing/shoe,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/underground/underground_town)
 "xtM" = (
 /obj/machinery/light/ms13/bulb,
 /obj/structure/chair/sofa/corp/corner{
@@ -19629,12 +19629,6 @@
 /obj/effect/spawner/random/ms13/guaranteed/drink/alcohol,
 /turf/open/floor/plating/ms13/ground/mountain,
 /area/ms13/underground/underground_town)
-"xGc" = (
-/obj/machinery/light/ms13/bulb{
-	dir = 8
-	},
-/turf/open/floor/wood/ms13/wide,
-/area/ms13/underground/underground_town)
 "xHF" = (
 /obj/effect/spawner/random/ms13/drink/alcohol,
 /obj/effect/spawner/random/ms13/drink/alcohol,
@@ -19707,6 +19701,13 @@
 /obj/structure/stairs/north,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
+"ybs" = (
+/obj/item/ms13_small_flag/usa,
+/obj/machinery/light/ms13/bulb{
+	dir = 1
+	},
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/underground/underground_town)
 "ybQ" = (
 /obj/structure/ms13/storage/shelf{
 	dir = 1
@@ -19729,6 +19730,12 @@
 /obj/structure/ms13/medical_curtain,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/underground/underground_town)
+"yeN" = (
+/obj/effect/decal/cleanable/blood{
+	icon_state = "floor3"
+	},
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/underground/underground_town)
 "yfV" = (
 /obj/effect/turf_decal/ms13/graffiti/mirelurk,
 /turf/closed/indestructible/rock/ms13/mammoth,
@@ -19740,13 +19747,6 @@
 	},
 /turf/open/floor/ms13/tile/long,
 /area/ms13/town)
-"yit" = (
-/obj/effect/decal/cleanable/blood/footprints{
-	dir = 1;
-	pixel_x = -5
-	},
-/turf/open/floor/wood/ms13/wide,
-/area/ms13/underground/underground_town)
 "ykU" = (
 /obj/structure/railing/ms13/sewer{
 	dir = 8
@@ -83070,9 +83070,9 @@ afU
 afU
 afU
 aiR
-pXB
-sIr
-fMe
+hWg
+sox
+eqY
 aiR
 afU
 afU
@@ -83372,9 +83372,9 @@ afU
 afU
 afU
 aiR
-qQz
-vhZ
-dMI
+tSL
+upY
+qok
 aiR
 afU
 afU
@@ -83674,12 +83674,12 @@ afU
 afU
 afU
 aiR
-qqm
-slr
-lBW
+edM
+lfU
+prc
 aiR
-srq
-gZL
+blW
+sdh
 afU
 afU
 afU
@@ -83976,11 +83976,11 @@ afU
 afU
 afU
 aiR
-oXh
-vHs
-bXj
+frr
+nTK
+mhT
 aiR
-uNH
+fAd
 aMU
 aXl
 afU
@@ -84278,14 +84278,14 @@ afU
 afU
 aiR
 aiR
-cqv
+gaw
 aiR
 aiR
 aiR
-rOg
-rHY
+gri
+ipo
 aXl
-gDG
+nZk
 afU
 afU
 afU
@@ -84579,15 +84579,15 @@ afU
 afU
 afU
 aiR
-dfM
-vHs
-xGc
-fnh
-bSL
-uNH
-osa
-cQs
-klm
+xpA
+nTK
+xgm
+gSg
+iyo
+fAd
+cVc
+bPt
+dTu
 afU
 afU
 afU
@@ -84874,17 +84874,17 @@ aRM
 aSH
 aZW
 afU
-rUY
-rUY
-rUY
-rUY
-rUY
+wfx
+wfx
+wfx
+wfx
+wfx
 afU
 aiR
-fuR
+wdM
 aff
-osR
-mLe
+cEG
+ciU
 aiR
 aiR
 aiR
@@ -85175,22 +85175,22 @@ aqI
 aqI
 aLH
 aZW
-rUY
-rUY
-rUY
-rUY
-rUY
+wfx
+wfx
+wfx
+wfx
+wfx
 aXl
 aiR
 aiR
-bfL
-rsj
-tPX
-iAl
+wzX
+hFE
+rOt
+wkQ
 aiR
-gVX
-tOL
-itS
+cfy
+iyi
+eEZ
 aiR
 afU
 afU
@@ -85478,21 +85478,21 @@ aRM
 aSH
 aPL
 aXl
-rUY
-rUY
-rUY
+wfx
 aXl
-geq
+wfx
+aXl
+qtM
 aiR
-dFE
+ybs
 aff
-vvV
+ddI
 dFl
-vHs
+nTK
 aiR
-jLe
-wVE
-eYy
+jfx
+miz
+yeN
 aiR
 afU
 afU
@@ -85781,20 +85781,20 @@ aLH
 aZW
 aXl
 aXl
-rUY
 aXl
 aXl
 aXl
-dqg
-hNz
+aXl
+uBf
+tUc
 aff
 aff
-nrC
-yit
-bSR
-joB
-uFa
-uvU
+rwP
+gFD
+mgd
+qne
+gAC
+xtq
 aiR
 afU
 afU
@@ -86090,13 +86090,13 @@ afU
 aiR
 aiR
 aff
-wCy
-stJ
-jtd
+iCN
+glQ
+dnB
 aiR
-eBT
-fwH
-gAG
+uYo
+dBO
+buE
 aiR
 afU
 afU
@@ -86391,10 +86391,10 @@ afU
 afU
 afU
 aiR
-nKH
-iuZ
-oAK
-eCq
+koy
+jaN
+soy
+isp
 aiR
 aiR
 aiR

--- a/_maps/map_files/Mammoth/Mammoth_below.dmm
+++ b/_maps/map_files/Mammoth/Mammoth_below.dmm
@@ -12252,6 +12252,11 @@
 /obj/structure/ms13/barricade,
 /turf/open/floor/plating/ms13/ground/mountain,
 /area/ms13/underground/mountain)
+"bfL" = (
+/obj/structure/ms13/storage/shelf/wood,
+/obj/effect/spawner/random/ms13/medical/tier1,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/underground/underground_town)
 "bfV" = (
 /obj/structure/ms13/foundation/wide/variantfour,
 /turf/open/floor/plating/ms13/ground/mountain,
@@ -12271,10 +12276,6 @@
 	},
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
-"bhR" = (
-/obj/effect/decal/cleanable/greenglow,
-/turf/open/floor/wood/ms13/wide,
-/area/ms13/underground/mountain)
 "biD" = (
 /obj/structure/ms13/storage/large/shelf{
 	dir = 8
@@ -12386,10 +12387,6 @@
 /obj/structure/bed/ms13/sleepingbag/green,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/underground/underground_town)
-"bzK" = (
-/obj/machinery/light/ms13/bulb/industrial/broken,
-/turf/open/floor/plating/ms13/ground/mountain,
-/area/ms13/underground/mountain)
 "bzR" = (
 /obj/structure/table/ms13/no_smooth/counter/wood/crafted{
 	dir = 4
@@ -12492,16 +12489,6 @@
 	},
 /turf/open/floor/ms13/metal,
 /area/ms13/town)
-"bPr" = (
-/obj/structure/table/ms13/no_smooth/large/wood/desk{
-	dir = 4
-	},
-/obj/item/pen/ms13,
-/obj/machinery/light/ms13/bulb{
-	dir = 8
-	},
-/turf/open/floor/wood/ms13/wide,
-/area/ms13/underground/mountain)
 "bPM" = (
 /obj/structure/ms13/storage/shelf{
 	dir = 8
@@ -12528,6 +12515,19 @@
 	},
 /turf/open/floor/ms13/concrete,
 /area/ms13/underground/underground_town)
+"bSL" = (
+/obj/machinery/door/unpowered/ms13/metal/red,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/underground/underground_town)
+"bSR" = (
+/obj/structure/ms13/foundation/wide/variantsix{
+	dir = 5
+	},
+/obj/machinery/door/unpowered/ms13/metal/red{
+	dir = 1
+	},
+/turf/open/floor/plating/ms13/ground/mountain,
+/area/ms13/underground/underground_town)
 "bUc" = (
 /obj/structure/closet/ms13/wall/firstaid,
 /obj/effect/spawner/random/ms13/medical/tier2,
@@ -12553,16 +12553,11 @@
 /obj/effect/spawner/random/ms13/seeds/unique,
 /turf/open/floor/ms13/metal/plate,
 /area/ms13/underground/military_crypt)
-"bXc" = (
-/obj/structure/closet/crate/ms13/footlocker{
-	dir = 8
-	},
-/obj/effect/spawner/random/ms13/drink/alcohol,
-/obj/effect/spawner/random/ms13/drink/alcohol,
-/obj/effect/spawner/random/ms13/guaranteed/drink/alcohol,
-/obj/effect/spawner/random/ms13/guaranteed/drink/alcohol,
+"bXj" = (
+/obj/structure/bed/ms13/bedframe/wood,
+/obj/structure/bed/ms13/mattress/stained,
 /turf/open/floor/wood/ms13/wide,
-/area/ms13/underground/mountain)
+/area/ms13/underground/underground_town)
 "bXK" = (
 /obj/effect/spawner/random/ms13/tools/lights,
 /turf/open/floor/ms13/concrete,
@@ -12708,6 +12703,12 @@
 /obj/item/radio/ms13/ham,
 /turf/open/floor/ms13/concrete,
 /area/ms13/underground/underground_town)
+"cqv" = (
+/obj/machinery/door/unpowered/ms13/metal/red{
+	dir = 4
+	},
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/underground/underground_town)
 "crj" = (
 /obj/structure/chair/ms13/metal/unfinished{
 	dir = 4
@@ -12763,10 +12764,6 @@
 	},
 /turf/open/floor/ms13/sewer,
 /area/ms13/underground/underground_town)
-"cyk" = (
-/obj/effect/spawner/random/ms13/crafting/lowrandom,
-/turf/open/floor/plating/ms13/ground/mountain,
-/area/ms13/underground/mountain)
 "cyt" = (
 /obj/structure/fluff/ms13/trash/papers,
 /mob/living/basic/ms13/ghoul/radioactive,
@@ -12798,11 +12795,6 @@
 	},
 /turf/open/floor/ms13/tile/large/cafeteria,
 /area/ms13/underground/sewer)
-"cAT" = (
-/obj/structure/ms13/storage/shelf/wood,
-/obj/effect/spawner/random/ms13/medical/tier1,
-/turf/open/floor/wood/ms13/wide,
-/area/ms13/underground/mountain)
 "cAW" = (
 /obj/effect/spawner/random/ms13/clothing/under,
 /obj/structure/closet/crate/ms13/footlocker{
@@ -12887,6 +12879,10 @@
 /obj/effect/spawner/random/ms13/guaranteed/seeds/random,
 /turf/open/floor/plating/ms13/ground/mountain,
 /area/ms13/underground/mountain)
+"cQs" = (
+/obj/structure/fluff/ms13/barrel/triple/waste/two,
+/turf/open/floor/plating/ms13/ground/mountain,
+/area/ms13/underground/underground_town)
 "cRg" = (
 /obj/machinery/light/ms13{
 	dir = 1
@@ -12997,6 +12993,10 @@
 /obj/structure/ms13/cave_decor/sign_left,
 /turf/open/floor/plating/ms13/ground/mountain,
 /area/ms13/underground/mountain)
+"dfM" = (
+/obj/structure/ms13/pot/plant,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/underground/underground_town)
 "dgu" = (
 /obj/machinery/server,
 /turf/open/floor/ms13/concrete/industrial,
@@ -13096,6 +13096,12 @@
 	},
 /turf/open/ms13/water/sewer/medium,
 /area/ms13/underground/mountain)
+"dqg" = (
+/obj/machinery/door/unpowered/ms13/metal/red{
+	dir = 1
+	},
+/turf/open/floor/plating/ms13/ground/mountain,
+/area/ms13/underground/underground_town)
 "dqv" = (
 /obj/structure/toilet,
 /obj/structure/closet/ms13/wall/firstaid,
@@ -13186,6 +13192,13 @@
 	},
 /turf/open/floor/plating/ms13/ground/mountain,
 /area/ms13/underground/underground_town)
+"dFE" = (
+/obj/item/ms13_small_flag/usa,
+/obj/machinery/light/ms13/bulb{
+	dir = 1
+	},
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/underground/underground_town)
 "dHb" = (
 /obj/structure/stairs/north,
 /turf/open/floor/ms13/concrete/industrial,
@@ -13224,6 +13237,15 @@
 /obj/effect/spawner/random/ms13/crafting/lowrandom,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
+"dMI" = (
+/obj/structure/ms13/foundation/wide/variantfive{
+	dir = 8
+	},
+/obj/structure/chair/ms13/overlaypickup/plastic{
+	dir = 8
+	},
+/turf/open/floor/plating/ms13/ground/mountain,
+/area/ms13/underground/underground_town)
 "dOc" = (
 /obj/structure/ms13/skeleton,
 /obj/machinery/light/ms13/bulb/industrial{
@@ -13500,6 +13522,23 @@
 /mob/living/basic/ms13/ghoul/radioactive,
 /turf/open/floor/ms13/metal,
 /area/ms13/town)
+"eBT" = (
+/obj/structure/ms13/foundation/wide/variantthree{
+	dir = 6
+	},
+/obj/effect/spawner/random/ms13/melee/lowrandom,
+/mob/living/basic/ms13/hostile_animal/radroach/glowie,
+/turf/open/floor/plating/ms13/ground/mountain,
+/area/ms13/underground/underground_town)
+"eCq" = (
+/obj/structure/closet/ms13/fridge,
+/obj/effect/spawner/random/ms13/drink/alcohol_beer,
+/obj/effect/spawner/random/ms13/drink/alcohol_beer,
+/obj/effect/spawner/random/ms13/drink/alcohol_beer,
+/obj/effect/spawner/random/ms13/drink/alcohol_uncommon,
+/obj/effect/spawner/random/ms13/guaranteed/drink/alcohol_beer,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/underground/underground_town)
 "eCV" = (
 /obj/item/clothing/head/helmet/ms13/tall/cone,
 /turf/open/floor/wood/ms13/carpet/shaggy,
@@ -13636,6 +13675,12 @@
 /obj/structure/ms13/skeleton,
 /turf/open/floor/ms13/concrete,
 /area/ms13/underground/underground_town)
+"eYy" = (
+/obj/effect/decal/cleanable/blood{
+	icon_state = "floor3"
+	},
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/underground/underground_town)
 "eZM" = (
 /obj/machinery/light/ms13,
 /turf/open/floor/ms13/concrete,
@@ -13650,10 +13695,6 @@
 /obj/item/clothing/head/hardhat/ms13/mining,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/underground/underground_town)
-"fcy" = (
-/obj/structure/ms13/rug/mat/vulgar/fuckoff,
-/turf/open/floor/wood/ms13/wide,
-/area/ms13/underground/mountain)
 "ffl" = (
 /obj/structure/closet/ms13/metal,
 /obj/item/clothing/under/ms13/wasteland/mechanicprewar/mechanicgrey,
@@ -13722,6 +13763,10 @@
 /obj/effect/spawner/random/ms13/tools/lights,
 /turf/open/floor/plating/ms13/ground/mountain,
 /area/ms13/underground/mountain)
+"fnh" = (
+/mob/living/basic/ms13/hostile_animal/radroach/glowie,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/underground/underground_town)
 "fpY" = (
 /obj/structure/closet/crate/ms13/woodcrate/compact,
 /obj/effect/spawner/random/ms13/tools/tool,
@@ -13732,6 +13777,10 @@
 /obj/structure/ms13/cave_decor/support/wall,
 /turf/open/floor/plating/ms13/ground/mountain,
 /area/ms13/underground/mountain)
+"fuR" = (
+/obj/structure/ms13/tv/wooden,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/underground/underground_town)
 "fvr" = (
 /obj/structure/table/ms13/metal/small,
 /obj/item/ms13/fluff/ashtray,
@@ -13746,6 +13795,11 @@
 	},
 /turf/open/floor/ms13/concrete,
 /area/ms13/town)
+"fwH" = (
+/obj/item/chair/ms13/plastic,
+/obj/item/ms13/brick,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/underground/underground_town)
 "fxo" = (
 /obj/structure/table/ms13/crafting/weaponbench,
 /turf/open/floor/ms13/concrete,
@@ -13813,6 +13867,15 @@
 /obj/item/clothing/shoes/ms13/military,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/underground/army_bunker)
+"fMe" = (
+/obj/structure/table/ms13/no_smooth/large/wood/desk{
+	dir = 4
+	},
+/obj/machinery/ms13/terminal/wasteland{
+	dir = 4
+	},
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/underground/underground_town)
 "fMu" = (
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/ms13/sewer,
@@ -13833,13 +13896,6 @@
 /obj/effect/spawner/random/ms13/clothing/under,
 /turf/open/floor/wood/ms13/carpet/blue,
 /area/ms13/town)
-"fQn" = (
-/obj/item/ms13_small_flag/usa,
-/obj/machinery/light/ms13/bulb{
-	dir = 1
-	},
-/turf/open/floor/wood/ms13/wide,
-/area/ms13/underground/mountain)
 "fQG" = (
 /obj/structure/table/ms13/metal/grate,
 /obj/effect/spawner/random/ms13/guaranteed/drugs/prewar,
@@ -13854,10 +13910,6 @@
 /obj/effect/spawner/random/ms13/drugs/highrandom,
 /turf/open/floor/wood/ms13/common,
 /area/ms13/underground/underground_town)
-"fSs" = (
-/obj/structure/fluff/ms13/barrel/single/toxic/four,
-/turf/open/floor/wood/ms13/wide,
-/area/ms13/underground/mountain)
 "fSL" = (
 /obj/structure/closet/crate/ms13/woodcrate/compact,
 /obj/effect/spawner/random/ms13/crafting/electrical,
@@ -13888,10 +13940,6 @@
 /obj/item/ammo_casing/ms13/c10mm,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
-"fTT" = (
-/obj/item/paper_bin/ms13,
-/turf/open/floor/wood/ms13/wide,
-/area/ms13/underground/mountain)
 "fUq" = (
 /obj/structure/closet/ms13/metal,
 /obj/effect/spawner/random/ms13/clothing/backpack,
@@ -13905,10 +13953,6 @@
 /obj/effect/spawner/random/ms13/crafting/highrandom,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
-"fXm" = (
-/obj/machinery/light/ms13/bulb,
-/turf/open/floor/wood/ms13/wide,
-/area/ms13/underground/mountain)
 "gaN" = (
 /obj/structure/table/ms13/metal/grate,
 /obj/structure/ms13/rug/mat/rubber,
@@ -13930,6 +13974,10 @@
 	},
 /obj/structure/ms13/rug/mat/rubber,
 /turf/open/floor/wood/ms13/wide,
+/area/ms13/underground/underground_town)
+"geq" = (
+/obj/machinery/light/ms13/bulb/industrial/broken,
+/turf/open/floor/plating/ms13/ground/mountain,
 /area/ms13/underground/underground_town)
 "geJ" = (
 /obj/machinery/server/alt,
@@ -14063,10 +14111,6 @@
 /obj/structure/table/ms13/crafting/workbench,
 /turf/open/floor/ms13/metal,
 /area/ms13/underground/vault_atrium_lower)
-"gxh" = (
-/mob/living/basic/ms13/hostile_animal/radroach/glowie,
-/turf/open/floor/wood/ms13/wide,
-/area/ms13/underground/mountain)
 "gyC" = (
 /obj/structure/closet/crate/ms13/footlocker{
 	dir = 1
@@ -14116,17 +14160,19 @@
 	},
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
-"gCG" = (
-/obj/structure/ms13/foundation/wide/variantsix{
-	dir = 1
-	},
-/obj/structure/ms13/skeleton,
-/turf/open/floor/plating/ms13/ground/mountain,
-/area/ms13/underground/mountain)
+"gAG" = (
+/obj/structure/bed/ms13/mattress/yellowed,
+/obj/structure/bed/ms13/bedframe/wood,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/underground/underground_town)
 "gCZ" = (
 /obj/structure/ms13/medical_curtain,
 /turf/open/floor/ms13/tile/navy,
 /area/ms13/town)
+"gDG" = (
+/mob/living/basic/ms13/ghoul/radioactive,
+/turf/open/floor/plating/ms13/ground/mountain,
+/area/ms13/underground/underground_town)
 "gEh" = (
 /obj/effect/decal/cleanable/blood/drip{
 	pixel_x = -7;
@@ -14195,16 +14241,6 @@
 	},
 /turf/open/floor/plating/ms13/ground/mountain,
 /area/ms13/underground/mountain)
-"gRn" = (
-/obj/structure/table/ms13/no_smooth/counter/wood/crafted{
-	dir = 4
-	},
-/obj/structure/ms13/foundation/wide/variantfour{
-	dir = 9
-	},
-/obj/effect/spawner/random/ms13/medical/lowrandom,
-/turf/open/floor/plating/ms13/ground/mountain,
-/area/ms13/underground/mountain)
 "gRq" = (
 /obj/structure/ms13/foundation/wide/variantfive{
 	dir = 1
@@ -14229,6 +14265,12 @@
 /obj/effect/spawner/random/ms13/crafting/lowrandom,
 /turf/open/floor/ms13/tile/full/green,
 /area/ms13/underground/army_bunker)
+"gVX" = (
+/obj/structure/fluff/ms13/trash/papers{
+	dir = 5
+	},
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/underground/underground_town)
 "gWH" = (
 /obj/structure/table/ms13/no_smooth/counter/wood/bend{
 	dir = 8
@@ -14254,15 +14296,10 @@
 /obj/effect/spawner/random/ms13/armor/lowrandom,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/underground/underground_town)
-"hcd" = (
-/obj/structure/ms13/foundation/wide/variantfive{
-	dir = 8
-	},
-/obj/structure/chair/ms13/overlaypickup/plastic{
-	dir = 8
-	},
+"gZL" = (
+/obj/structure/fluff/ms13/barrel/single/toxic/two,
 /turf/open/floor/plating/ms13/ground/mountain,
-/area/ms13/underground/mountain)
+/area/ms13/underground/underground_town)
 "hfx" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/ms13/concrete,
@@ -14474,6 +14511,10 @@
 /obj/effect/spawner/random/ms13/medical/bloodbag,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/underground/underground_town)
+"hNz" = (
+/obj/structure/ms13/rug/mat/vulgar/fuckoff,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/underground/underground_town)
 "hNG" = (
 /obj/structure/window/fulltile/ms13/glass,
 /obj/structure/table/ms13/low_wall/sewer,
@@ -14493,12 +14534,6 @@
 /obj/structure/ms13/rug/rubber,
 /turf/open/floor/ms13/metal/grate/border,
 /area/ms13/underground/underground_town)
-"hOW" = (
-/obj/effect/decal/cleanable/blood/tracks{
-	dir = 6
-	},
-/turf/open/floor/wood/ms13/wide,
-/area/ms13/underground/mountain)
 "hQB" = (
 /obj/effect/turf_decal/trimline/yellow/line{
 	dir = 4
@@ -14520,11 +14555,6 @@
 /obj/structure/bed/ms13/bedframe/metal,
 /turf/open/floor/ms13/concrete/bricks,
 /area/ms13/underground/underground_town)
-"hTe" = (
-/obj/item/chair/ms13/plastic,
-/obj/item/ms13/brick,
-/turf/open/floor/wood/ms13/wide,
-/area/ms13/underground/mountain)
 "hVp" = (
 /obj/structure/fluff/ms13/barrel/quadruple/red/two,
 /turf/open/floor/plating/ms13/ground/mountain,
@@ -14645,16 +14675,6 @@
 /obj/effect/spawner/random/ms13/guaranteed/medical/lowrandom,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/underground/underground_town)
-"ikE" = (
-/obj/structure/fluff/ms13/trash/papers{
-	dir = 5
-	},
-/turf/open/floor/wood/ms13/wide,
-/area/ms13/underground/mountain)
-"ilb" = (
-/obj/structure/fluff/ms13/barrel/single/toxic/two,
-/turf/open/floor/plating/ms13/ground/mountain,
-/area/ms13/underground/mountain)
 "ilz" = (
 /mob/living/basic/ms13/ghoul,
 /turf/open/floor/ms13/tile/blue,
@@ -14687,17 +14707,6 @@
 /obj/structure/ms13/rug/mat/rubber/single,
 /turf/open/floor/ms13/tile/fancy,
 /area/ms13/town)
-"iqc" = (
-/obj/structure/ms13/foundation/wide/variantfive{
-	dir = 9
-	},
-/obj/effect/decal/cleanable/blood/footprints{
-	dir = 8;
-	pixel_y = 6
-	},
-/mob/living/basic/ms13/ghoul/radioactive,
-/turf/open/floor/plating/ms13/ground/mountain,
-/area/ms13/underground/mountain)
 "iqP" = (
 /obj/effect/spawner/random/ms13/food/packaged,
 /obj/effect/spawner/random/ms13/food/packaged,
@@ -14708,9 +14717,29 @@
 /obj/effect/spawner/random/ms13/medical/tier1,
 /turf/open/floor/ms13/sewer,
 /area/ms13/underground/underground_town)
+"itS" = (
+/obj/structure/table/ms13/no_smooth/large/wood/desk{
+	dir = 4
+	},
+/obj/item/pen/ms13,
+/obj/machinery/light/ms13/bulb{
+	dir = 8
+	},
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/underground/underground_town)
 "iuv" = (
 /obj/structure/ms13/rug/mat/rubber,
 /turf/open/floor/ms13/concrete,
+/area/ms13/underground/underground_town)
+"iuZ" = (
+/obj/structure/table/ms13/no_smooth/counter/wood/crafted{
+	dir = 4
+	},
+/obj/structure/ms13/foundation/wide/variantfour{
+	dir = 9
+	},
+/obj/effect/spawner/random/ms13/medical/lowrandom,
+/turf/open/floor/plating/ms13/ground/mountain,
 /area/ms13/underground/underground_town)
 "iwb" = (
 /obj/structure/stairs{
@@ -14739,6 +14768,12 @@
 /obj/effect/spawner/random/ms13/seeds/random,
 /turf/open/floor/ms13/concrete,
 /area/ms13/underground/mountain)
+"iAl" = (
+/obj/structure/chair/ms13/overlaypickup/plastic{
+	dir = 8
+	},
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/underground/underground_town)
 "iBj" = (
 /obj/machinery/light/ms13{
 	dir = 1
@@ -14759,11 +14794,6 @@
 /obj/effect/spawner/random/ms13/tools/hardware,
 /turf/open/floor/ms13/concrete,
 /area/ms13/underground/underground_town)
-"iFO" = (
-/obj/item/paper/ms13/paperslip,
-/obj/effect/decal/cleanable/greenglow,
-/turf/open/floor/plating/ms13/ground/mountain,
-/area/ms13/underground/mountain)
 "iHn" = (
 /obj/structure/table/ms13/crafting/weaponbench,
 /turf/open/floor/ms13/metal,
@@ -14926,6 +14956,13 @@
 /obj/structure/ms13/pipes/horizontal/end,
 /turf/closed/wall/ms13/sewer,
 /area/ms13/town)
+"joB" = (
+/obj/structure/ms13/foundation/wide/variantsix{
+	dir = 1
+	},
+/obj/structure/ms13/skeleton,
+/turf/open/floor/plating/ms13/ground/mountain,
+/area/ms13/underground/underground_town)
 "jpK" = (
 /obj/structure/ms13/skeleton,
 /obj/effect/decal/cleanable/blood/splatter,
@@ -14953,6 +14990,10 @@
 /obj/structure/flora/grass/jungle/b,
 /turf/open/floor/plating/ms13/ground/mountain,
 /area/ms13/town)
+"jtd" = (
+/obj/machinery/light/ms13/bulb,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/underground/underground_town)
 "jvv" = (
 /obj/item/pickaxe/ms13,
 /turf/open/floor/plating/ms13/ground/mountain,
@@ -15060,6 +15101,14 @@
 	},
 /turf/open/floor/plating/ms13/ground/mountain,
 /area/ms13/underground/mountain)
+"jLe" = (
+/obj/structure/ms13/foundation/wide/variantthree,
+/obj/structure/fluff/ms13/trash/papers{
+	dir = 9
+	},
+/obj/item/clothing/head/helmet/ms13/sailor,
+/turf/open/floor/plating/ms13/ground/mountain,
+/area/ms13/underground/underground_town)
 "jOl" = (
 /obj/effect/spawner/random/ms13/food/packaged,
 /obj/effect/spawner/random/ms13/food/packaged,
@@ -15125,12 +15174,6 @@
 /obj/machinery/light/ms13/bulb,
 /turf/open/floor/ms13/concrete,
 /area/ms13/town)
-"kaY" = (
-/obj/effect/decal/cleanable/blood{
-	icon_state = "floor3"
-	},
-/turf/open/floor/wood/ms13/wide,
-/area/ms13/underground/mountain)
 "kcz" = (
 /obj/structure/flora/grass/jungle/b,
 /obj/structure/flora/grass/jungle/b,
@@ -15189,6 +15232,10 @@
 /obj/structure/ms13/rug/rubber,
 /turf/open/floor/ms13/metal,
 /area/ms13/underground/vault_atrium_lower)
+"klm" = (
+/obj/structure/fluff/ms13/barrel/single/waste/one,
+/turf/open/floor/plating/ms13/ground/mountain,
+/area/ms13/underground/underground_town)
 "kmd" = (
 /obj/structure/ms13/storage/shelf,
 /obj/effect/spawner/random/ms13/tools/tool,
@@ -15260,10 +15307,6 @@
 /obj/structure/ms13/wall_decor/flag/california,
 /turf/open/floor/ms13/concrete,
 /area/ms13/town)
-"kAH" = (
-/obj/structure/ms13/foundation/wide/varianttwo,
-/turf/open/floor/plating/ms13/ground/mountain,
-/area/ms13/underground/mountain)
 "kBx" = (
 /obj/machinery/porta_turret/ms13/ballistic{
 	dir = 9
@@ -15384,12 +15427,6 @@
 /obj/structure/table/ms13/wood,
 /turf/open/floor/wood/ms13/carpet/blue,
 /area/ms13/town)
-"kQB" = (
-/obj/machinery/light/ms13/bulb{
-	dir = 8
-	},
-/turf/open/floor/wood/ms13/wide,
-/area/ms13/underground/mountain)
 "kRk" = (
 /obj/structure/ms13/fence/wire,
 /obj/structure/ms13/foundation/common/variantfour{
@@ -15561,12 +15598,6 @@
 /obj/effect/spawner/random/ms13/drink/alcohol,
 /turf/open/floor/ms13/concrete,
 /area/ms13/underground/underground_town)
-"liT" = (
-/obj/effect/decal/cleanable/blood/footprints{
-	dir = 1
-	},
-/turf/open/floor/wood/ms13/wide,
-/area/ms13/underground/mountain)
 "llr" = (
 /obj/structure/ms13/storage/shelf{
 	dir = 4
@@ -15587,10 +15618,6 @@
 	},
 /turf/open/floor/plating/ms13/ground/mountain,
 /area/ms13/underground/mountain)
-"loM" = (
-/obj/structure/fluff/ms13/barrel/single/toxic/three,
-/turf/open/floor/wood/ms13/wide,
-/area/ms13/underground/mountain)
 "lpN" = (
 /obj/machinery/light/ms13,
 /turf/open/floor/ms13/metal,
@@ -15606,10 +15633,6 @@
 "luy" = (
 /obj/effect/turf_decal/ms13/graffiti/moyai,
 /turf/closed/indestructible/rock/ms13/mammoth,
-/area/ms13/underground/mountain)
-"luN" = (
-/obj/structure/ms13/pot/plant,
-/turf/open/floor/wood/ms13/wide,
 /area/ms13/underground/mountain)
 "luP" = (
 /obj/effect/decal/cleanable/blood/old,
@@ -15662,6 +15685,20 @@
 /obj/effect/spawner/random/ms13/melee/lowrandom,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/underground/sewer)
+"lBW" = (
+/obj/structure/ms13/foundation/wide/variantfive{
+	dir = 6
+	},
+/obj/structure/closet/crate/ms13/footlocker{
+	dir = 8
+	},
+/obj/effect/spawner/random/ms13/currency/mammoth/prewar/lowrandom,
+/obj/item/clothing/under/ms13/wasteland/navy,
+/obj/item/clothing/head/helmet/ms13/sailor,
+/obj/effect/spawner/random/ms13/clothing/under,
+/obj/effect/spawner/random/ms13/clothing/shoe,
+/turf/open/floor/plating/ms13/ground/mountain,
+/area/ms13/underground/underground_town)
 "lCa" = (
 /obj/structure/table/ms13/metal/grate,
 /obj/item/radio/ms13/ham/receiver/radioking,
@@ -15671,13 +15708,6 @@
 /obj/effect/spawner/random/ms13/gun/highunique,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/underground/army_bunker)
-"lEj" = (
-/obj/effect/decal/cleanable/blood/footprints{
-	dir = 8;
-	pixel_y = 6
-	},
-/turf/open/floor/wood/ms13/wide,
-/area/ms13/underground/mountain)
 "lET" = (
 /obj/item/shovel/ms13,
 /obj/structure/ms13/skeleton,
@@ -16040,6 +16070,11 @@
 	},
 /turf/open/floor/wood/ms13/carpet/blue,
 /area/ms13/town)
+"mLe" = (
+/obj/structure/table/ms13/no_smooth/wood,
+/obj/effect/spawner/random/ms13/drink/alcohol,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/underground/underground_town)
 "mLi" = (
 /obj/machinery/light/ms13/bulb/industrial{
 	dir = 1
@@ -16109,12 +16144,6 @@
 /obj/effect/spawner/random/ms13/ammo/tier2,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/underground/underground_town)
-"mXh" = (
-/obj/effect/decal/cleanable/blood/footprints{
-	dir = 8
-	},
-/turf/open/floor/wood/ms13/wide,
-/area/ms13/underground/mountain)
 "mYl" = (
 /obj/effect/spawner/random/ms13/ammo/tier1,
 /turf/open/floor/wood/ms13/wide,
@@ -16203,15 +16232,6 @@
 	},
 /turf/open/floor/plating/ms13/ground/mountain,
 /area/ms13/underground/mountain)
-"niz" = (
-/obj/structure/closet/ms13/fridge,
-/obj/effect/spawner/random/ms13/drink/alcohol_beer,
-/obj/effect/spawner/random/ms13/drink/alcohol_beer,
-/obj/effect/spawner/random/ms13/drink/alcohol_beer,
-/obj/effect/spawner/random/ms13/drink/alcohol_uncommon,
-/obj/effect/spawner/random/ms13/guaranteed/drink/alcohol_beer,
-/turf/open/floor/wood/ms13/wide,
-/area/ms13/underground/mountain)
 "nji" = (
 /obj/structure/ms13/storage/shelf{
 	dir = 4
@@ -16245,6 +16265,12 @@
 "nnR" = (
 /turf/closed/wall/ms13/scrap/white,
 /area/ms13/underground/sewer)
+"nrC" = (
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 1
+	},
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/underground/underground_town)
 "ntK" = (
 /obj/structure/lattice/catwalk/ms13,
 /obj/structure/railing/ms13/sewer,
@@ -16283,14 +16309,6 @@
 /obj/structure/railing/ms13/sewer,
 /turf/open/floor/ms13/concrete,
 /area/ms13/underground/underground_town)
-"nxN" = (
-/obj/structure/ms13/foundation/wide/variantthree,
-/obj/structure/fluff/ms13/trash/papers{
-	dir = 9
-	},
-/obj/item/clothing/head/helmet/ms13/sailor,
-/turf/open/floor/plating/ms13/ground/mountain,
-/area/ms13/underground/mountain)
 "nxW" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/spawner/random/ms13/crafting/lowrandom,
@@ -16354,6 +16372,16 @@
 "nHS" = (
 /obj/structure/chair/sofa/corp/corner,
 /turf/open/floor/wood/ms13/carpet,
+/area/ms13/underground/underground_town)
+"nKH" = (
+/obj/structure/closet/crate/ms13/footlocker{
+	dir = 8
+	},
+/obj/effect/spawner/random/ms13/drink/alcohol,
+/obj/effect/spawner/random/ms13/drink/alcohol,
+/obj/effect/spawner/random/ms13/guaranteed/drink/alcohol,
+/obj/effect/spawner/random/ms13/guaranteed/drink/alcohol,
+/turf/open/floor/wood/ms13/wide,
 /area/ms13/underground/underground_town)
 "nLa" = (
 /obj/structure/bed/ms13/bedframe/metal,
@@ -16592,28 +16620,23 @@
 	},
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/underground/underground_town)
-"ora" = (
-/obj/effect/decal/cleanable/blood/footprints{
-	dir = 4
-	},
-/turf/open/floor/wood/ms13/wide,
-/area/ms13/underground/mountain)
 "oro" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 5
 	},
 /turf/open/floor/ms13/concrete,
 /area/ms13/underground/underground_town)
-"osv" = (
-/obj/structure/ms13/foundation/wide/varianttwo{
-	dir = 10
-	},
+"osa" = (
+/obj/item/paper/ms13/paperslip,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plating/ms13/ground/mountain,
+/area/ms13/underground/underground_town)
+"osR" = (
 /obj/effect/decal/cleanable/blood/footprints{
 	dir = 4
 	},
-/mob/living/basic/ms13/hostile_animal/radroach/glowie,
-/turf/open/floor/plating/ms13/ground/mountain,
-/area/ms13/underground/mountain)
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/underground/underground_town)
 "otb" = (
 /obj/structure/ms13/skeleton,
 /obj/effect/decal/cleanable/blood/splatter,
@@ -16644,6 +16667,16 @@
 /obj/structure/ms13/rug/rubber,
 /turf/open/floor/ms13/metal,
 /area/ms13/town)
+"oAK" = (
+/obj/structure/table/ms13/no_smooth/counter/wood/crafted{
+	dir = 8
+	},
+/obj/structure/ms13/foundation/wide/variantfour{
+	dir = 6
+	},
+/obj/effect/spawner/random/ms13/crafting/household,
+/turf/open/floor/plating/ms13/ground/mountain,
+/area/ms13/underground/underground_town)
 "oAP" = (
 /obj/effect/spawner/random/ms13/tools/tool,
 /turf/open/floor/ms13/concrete,
@@ -16672,13 +16705,6 @@
 /obj/structure/fluff/ms13/barrel/triple/yellow/one,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
-"oFx" = (
-/obj/structure/ms13/foundation/wide/variantfour{
-	dir = 8
-	},
-/mob/living/basic/ms13/hostile_animal/radroach/glowie,
-/turf/open/floor/plating/ms13/ground/mountain,
-/area/ms13/underground/mountain)
 "oHf" = (
 /obj/structure/ms13/celldoor/rusty{
 	dir = 1
@@ -16825,6 +16851,13 @@
 /obj/machinery/griddle,
 /turf/open/floor/ms13/tile,
 /area/ms13/town)
+"oXh" = (
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 8;
+	pixel_y = 6
+	},
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/underground/underground_town)
 "oXm" = (
 /obj/structure/closet/ms13/fridge,
 /obj/effect/spawner/random/ms13/food/produce_random,
@@ -16883,12 +16916,6 @@
 	},
 /turf/open/floor/ms13/sewer,
 /area/ms13/underground/underground_town)
-"pdr" = (
-/obj/structure/chair/ms13/overlaypickup/plastic{
-	dir = 8
-	},
-/turf/open/floor/wood/ms13/wide,
-/area/ms13/underground/mountain)
 "pfl" = (
 /obj/structure/ms13/barricade,
 /turf/open/floor/plating/ms13/ground/mountain,
@@ -17146,22 +17173,6 @@
 /obj/effect/spawner/random/ms13/medical/lowrandom,
 /turf/open/floor/ms13/concrete,
 /area/ms13/town)
-"pSP" = (
-/obj/structure/table/ms13/no_smooth/counter/wood/crafted{
-	dir = 8
-	},
-/obj/structure/ms13/foundation/wide/variantfour{
-	dir = 6
-	},
-/obj/effect/spawner/random/ms13/crafting/household,
-/turf/open/floor/plating/ms13/ground/mountain,
-/area/ms13/underground/mountain)
-"pTh" = (
-/obj/machinery/door/unpowered/ms13/metal/red{
-	dir = 4
-	},
-/turf/open/floor/wood/ms13/wide,
-/area/ms13/underground/mountain)
 "pTy" = (
 /obj/effect/spawner/random/ms13/drugs/lowrandom,
 /turf/open/floor/ms13/concrete,
@@ -17210,14 +17221,10 @@
 /obj/effect/spawner/random/ms13/clothing/gloves,
 /turf/open/floor/ms13/concrete,
 /area/ms13/underground/underground_town)
-"pXE" = (
-/obj/structure/ms13/foundation/wide/variantthree{
-	dir = 6
-	},
-/obj/effect/spawner/random/ms13/melee/lowrandom,
-/mob/living/basic/ms13/hostile_animal/radroach/glowie,
-/turf/open/floor/plating/ms13/ground/mountain,
-/area/ms13/underground/mountain)
+"pXB" = (
+/obj/structure/fluff/ms13/barrel/single/toxic/four,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/underground/underground_town)
 "pZP" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/cleanable/blood/tracks{
@@ -17330,6 +17337,10 @@
 	},
 /turf/open/floor/ms13/metal,
 /area/ms13/town)
+"qqm" = (
+/obj/structure/fluff/ms13/barrel/single/toxic/three,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/underground/underground_town)
 "qtd" = (
 /obj/structure/ms13/storage/large/shelf{
 	dir = 8
@@ -17391,13 +17402,6 @@
 /obj/effect/spawner/random/ms13/crafting/highrandom,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/underground/underground_town)
-"qDh" = (
-/obj/item/paper/ms13/paperslip,
-/obj/machinery/light/ms13/bulb/industrial{
-	dir = 1
-	},
-/turf/open/floor/plating/ms13/ground/mountain,
-/area/ms13/underground/mountain)
 "qEs" = (
 /obj/machinery/door/airlock/ms13,
 /turf/open/floor/ms13/concrete/industrial,
@@ -17417,10 +17421,6 @@
 /obj/effect/spawner/random/ms13/medical/lowrandom,
 /turf/open/floor/ms13/tile/long,
 /area/ms13/town)
-"qGS" = (
-/obj/effect/decal/cleanable/greenglow,
-/turf/open/floor/plating/ms13/ground/mountain,
-/area/ms13/underground/mountain)
 "qHV" = (
 /obj/effect/spawner/random/ms13/guaranteed/food/packaged,
 /obj/structure/ms13/storage/large/shelf{
@@ -17482,18 +17482,16 @@
 /obj/structure/ms13/storage/shelf,
 /turf/open/floor/ms13/concrete,
 /area/ms13/underground/subway)
+"qQz" = (
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/underground/underground_town)
 "qQW" = (
 /obj/structure/fluff/ms13/trash/papers{
 	dir = 4
 	},
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/underground/sewer)
-"qRr" = (
-/obj/machinery/door/unpowered/ms13/metal/red{
-	dir = 1
-	},
-/turf/open/floor/plating/ms13/ground/mountain,
-/area/ms13/underground/mountain)
 "qUC" = (
 /obj/structure/fluff/ms13/barrel/single/redalt,
 /turf/open/floor/plating/ms13/ground/mountain,
@@ -17558,10 +17556,6 @@
 /obj/effect/spawner/random/ms13/locked/guaranteed/random,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/ncr)
-"rlh" = (
-/obj/structure/fluff/ms13/barrel/triple/waste,
-/turf/open/floor/plating/ms13/ground/mountain,
-/area/ms13/underground/mountain)
 "rmf" = (
 /obj/item/shovel/ms13/rake,
 /obj/item/shovel/ms13/spade,
@@ -17580,13 +17574,16 @@
 /mob/living/basic/ms13/robot/handy,
 /turf/open/floor/ms13/metal,
 /area/ms13/underground/enclave_base)
-"rsK" = (
-/obj/structure/fluff/ms13/trash/papers,
-/obj/effect/decal/cleanable/blood/tracks{
-	dir = 9
+"rsj" = (
+/obj/structure/ms13/foundation/wide/varianttwo{
+	dir = 10
 	},
-/turf/open/floor/wood/ms13/wide,
-/area/ms13/underground/mountain)
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 4
+	},
+/mob/living/basic/ms13/hostile_animal/radroach/glowie,
+/turf/open/floor/plating/ms13/ground/mountain,
+/area/ms13/underground/underground_town)
 "rtS" = (
 /obj/structure/table/ms13/metal,
 /obj/effect/spawner/random/ms13/medical/lowrandom,
@@ -17706,6 +17703,12 @@
 	},
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/underground/underground_town)
+"rHY" = (
+/obj/structure/table/ms13/no_smooth/cable_reel,
+/obj/item/paper/ms13/paperslip,
+/obj/effect/spawner/random/ms13/crafting/lowrandom,
+/turf/open/floor/plating/ms13/ground/mountain,
+/area/ms13/underground/underground_town)
 "rJe" = (
 /obj/structure/chair/office/ms13/red{
 	dir = 1
@@ -17719,13 +17722,6 @@
 /obj/effect/spawner/random/ms13/crafting/lowrandom,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/underground/underground_town)
-"rKW" = (
-/obj/effect/decal/cleanable/blood/footprints{
-	dir = 1;
-	pixel_x = -5
-	},
-/turf/open/floor/wood/ms13/wide,
-/area/ms13/underground/mountain)
 "rLz" = (
 /obj/structure/table/ms13/metal/heavy,
 /obj/effect/spawner/random/ms13/crafting/electrical,
@@ -17768,16 +17764,19 @@
 /obj/effect/spawner/random/ms13/crafting/lowrandom,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
+"rOg" = (
+/obj/item/paper/ms13/paperslip,
+/obj/machinery/light/ms13/bulb/industrial{
+	dir = 1
+	},
+/turf/open/floor/plating/ms13/ground/mountain,
+/area/ms13/underground/underground_town)
 "rOY" = (
 /obj/structure/railing/ms13/sewer{
 	dir = 4
 	},
 /turf/open/ms13/water/sewer/medium,
 /area/ms13/underground/sewer)
-"rPy" = (
-/obj/machinery/door/unpowered/ms13/metal/red,
-/turf/open/floor/wood/ms13/wide,
-/area/ms13/underground/mountain)
 "rPH" = (
 /obj/structure/ms13/skeleton,
 /obj/item/clothing/head/helmet/ms13/fedora/yellow,
@@ -17801,6 +17800,9 @@
 /obj/effect/spawner/random/ms13/tools/tool,
 /obj/effect/spawner/random/ms13/tools/tool,
 /turf/open/floor/ms13/concrete/industrial,
+/area/ms13/underground/underground_town)
+"rUY" = (
+/turf/open/ms13/water/sewer/medium,
 /area/ms13/underground/underground_town)
 "rXp" = (
 /obj/machinery/door/unpowered/ms13/seethrough/grate{
@@ -17928,6 +17930,17 @@
 /obj/structure/ms13/storage/shelf,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/underground/underground_town)
+"slr" = (
+/obj/structure/ms13/foundation/wide/variantfive{
+	dir = 9
+	},
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 8;
+	pixel_y = 6
+	},
+/mob/living/basic/ms13/ghoul/radioactive,
+/turf/open/floor/plating/ms13/ground/mountain,
+/area/ms13/underground/underground_town)
 "sls" = (
 /obj/effect/spawner/random/ms13/ammo/lowrandom,
 /obj/structure/table/ms13/wood/bar,
@@ -17978,6 +17991,10 @@
 /obj/structure/filingcabinet/ms13,
 /turf/open/floor/ms13/concrete,
 /area/ms13/underground/subway)
+"srq" = (
+/obj/structure/fluff/ms13/barrel/triple/waste,
+/turf/open/floor/plating/ms13/ground/mountain,
+/area/ms13/underground/underground_town)
 "ssh" = (
 /obj/structure/railing/ms13/sewer{
 	dir = 4
@@ -17995,6 +18012,13 @@
 /obj/effect/turf_decal/ms13/graffiti/no_way,
 /turf/open/floor/plating/ms13/ground/mountain,
 /area/ms13/underground/mountain)
+"stJ" = (
+/obj/structure/ms13/foundation/wide/variantfour{
+	dir = 8
+	},
+/mob/living/basic/ms13/hostile_animal/radroach/glowie,
+/turf/open/floor/plating/ms13/ground/mountain,
+/area/ms13/underground/underground_town)
 "svg" = (
 /obj/effect/spawner/random/ms13/tools/lights,
 /obj/effect/spawner/random/ms13/tools/lights,
@@ -18051,15 +18075,6 @@
 /obj/machinery/iv_drip/ms13,
 /turf/open/floor/ms13/tile/navy,
 /area/ms13/underground/enclave_base)
-"sGY" = (
-/obj/structure/table/ms13/no_smooth/large/wood/desk{
-	dir = 4
-	},
-/obj/machinery/ms13/terminal/wasteland{
-	dir = 4
-	},
-/turf/open/floor/wood/ms13/wide,
-/area/ms13/underground/mountain)
 "sHf" = (
 /obj/machinery/button/ms13{
 	dir = 8;
@@ -18075,6 +18090,18 @@
 /obj/structure/bonfire/ms13/fire_barrel,
 /turf/open/floor/ms13/concrete,
 /area/ms13/town)
+"sIr" = (
+/obj/structure/ms13/foundation/wide/variantfour{
+	dir = 6
+	},
+/obj/effect/spawner/random/ms13/gun/tier2,
+/obj/effect/spawner/random/ms13/currency/mammoth/prewar/lowrandom,
+/obj/effect/spawner/random/ms13/clothing/gloves,
+/obj/machinery/light/ms13/bulb{
+	dir = 8
+	},
+/turf/open/floor/plating/ms13/ground/mountain,
+/area/ms13/underground/underground_town)
 "sIs" = (
 /obj/structure/chair/ms13/metal/blue/broken,
 /turf/open/floor/ms13/tile/navy,
@@ -18287,18 +18314,6 @@
 	},
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
-"tna" = (
-/obj/structure/ms13/foundation/wide/variantfour{
-	dir = 6
-	},
-/obj/effect/spawner/random/ms13/gun/tier2,
-/obj/effect/spawner/random/ms13/currency/mammoth/prewar/lowrandom,
-/obj/effect/spawner/random/ms13/clothing/gloves,
-/obj/machinery/light/ms13/bulb{
-	dir = 8
-	},
-/turf/open/floor/plating/ms13/ground/mountain,
-/area/ms13/underground/mountain)
 "tnM" = (
 /obj/structure/table/ms13/crafting/armorbench,
 /turf/open/floor/wood/ms13/wide,
@@ -18340,20 +18355,6 @@
 /obj/structure/rustic_extractor,
 /turf/open/floor/plating/ms13/ground/mountain,
 /area/ms13/underground/vault_atrium_lower)
-"txO" = (
-/obj/structure/ms13/foundation/wide/variantfive{
-	dir = 6
-	},
-/obj/structure/closet/crate/ms13/footlocker{
-	dir = 8
-	},
-/obj/effect/spawner/random/ms13/currency/mammoth/prewar/lowrandom,
-/obj/item/clothing/under/ms13/wasteland/navy,
-/obj/item/clothing/head/helmet/ms13/sailor,
-/obj/effect/spawner/random/ms13/clothing/under,
-/obj/effect/spawner/random/ms13/clothing/shoe,
-/turf/open/floor/plating/ms13/ground/mountain,
-/area/ms13/underground/mountain)
 "tzs" = (
 /obj/structure/closet/crate/ms13/woodcrate/compact,
 /obj/effect/spawner/random/ms13/crafting/household,
@@ -18453,6 +18454,14 @@
 /obj/structure/table/ms13/no_smooth/counter/metal,
 /turf/open/floor/ms13/concrete,
 /area/ms13/underground/underground_town)
+"tOL" = (
+/obj/item/paper_bin/ms13,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/underground/underground_town)
+"tPX" = (
+/obj/structure/ms13/foundation/wide/varianttwo,
+/turf/open/floor/plating/ms13/ground/mountain,
+/area/ms13/underground/underground_town)
 "tQq" = (
 /obj/structure/chair/ms13/wood/padded{
 	dir = 8
@@ -18516,10 +18525,6 @@
 	},
 /turf/open/floor/ms13/metal,
 /area/ms13/underground/vault_atrium_lower)
-"tWD" = (
-/obj/structure/fluff/ms13/barrel/triple/waste/two,
-/turf/open/floor/plating/ms13/ground/mountain,
-/area/ms13/underground/mountain)
 "tWL" = (
 /obj/effect/decal/cleanable/blood,
 /obj/structure/dresser/ms13/orange/tall,
@@ -18613,23 +18618,11 @@
 	},
 /turf/open/floor/plating/ms13/ground/mountain,
 /area/ms13/underground/mountain)
-"ugo" = (
-/obj/structure/table/ms13/no_smooth/cable_reel,
-/obj/item/paper/ms13/paperslip,
-/obj/effect/spawner/random/ms13/crafting/lowrandom,
-/turf/open/floor/plating/ms13/ground/mountain,
-/area/ms13/underground/mountain)
 "ugt" = (
 /obj/structure/table/ms13/metal/heavy,
 /obj/effect/spawner/random/ms13/crafting/electrical,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/underground/underground_town)
-"ugO" = (
-/obj/structure/ms13/foundation/wide/varianttwo{
-	dir = 9
-	},
-/turf/open/floor/plating/ms13/ground/mountain,
-/area/ms13/underground/mountain)
 "ukv" = (
 /obj/structure/bed/ms13/bedframe/wire,
 /turf/open/floor/ms13/concrete,
@@ -18638,15 +18631,6 @@
 /obj/structure/ms13/rug/rubber,
 /turf/open/floor/ms13/concrete,
 /area/ms13/underground/military_crypt)
-"umv" = (
-/obj/structure/ms13/foundation/wide/variantfive{
-	dir = 10
-	},
-/obj/effect/decal/cleanable/blood/footprints{
-	dir = 4
-	},
-/turf/open/floor/plating/ms13/ground/mountain,
-/area/ms13/underground/mountain)
 "unc" = (
 /obj/effect/decal/cleanable/blood/drip{
 	pixel_x = -7;
@@ -18654,11 +18638,6 @@
 	},
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/underground/underground_town)
-"unQ" = (
-/obj/structure/table/ms13/no_smooth/wood,
-/obj/effect/spawner/random/ms13/drink/alcohol,
-/turf/open/floor/wood/ms13/wide,
-/area/ms13/underground/mountain)
 "unX" = (
 /obj/structure/table/ms13/wood,
 /obj/effect/spawner/random/ms13/ammo/lowrandom,
@@ -18707,6 +18686,16 @@
 /obj/structure/ms13/smelter,
 /turf/open/floor/ms13/concrete,
 /area/ms13/underground/underground_town)
+"uvU" = (
+/obj/structure/closet/crate/ms13/footlocker{
+	dir = 8
+	},
+/obj/effect/spawner/random/ms13/currency/mammoth/prewar/lowrandom,
+/obj/item/clothing/under/ms13/wasteland/navy,
+/obj/effect/spawner/random/ms13/clothing/under,
+/obj/effect/spawner/random/ms13/clothing/shoe,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/underground/underground_town)
 "uAU" = (
 /obj/machinery/button/ms13{
 	dir = 4;
@@ -18738,6 +18727,12 @@
 "uEh" = (
 /obj/structure/table/ms13/wood/constructed,
 /obj/effect/spawner/random/ms13/drink/soda,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/underground/underground_town)
+"uFa" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 6
+	},
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/underground/underground_town)
 "uFf" = (
@@ -18821,6 +18816,10 @@
 /obj/effect/spawner/random/ms13/crafting/lowrandom,
 /turf/open/floor/ms13/concrete,
 /area/ms13/underground/underground_town)
+"uNH" = (
+/obj/effect/spawner/random/ms13/crafting/lowrandom,
+/turf/open/floor/plating/ms13/ground/mountain,
+/area/ms13/underground/underground_town)
 "uNL" = (
 /obj/structure/ms13/rug/rubber,
 /turf/open/floor/ms13/concrete,
@@ -18846,11 +18845,6 @@
 /obj/item/clothing/suit/ms13/ljacket/military,
 /turf/open/floor/ms13/sewer,
 /area/ms13/underground/underground_town)
-"uSt" = (
-/obj/structure/bed/ms13/mattress/yellowed,
-/obj/structure/bed/ms13/bedframe/wood,
-/turf/open/floor/wood/ms13/wide,
-/area/ms13/underground/mountain)
 "uUD" = (
 /obj/effect/spawner/random/ms13/guaranteed/ammo/tier1,
 /obj/structure/closet/crate/ms13/footlocker{
@@ -18962,6 +18956,15 @@
 /obj/machinery/ms13/terminal,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/underground/sewer)
+"vhZ" = (
+/obj/structure/ms13/foundation/wide/variantfive{
+	dir = 10
+	},
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 4
+	},
+/turf/open/floor/plating/ms13/ground/mountain,
+/area/ms13/underground/underground_town)
 "vji" = (
 /obj/machinery/light/ms13/bulb/industrial{
 	dir = 8
@@ -19051,10 +19054,6 @@
 /obj/effect/spawner/random/ms13/clothing/mask,
 /turf/open/floor/ms13/concrete,
 /area/ms13/underground/underground_town)
-"vtV" = (
-/obj/structure/ms13/tv/wooden,
-/turf/open/floor/wood/ms13/wide,
-/area/ms13/underground/mountain)
 "vtW" = (
 /obj/structure/table/ms13/metal/grate,
 /obj/effect/spawner/random/ms13/tools/lights,
@@ -19074,15 +19073,12 @@
 /obj/structure/chair/ms13/metal/stool,
 /turf/open/floor/ms13/tile,
 /area/ms13/town)
-"vuS" = (
-/obj/structure/ms13/foundation/wide/variantsix{
-	dir = 5
-	},
-/obj/machinery/door/unpowered/ms13/metal/red{
-	dir = 1
+"vvV" = (
+/obj/structure/ms13/foundation/wide/varianttwo{
+	dir = 9
 	},
 /turf/open/floor/plating/ms13/ground/mountain,
-/area/ms13/underground/mountain)
+/area/ms13/underground/underground_town)
 "vwv" = (
 /obj/effect/spawner/random/ms13/tools/tool,
 /turf/open/floor/ms13/concrete,
@@ -19122,11 +19118,12 @@
 	},
 /turf/open/floor/plating/ms13/ground/mountain,
 /area/ms13/underground/underground_town)
-"vFk" = (
-/obj/structure/bed/ms13/bedframe/wood,
-/obj/structure/bed/ms13/mattress/stained,
+"vHs" = (
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 8
+	},
 /turf/open/floor/wood/ms13/wide,
-/area/ms13/underground/mountain)
+/area/ms13/underground/underground_town)
 "vIg" = (
 /obj/structure/ms13/bars/rusty,
 /turf/open/ms13/water/sewer/medium,
@@ -19304,6 +19301,12 @@
 /obj/item/radio/ms13/ham/receiver/radioking/wood,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/underground/underground_town)
+"wCy" = (
+/obj/structure/ms13/foundation/wide/variantfour{
+	dir = 10
+	},
+/turf/open/floor/plating/ms13/ground/mountain,
+/area/ms13/underground/underground_town)
 "wDi" = (
 /obj/structure/fluff/ms13/barrel/triple/yellow/two,
 /turf/open/floor/plating/ms13/ground/mountain,
@@ -19429,6 +19432,13 @@
 /obj/structure/bed/ms13/bedframe/metal,
 /turf/open/floor/ms13/concrete,
 /area/ms13/underground/underground_town)
+"wVE" = (
+/obj/structure/fluff/ms13/trash/papers,
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 9
+	},
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/underground/underground_town)
 "wVV" = (
 /obj/structure/ms13/tank/pipe,
 /turf/open/floor/ms13/concrete/industrial,
@@ -19476,12 +19486,6 @@
 	},
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
-"xiO" = (
-/obj/structure/ms13/foundation/wide/varianttwo{
-	dir = 4
-	},
-/turf/open/floor/plating/ms13/ground/mountain,
-/area/ms13/underground/mountain)
 "xjg" = (
 /obj/machinery/light/ms13{
 	dir = 1
@@ -19625,6 +19629,12 @@
 /obj/effect/spawner/random/ms13/guaranteed/drink/alcohol,
 /turf/open/floor/plating/ms13/ground/mountain,
 /area/ms13/underground/underground_town)
+"xGc" = (
+/obj/machinery/light/ms13/bulb{
+	dir = 8
+	},
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/underground/underground_town)
 "xHF" = (
 /obj/effect/spawner/random/ms13/drink/alcohol,
 /obj/effect/spawner/random/ms13/drink/alcohol,
@@ -19656,10 +19666,6 @@
 	},
 /turf/open/floor/ms13/concrete,
 /area/ms13/town)
-"xPs" = (
-/obj/structure/fluff/ms13/barrel/single/waste/one,
-/turf/open/floor/plating/ms13/ground/mountain,
-/area/ms13/underground/mountain)
 "xRo" = (
 /obj/machinery/light/ms13/bulb{
 	dir = 4
@@ -19715,16 +19721,6 @@
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/open/floor/ms13/concrete,
 /area/ms13/underground/underground_town)
-"ydx" = (
-/obj/structure/closet/crate/ms13/footlocker{
-	dir = 8
-	},
-/obj/effect/spawner/random/ms13/currency/mammoth/prewar/lowrandom,
-/obj/item/clothing/under/ms13/wasteland/navy,
-/obj/effect/spawner/random/ms13/clothing/under,
-/obj/effect/spawner/random/ms13/clothing/shoe,
-/turf/open/floor/wood/ms13/wide,
-/area/ms13/underground/mountain)
 "yem" = (
 /obj/structure/table/ms13/crafting/armorbench,
 /turf/open/floor/ms13/metal,
@@ -19744,6 +19740,13 @@
 	},
 /turf/open/floor/ms13/tile/long,
 /area/ms13/town)
+"yit" = (
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 1;
+	pixel_x = -5
+	},
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/underground/underground_town)
 "ykU" = (
 /obj/structure/railing/ms13/sewer{
 	dir = 8
@@ -82764,11 +82767,11 @@ afU
 afU
 afU
 afU
-aRy
-aRy
-aRy
-aRy
-aRy
+aiR
+aiR
+aiR
+aiR
+aiR
 afU
 afU
 afU
@@ -83066,11 +83069,11 @@ afU
 afU
 afU
 afU
-aRy
-fSs
-tna
-sGY
-aRy
+aiR
+pXB
+sIr
+fMe
+aiR
 afU
 afU
 afU
@@ -83368,11 +83371,11 @@ afU
 afU
 afU
 afU
-aRy
-bhR
-umv
-hcd
-aRy
+aiR
+qQz
+vhZ
+dMI
+aiR
 afU
 afU
 afU
@@ -83670,13 +83673,13 @@ afU
 afU
 afU
 afU
-aRy
-loM
-iqc
-txO
-aRy
-rlh
-ilb
+aiR
+qqm
+slr
+lBW
+aiR
+srq
+gZL
 afU
 afU
 afU
@@ -83972,14 +83975,14 @@ afU
 afU
 afU
 afU
-aRy
-lEj
-mXh
-vFk
-aRy
-cyk
-qGS
-akx
+aiR
+oXh
+vHs
+bXj
+aiR
+uNH
+aMU
+aXl
 afU
 afU
 afU
@@ -84273,16 +84276,16 @@ afU
 afU
 afU
 afU
-aRy
-aRy
-pTh
-aRy
-aRy
-aRy
-qDh
-ugo
-akx
-aiP
+aiR
+aiR
+cqv
+aiR
+aiR
+aiR
+rOg
+rHY
+aXl
+gDG
 afU
 afU
 afU
@@ -84575,16 +84578,16 @@ afU
 afU
 afU
 afU
-aRy
-luN
-mXh
-kQB
-gxh
-rPy
-cyk
-iFO
-tWD
-xPs
+aiR
+dfM
+vHs
+xGc
+fnh
+bSL
+uNH
+osa
+cQs
+klm
 afU
 afU
 afU
@@ -84871,22 +84874,22 @@ aRM
 aSH
 aZW
 afU
-abd
-abd
-abd
-abd
-abd
+rUY
+rUY
+rUY
+rUY
+rUY
 afU
-aRy
-vtV
-aOV
-ora
-unQ
-aRy
-aRy
-aRy
-aRy
-aRy
+aiR
+fuR
+aff
+osR
+mLe
+aiR
+aiR
+aiR
+aiR
+aiR
 afU
 afU
 afU
@@ -85172,23 +85175,23 @@ aqI
 aqI
 aLH
 aZW
-abd
-abd
-abd
-abd
-abd
-akx
-aRy
-aRy
-cAT
-osv
-kAH
-pdr
-aRy
-ikE
-fTT
-bPr
-aRy
+rUY
+rUY
+rUY
+rUY
+rUY
+aXl
+aiR
+aiR
+bfL
+rsj
+tPX
+iAl
+aiR
+gVX
+tOL
+itS
+aiR
 afU
 afU
 afU
@@ -85474,23 +85477,23 @@ aRM
 aRM
 aSH
 aPL
-akx
-abd
-abd
-abd
-akx
-bzK
-aRy
-fQn
-aOV
-ugO
-xiO
-mXh
-aRy
-nxN
-rsK
-kaY
-aRy
+aXl
+rUY
+rUY
+rUY
+aXl
+geq
+aiR
+dFE
+aff
+vvV
+dFl
+vHs
+aiR
+jLe
+wVE
+eYy
+aiR
 afU
 afU
 afU
@@ -85776,23 +85779,23 @@ aRM
 aRM
 aLH
 aZW
-akx
-akx
-abd
-akx
-akx
-akx
-qRr
-fcy
-aOV
-aOV
-liT
-rKW
-vuS
-gCG
-hOW
-ydx
-aRy
+aXl
+aXl
+rUY
+aXl
+aXl
+aXl
+dqg
+hNz
+aff
+aff
+nrC
+yit
+bSR
+joB
+uFa
+uvU
+aiR
 afU
 afU
 afU
@@ -86079,22 +86082,22 @@ aRM
 aLH
 aZW
 afU
-akx
-akx
-akx
-akx
+aXl
+aXl
+aXl
+aXl
 afU
-aRy
-aRy
-aOV
-bbA
-oFx
-fXm
-aRy
-pXE
-hTe
-uSt
-aRy
+aiR
+aiR
+aff
+wCy
+stJ
+jtd
+aiR
+eBT
+fwH
+gAG
+aiR
 afU
 afU
 afU
@@ -86382,21 +86385,21 @@ aLH
 aZW
 afU
 afU
-akx
-akx
+aXl
+aXl
 afU
 afU
 afU
-aRy
-bXc
-gRn
-pSP
-niz
-aRy
-aRy
-aRy
-aRy
-aRy
+aiR
+nKH
+iuZ
+oAK
+eCq
+aiR
+aiR
+aiR
+aiR
+aiR
 afU
 afU
 afU
@@ -86689,12 +86692,12 @@ afU
 afU
 afU
 afU
-aRy
-aRy
-aRy
-aRy
-aRy
-aRy
+aiR
+aiR
+aiR
+aiR
+aiR
+aiR
 afU
 afU
 afU

--- a/_maps/map_files/Mammoth/Mammoth_below.dmm
+++ b/_maps/map_files/Mammoth/Mammoth_below.dmm
@@ -12292,7 +12292,7 @@
 "blW" = (
 /obj/structure/fluff/ms13/barrel/triple/waste,
 /turf/open/floor/plating/ms13/ground/mountain,
-/area/ms13/underground/underground_town)
+/area/ms13/underground/mountain)
 "bmE" = (
 /obj/structure/ms13/storage/shelf,
 /obj/effect/spawner/random/ms13/crafting/highrandom,
@@ -12496,7 +12496,7 @@
 "bPt" = (
 /obj/structure/fluff/ms13/barrel/triple/waste/two,
 /turf/open/floor/plating/ms13/ground/mountain,
-/area/ms13/underground/underground_town)
+/area/ms13/underground/mountain)
 "bPM" = (
 /obj/structure/ms13/storage/shelf{
 	dir = 8
@@ -12941,7 +12941,7 @@
 /obj/item/paper/ms13/paperslip,
 /obj/effect/decal/cleanable/greenglow,
 /turf/open/floor/plating/ms13/ground/mountain,
-/area/ms13/underground/underground_town)
+/area/ms13/underground/mountain)
 "cVz" = (
 /obj/structure/ms13/rug/rubber,
 /turf/open/floor/ms13/concrete/industrial,
@@ -13065,10 +13065,6 @@
 /obj/effect/spawner/random/ms13/locked/random/highchance,
 /turf/open/floor/ms13/tile/navy,
 /area/ms13/town)
-"dnB" = (
-/obj/machinery/light/ms13/bulb,
-/turf/open/floor/wood/ms13/wide,
-/area/ms13/underground/underground_town)
 "doj" = (
 /obj/structure/table/ms13/metal/grate,
 /obj/machinery/light/ms13,
@@ -13306,7 +13302,7 @@
 "dTu" = (
 /obj/structure/fluff/ms13/barrel/single/waste/one,
 /turf/open/floor/plating/ms13/ground/mountain,
-/area/ms13/underground/underground_town)
+/area/ms13/underground/mountain)
 "dTJ" = (
 /obj/structure/ms13/celldoor/rusty,
 /turf/open/floor/ms13/concrete,
@@ -13553,9 +13549,6 @@
 	dir = 4
 	},
 /obj/item/pen/ms13,
-/obj/machinery/light/ms13/bulb{
-	dir = 8
-	},
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/underground/underground_town)
 "eGY" = (
@@ -13800,7 +13793,7 @@
 "fAd" = (
 /obj/effect/spawner/random/ms13/crafting/lowrandom,
 /turf/open/floor/plating/ms13/ground/mountain,
-/area/ms13/underground/underground_town)
+/area/ms13/underground/mountain)
 "fBS" = (
 /obj/structure/closet/crate/ms13/woodcrate,
 /obj/effect/spawner/random/ms13/guaranteed/crafting/precious,
@@ -14067,7 +14060,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating/ms13/ground/mountain,
-/area/ms13/underground/underground_town)
+/area/ms13/underground/mountain)
 "gsd" = (
 /obj/machinery/door/unpowered/ms13/seethrough/fence/wire,
 /turf/open/floor/ms13/concrete/industrial,
@@ -14251,10 +14244,6 @@
 	},
 /turf/open/floor/plating/ms13/ground/mountain,
 /area/ms13/underground/mountain)
-"gSg" = (
-/mob/living/basic/ms13/hostile_animal/radroach/glowie,
-/turf/open/floor/wood/ms13/wide,
-/area/ms13/underground/underground_town)
 "gSj" = (
 /obj/structure/sink{
 	dir = 8;
@@ -14720,7 +14709,7 @@
 /obj/item/paper/ms13/paperslip,
 /obj/effect/spawner/random/ms13/crafting/lowrandom,
 /turf/open/floor/plating/ms13/ground/mountain,
-/area/ms13/underground/underground_town)
+/area/ms13/underground/mountain)
 "iqP" = (
 /obj/effect/spawner/random/ms13/food/packaged,
 /obj/effect/spawner/random/ms13/food/packaged,
@@ -14768,6 +14757,9 @@
 /area/ms13/underground/mountain)
 "iyi" = (
 /obj/item/paper_bin/ms13,
+/obj/machinery/light/ms13/bulb{
+	dir = 8
+	},
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/underground/underground_town)
 "iyo" = (
@@ -16502,8 +16494,10 @@
 /turf/open/floor/plating/ms13/ground/mountain,
 /area/ms13/underground/mountain)
 "nZk" = (
-/mob/living/basic/ms13/ghoul/radioactive,
-/turf/open/floor/plating/ms13/ground/mountain,
+/obj/machinery/light/ms13/bulb{
+	dir = 1
+	},
+/turf/open/floor/wood/ms13/wide,
 /area/ms13/underground/underground_town)
 "nZq" = (
 /turf/closed/wall/ms13/concrete,
@@ -17377,7 +17371,7 @@
 "qtM" = (
 /obj/machinery/light/ms13/bulb/industrial/broken,
 /turf/open/floor/plating/ms13/ground/mountain,
-/area/ms13/underground/underground_town)
+/area/ms13/underground/mountain)
 "qtS" = (
 /obj/structure/table/ms13/crafting/tinkerbench,
 /turf/open/floor/ms13/metal,
@@ -17869,7 +17863,7 @@
 "sdh" = (
 /obj/structure/fluff/ms13/barrel/single/toxic/two,
 /turf/open/floor/plating/ms13/ground/mountain,
-/area/ms13/underground/underground_town)
+/area/ms13/underground/mountain)
 "seC" = (
 /obj/effect/decal/cleanable/blood/old{
 	pixel_x = 10
@@ -17964,12 +17958,12 @@
 /obj/structure/ms13/foundation/wide/variantfour{
 	dir = 6
 	},
-/obj/effect/spawner/random/ms13/gun/tier2,
 /obj/effect/spawner/random/ms13/currency/mammoth/prewar/lowrandom,
 /obj/effect/spawner/random/ms13/clothing/gloves,
 /obj/machinery/light/ms13/bulb{
 	dir = 8
 	},
+/obj/effect/spawner/random/ms13/gun/lowrandom,
 /turf/open/floor/plating/ms13/ground/mountain,
 /area/ms13/underground/underground_town)
 "soy" = (
@@ -18876,7 +18870,6 @@
 /obj/structure/ms13/foundation/wide/variantthree{
 	dir = 6
 	},
-/obj/effect/spawner/random/ms13/melee/lowrandom,
 /mob/living/basic/ms13/hostile_animal/radroach/glowie,
 /turf/open/floor/plating/ms13/ground/mountain,
 /area/ms13/underground/underground_town)
@@ -19196,11 +19189,15 @@
 /area/ms13/underground/underground_town)
 "wdM" = (
 /obj/structure/ms13/tv/wooden,
+/obj/machinery/light/ms13/bulb{
+	dir = 1
+	},
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/underground/underground_town)
 "wfx" = (
-/turf/open/ms13/water/sewer/medium,
-/area/ms13/underground/underground_town)
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plating/ms13/ground/mountain,
+/area/ms13/underground/mountain)
 "wfy" = (
 /obj/structure/table/ms13/no_smooth/large/metal/desk{
 	dir = 4
@@ -19450,12 +19447,6 @@
 /obj/effect/spawner/random/ms13/drink/alcohol_uncommon,
 /turf/open/floor/ms13/tile,
 /area/ms13/town)
-"xgm" = (
-/obj/machinery/light/ms13/bulb{
-	dir = 8
-	},
-/turf/open/floor/wood/ms13/wide,
-/area/ms13/underground/underground_town)
 "xhY" = (
 /obj/machinery/light/ms13,
 /turf/open/floor/ms13/concrete/industrial,
@@ -19703,9 +19694,6 @@
 /area/ms13/town)
 "ybs" = (
 /obj/item/ms13_small_flag/usa,
-/obj/machinery/light/ms13/bulb{
-	dir = 1
-	},
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/underground/underground_town)
 "ybQ" = (
@@ -83981,8 +83969,8 @@ nTK
 mhT
 aiR
 fAd
-aMU
-aXl
+wfx
+awx
 afU
 afU
 afU
@@ -84284,8 +84272,8 @@ aiR
 aiR
 gri
 ipo
-aXl
-nZk
+akx
+aiP
 afU
 afU
 afU
@@ -84581,8 +84569,8 @@ afU
 aiR
 xpA
 nTK
-xgm
-gSg
+aff
+aff
 iyo
 fAd
 cVc
@@ -84874,11 +84862,11 @@ aRM
 aSH
 aZW
 afU
-wfx
-wfx
-wfx
-wfx
-wfx
+abd
+abd
+abd
+abd
+abd
 afU
 aiR
 wdM
@@ -85175,12 +85163,12 @@ aqI
 aqI
 aLH
 aZW
-wfx
-wfx
-wfx
-wfx
-wfx
-aXl
+abd
+abd
+abd
+abd
+abd
+akx
 aiR
 aiR
 wzX
@@ -85477,11 +85465,11 @@ aRM
 aRM
 aSH
 aPL
-aXl
-wfx
-aXl
-wfx
-aXl
+akx
+abd
+akx
+abd
+akx
 qtM
 aiR
 ybs
@@ -85779,12 +85767,12 @@ aRM
 aRM
 aLH
 aZW
-aXl
-aXl
-aXl
-aXl
-aXl
-aXl
+akx
+akx
+akx
+akx
+akx
+akx
 uBf
 tUc
 aff
@@ -86082,17 +86070,17 @@ aRM
 aLH
 aZW
 afU
-aXl
-aXl
-aXl
-aXl
+akx
+akx
+akx
+akx
 afU
 aiR
 aiR
-aff
+nZk
 iCN
 glQ
-dnB
+aff
 aiR
 uYo
 dBO
@@ -86385,8 +86373,8 @@ aLH
 aZW
 afU
 afU
-aXl
-aXl
+akx
+akx
 afU
 afU
 afU


### PR DESCRIPTION
An area added to an emptier part of the Mammoth Underground, I'll probably end up doing more with the general vicinity. For now a home rich with LORE and GLOOP.

The only guaranteed spawns are beer. (BAR RP? 💯)

Pretty innocuous area for the most part, just more to see when exploring the deep.

![8jCUVrU](https://user-images.githubusercontent.com/51187536/234234452-8413726e-ed17-4ca7-a0bc-a62394eebb10.png)

![TSBis8x](https://user-images.githubusercontent.com/51187536/234234643-856757d9-06ca-402b-a094-b3aedb216349.png)

