### PR TITLE
Mining and Smelting Tweaks

### DIFF
--- a/_maps/map_files/Drought/Drought.dmm
+++ b/_maps/map_files/Drought/Drought.dmm
@@ -422,7 +422,7 @@
 /turf/open/floor/ms13/concrete/small,
 /area/ms13/water_baron/interior)
 "ayw" = (
-/obj/item/stack/sheet/ms13/scrap_wood,
+/obj/item/stack/sheet/ms13/wood/scrap_wood,
 /turf/open/floor/plating/ms13/ground/desert,
 /area/ms13/desert)
 "azd" = (
@@ -7363,7 +7363,7 @@
 /area/ms13/town)
 "iMC" = (
 /obj/structure/table/ms13/low_wall/siding,
-/obj/item/stack/sheet/ms13/plank{
+/obj/item/stack/sheet/ms13/wood/plank{
 	pixel_x = -5;
 	pixel_y = -3
 	},
@@ -8883,7 +8883,7 @@
 /turf/open/floor/ms13/concrete/small,
 /area/ms13/water_baron/interior)
 "kEd" = (
-/obj/item/stack/sheet/ms13/plank,
+/obj/item/stack/sheet/ms13/wood/plank,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "kEl" = (
@@ -11416,7 +11416,7 @@
 /turf/open/floor/plating/ms13/ground/sidewalk,
 /area/ms13/town)
 "nBq" = (
-/obj/item/stack/sheet/ms13/scrap_wood/two,
+/obj/item/stack/sheet/ms13/wood/scrap_wood/two,
 /turf/open/floor/plating/ms13/ground/desert,
 /area/ms13/desert)
 "nBO" = (
@@ -11762,7 +11762,7 @@
 /turf/open/floor/ms13/tile/full/green,
 /area/ms13/town)
 "nVv" = (
-/obj/item/stack/sheet/ms13/scrap_wood,
+/obj/item/stack/sheet/ms13/wood/scrap_wood,
 /obj/structure/ms13/foundation/variantsix{
 	dir = 9
 	},
@@ -12089,7 +12089,7 @@
 /turf/open/floor/ms13/concrete,
 /area/ms13/desert)
 "osr" = (
-/obj/item/stack/sheet/ms13/scrap_wood,
+/obj/item/stack/sheet/ms13/wood/scrap_wood,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "oss" = (
@@ -12573,7 +12573,7 @@
 /turf/open/floor/wood/ms13/carpet/shaggy/blue,
 /area/ms13/town)
 "oRt" = (
-/obj/item/stack/sheet/ms13/plank,
+/obj/item/stack/sheet/ms13/wood/plank,
 /turf/open/floor/plating/ms13/ground/desert,
 /area/ms13/water_baron)
 "oRv" = (
@@ -12886,7 +12886,7 @@
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "pkF" = (
-/obj/item/stack/sheet/ms13/scrap_wood,
+/obj/item/stack/sheet/ms13/wood/scrap_wood,
 /obj/structure/ms13/foundation/variantfour{
 	dir = 4
 	},
@@ -14657,7 +14657,7 @@
 /turf/open/floor/ms13/concrete,
 /area/ms13/water_baron/interior)
 "rmd" = (
-/obj/item/stack/sheet/ms13/scrap_wood,
+/obj/item/stack/sheet/ms13/wood/scrap_wood,
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 4
 	},
@@ -14894,7 +14894,7 @@
 /area/ms13/water_baron/interior)
 "rwl" = (
 /obj/effect/decal/cleanable/glass,
-/obj/item/stack/sheet/ms13/plank{
+/obj/item/stack/sheet/ms13/wood/plank{
 	pixel_x = 7;
 	pixel_y = 5
 	},
@@ -17154,7 +17154,7 @@
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 4
 	},
-/obj/item/stack/sheet/ms13/plank,
+/obj/item/stack/sheet/ms13/wood/plank,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "tYx" = (
@@ -19105,7 +19105,7 @@
 	},
 /obj/effect/decal/cleanable/blood/tracks,
 /obj/structure/ms13/cave_decor/boards/mammoth/northsouth,
-/obj/item/stack/sheet/ms13/scrap_wood{
+/obj/item/stack/sheet/ms13/wood/scrap_wood{
 	pixel_x = -9;
 	pixel_y = 12
 	},

--- a/_maps/map_files/Drought/Drought_above.dmm
+++ b/_maps/map_files/Drought/Drought_above.dmm
@@ -6921,7 +6921,7 @@
 "yk" = (
 /obj/item/ammo_casing/ms13/spent,
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
-/obj/item/stack/sheet/ms13/scrap_wood{
+/obj/item/stack/sheet/ms13/wood/scrap_wood{
 	pixel_x = -9;
 	pixel_y = 12
 	},

--- a/_maps/map_files/Mammoth/Mammoth.dmm
+++ b/_maps/map_files/Mammoth/Mammoth.dmm
@@ -1588,7 +1588,7 @@
 /area/ms13/town)
 "aWO" = (
 /obj/structure/ms13/foundation/variantfour,
-/obj/item/stack/sheet/ms13/scrap_wood,
+/obj/item/stack/sheet/ms13/wood/scrap_wood,
 /turf/open/floor/plating/ms13/ground/mountain,
 /area/ms13/town)
 "aXq" = (
@@ -6641,15 +6641,15 @@
 /turf/closed/wall/ms13/brick/alt,
 /area/ms13/town)
 "ela" = (
-/obj/item/stack/sheet/ms13/log{
+/obj/item/stack/sheet/ms13/wood/log{
 	pixel_x = -8;
 	pixel_y = 11
 	},
-/obj/item/stack/sheet/ms13/log{
+/obj/item/stack/sheet/ms13/wood/log{
 	pixel_x = -5;
 	pixel_y = 6
 	},
-/obj/item/stack/sheet/ms13/log{
+/obj/item/stack/sheet/ms13/wood/log{
 	pixel_x = -7;
 	pixel_y = 14
 	},
@@ -32842,7 +32842,7 @@
 /area/ms13/town)
 "xLK" = (
 /obj/structure/ms13/foundation/variantfive,
-/obj/item/stack/sheet/ms13/scrap_wood,
+/obj/item/stack/sheet/ms13/wood/scrap_wood,
 /turf/open/floor/plating/ms13/ground/mountain,
 /area/ms13/town)
 "xLS" = (

--- a/_maps/map_files/Mammoth/Mammoth_above.dmm
+++ b/_maps/map_files/Mammoth/Mammoth_above.dmm
@@ -5329,8 +5329,8 @@
 	pixel_x = 19;
 	pixel_y = 14
 	},
-/obj/item/stack/sheet/ms13/plank,
-/obj/item/stack/sheet/ms13/plank,
+/obj/item/stack/sheet/ms13/wood/plank,
+/obj/item/stack/sheet/ms13/wood/plank,
 /turf/open/floor/wood/ms13/common,
 /area/ms13/town)
 "auA" = (
@@ -23186,8 +23186,8 @@
 	pixel_x = 4;
 	pixel_y = 4
 	},
-/obj/item/stack/sheet/ms13/log,
-/obj/item/stack/sheet/ms13/log{
+/obj/item/stack/sheet/ms13/wood/log,
+/obj/item/stack/sheet/ms13/wood/log{
 	pixel_x = -5;
 	pixel_y = 6
 	},

--- a/_maps/map_files/Mammoth/Mammoth_below.dmm
+++ b/_maps/map_files/Mammoth/Mammoth_below.dmm
@@ -54,7 +54,7 @@
 /turf/open/floor/ms13/metal,
 /area/ms13/underground/bos)
 "aan" = (
-/obj/item/stack/sheet/ms13/plank,
+/obj/item/stack/sheet/ms13/wood/plank,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "aao" = (

--- a/code/game/machinery/deployable.dm
+++ b/code/game/machinery/deployable.dm
@@ -81,7 +81,7 @@
 	max_integrity = 75
 
 /obj/structure/barricade/wooden/make_debris()
-	new /obj/item/stack/sheet/ms13/scrap_wood(get_turf(src), drop_amount) //MOJAVE EDIT - Drops our wood instead of TG wood. Revert after CAT
+	new /obj/item/stack/sheet/ms13/wood/scrap_wood(get_turf(src), drop_amount) //MOJAVE EDIT - Drops our wood instead of TG wood. Revert after CAT
 
 /obj/structure/barricade/sandbags
 	name = "sandbags"

--- a/code/game/objects/structures/beds_chairs/pew.dm
+++ b/code/game/objects/structures/beds_chairs/pew.dm
@@ -5,7 +5,7 @@
 	icon_state = "pewmiddle"
 	resistance_flags = FLAMMABLE
 	max_integrity = 70
-	buildstacktype = /obj/item/stack/sheet/ms13/scrap_wood //MOJAVE EDIT - Makes it drop our scrap wood instead of TG wood. Revert after CAT
+	buildstacktype = /obj/item/stack/sheet/ms13/wood/scrap_wood //MOJAVE EDIT - Makes it drop our scrap wood instead of TG wood. Revert after CAT
 	buildstackamount = 1 //MOJAVE EDIT - Original value is 3. Revert after CAT
 	item_chair = null
 

--- a/code/game/objects/structures/crates_lockers/closets/gimmick.dm
+++ b/code/game/objects/structures/crates_lockers/closets/gimmick.dm
@@ -9,7 +9,7 @@
 	close_sound_volume = 50
 	max_integrity = 70
 	door_anim_time = 0 // no animation
-	material_drop = /obj/item/stack/sheet/ms13/scrap_wood //MOJAVE EDIT - Drops our scrap wood instead of TG wood. Revert after CAT
+	material_drop = /obj/item/stack/sheet/ms13/wood/scrap_wood //MOJAVE EDIT - Drops our scrap wood instead of TG wood. Revert after CAT
 
 /obj/structure/closet/acloset
 	name = "strange closet"

--- a/code/modules/food_and_drinks/kitchen_machinery/grill.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/grill.dm
@@ -36,11 +36,11 @@
 	return ..()
 
 /obj/machinery/grill/attackby(obj/item/I, mob/user)
-	if(istype(I, /obj/item/stack/sheet/ms13/plank) || istype(I, /obj/item/stack/sheet/ms13/scrap_wood)) //MOJAVE EDIT - Takes our wood instead of TG wood and coal. Revert after CAT
+	if(istype(I, /obj/item/stack/sheet/ms13/wood/plank) || istype(I, /obj/item/stack/sheet/ms13/wood/scrap_wood)) //MOJAVE EDIT - Takes our wood instead of TG wood and coal. Revert after CAT
 		var/obj/item/stack/S = I
 		var/stackamount = S.get_amount()
 		to_chat(user, span_notice("You put [stackamount] [I]s in [src]."))
-		if(istype(I, /obj/item/stack/sheet/ms13/plank)) //MOJAVE EDIT - Takes our wood instead of TG coal. Adjusted fuel amounts accordingly. Revert after CAT
+		if(istype(I, /obj/item/stack/sheet/ms13/wood/plank)) //MOJAVE EDIT - Takes our wood instead of TG coal. Adjusted fuel amounts accordingly. Revert after CAT
 			grill_fuel += (150 * stackamount)
 		else
 			grill_fuel += (50 * stackamount)

--- a/mojave/code/modules/jobs/job_types/drylanders/hunter.dm
+++ b/mojave/code/modules/jobs/job_types/drylanders/hunter.dm
@@ -1,7 +1,7 @@
 /datum/job/ms13/drylander/hunter
 	title = "Drylander Hunter"
-	total_positions = 6
-	spawn_positions = 6
+	total_positions = 5
+	spawn_positions = 5
 	supervisors = "The Chieftain and the Headtakers"
 	description = "You are a trained warrior and hunter of the Drylander tribe. Listen to the Chieftain and the Headtakers of the tribe and do what you must to protect your tribe and ensure they prosper."
 

--- a/mojave/code/modules/mob/robots/vendortrons.dm
+++ b/mojave/code/modules/mob/robots/vendortrons.dm
@@ -383,7 +383,7 @@
 		/obj/item/stack/sheet/ms13/scrap_lead/five = list(25, rand(4,6)),
 		/obj/item/stack/sheet/ms13/scrap_brass/five = list(25, rand(4,6)),
 		/obj/item/stack/sheet/ms13/scrap_alu/five = list(25, rand(4,6)),
-		/obj/item/stack/sheet/ms13/plank/four = list(25, rand(3,5))
+		/obj/item/stack/sheet/ms13/wood/plank/four = list(25, rand(3,5))
 				)
 
 /mob/living/simple_animal/hostile/retaliate/trader/ms13/tools/initial_wanteds()
@@ -392,7 +392,7 @@
 		/obj/item/stack/sheet/ms13/scrap = list(4, rand(5,30), ", per piece of scrap"),
 		/obj/item/stack/sheet/ms13/scrap_steel = list(4, rand(5,30), ", per piece of steel"),
 		/obj/item/stack/sheet/ms13/scrap_alu = list(4, rand(5,30), ", per piece of aluminum"),
-		/obj/item/stack/sheet/ms13/plank = list(5, rand(4,20), ", per plank"),
+		/obj/item/stack/sheet/ms13/wood/plank = list(5, rand(4,20), ", per plank"),
 		/obj/item/stack/sheet/ms13/scrap_copper = list(4, rand(5,30), ", per piece of copper wire"),
 		/obj/item/stack/sheet/ms13/scrap_gold = list(7, rand(5,25), ", per piece of gold"),
 		/obj/item/stack/sheet/ms13/scrap_silver = list(7, rand(5,25), ", per piece of silver"),
@@ -657,7 +657,7 @@
 		/obj/item/stack/sheet/ms13/scrap_lead/five = list(20, rand(3,6)),
 		/obj/item/stack/sheet/ms13/scrap_brass/five = list(20, rand(3,6)),
 		/obj/item/stack/sheet/ms13/scrap_alu/five = list(20, rand(3,6)),
-		/obj/item/stack/sheet/ms13/plank/four = list(20, rand(3,6))
+		/obj/item/stack/sheet/ms13/wood/plank/four = list(20, rand(3,6))
 				)
 
 /mob/living/simple_animal/hostile/retaliate/trader/ms13/drought/crimson/initial_wanteds()
@@ -666,7 +666,7 @@
 		/obj/item/stack/sheet/ms13/scrap = list(3, rand(4,20), ", per piece of scrap"),
 		/obj/item/stack/sheet/ms13/scrap_steel = list(3, rand(4,20), ", per piece of steel"),
 		/obj/item/stack/sheet/ms13/scrap_alu = list(3, rand(4,20), ", per piece of aluminum"),
-		/obj/item/stack/sheet/ms13/plank = list(4, rand(2,15), ", per plank"),
+		/obj/item/stack/sheet/ms13/wood/plank = list(4, rand(2,15), ", per plank"),
 		/obj/item/stack/sheet/ms13/scrap_copper = list(3, rand(4,20), ", per piece of copper wire"),
 		/obj/item/stack/sheet/ms13/scrap_gold = list(8, rand(3,15), ", per piece of gold"),
 		/obj/item/stack/sheet/ms13/scrap_silver = list(6, rand(3,15), ", per piece of silver"),
@@ -836,7 +836,7 @@
 		/obj/item/food/ms13/prewar/boxed/snackcake = list(25, rand(1,3)),
 		/obj/item/stack/medical/ms13/healing_powder = list(35, rand(1,3)),
 		/obj/item/stack/sheet/ms13/scrap/five = list(20, rand(3,6)),
-		/obj/item/stack/sheet/ms13/scrap_wood/five = list(20, rand(3,6)),
+		/obj/item/stack/sheet/ms13/wood/scrap_wood/five = list(20, rand(3,6)),
 		/obj/item/stack/sheet/ms13/scrap_parts/five = list(20, rand(3,6)),
 		/obj/item/stack/sheet/ms13/cloth/five = list(20, rand(3,6)),
 		/obj/item/stack/sheet/ms13/leather/five = list(20, rand(3,6)),

--- a/mojave/effects/spawners/lootdrop/guarenteed/meleeloot.dm
+++ b/mojave/effects/spawners/lootdrop/guarenteed/meleeloot.dm
@@ -42,7 +42,8 @@
 			/obj/item/shovel/ms13/spade,
 			/obj/item/ms13/twohanded/spear/throwing,
 			/obj/item/ms13/twohanded/hammer/rebar,
-			/obj/item/weldingtool/ms13
+			/obj/item/weldingtool/ms13,
+			/obj/item/pickaxe/ms13
 			)
 
 /obj/effect/spawner/random/ms13/guaranteed/melee/tier3

--- a/mojave/effects/spawners/lootdrop/guarenteed/miscloot.dm
+++ b/mojave/effects/spawners/lootdrop/guarenteed/miscloot.dm
@@ -38,7 +38,8 @@
 			/obj/item/shovel/ms13/spade,
 			/obj/item/shovel/ms13/snow,
 			/obj/item/shovel/ms13/rake,
-			/obj/item/ms13/brick
+			/obj/item/ms13/brick,
+			/obj/item/pickaxe/ms13
 			)
 
 /obj/effect/spawner/random/ms13/guaranteed/tools/lights

--- a/mojave/effects/spawners/lootdrop/guarenteed/miscloot.dm
+++ b/mojave/effects/spawners/lootdrop/guarenteed/miscloot.dm
@@ -82,8 +82,8 @@
 /obj/effect/spawner/random/ms13/guaranteed/crafting/lowrandom
 	name = "low tier random crafting spawner"
 	loot = list(
-			/obj/item/stack/sheet/ms13/scrap_wood/two,
-			/obj/item/stack/sheet/ms13/plank,
+			/obj/item/stack/sheet/ms13/wood/scrap_wood/two,
+			/obj/item/stack/sheet/ms13/wood/plank,
 			/obj/item/stack/sheet/ms13/leather/two,
 			/obj/item/stack/sheet/ms13/thread/two,
 			/obj/item/stack/sheet/ms13/scrap_electronics/two,

--- a/mojave/effects/spawners/lootdrop/meleeloot.dm
+++ b/mojave/effects/spawners/lootdrop/meleeloot.dm
@@ -44,7 +44,8 @@
 			/obj/item/shovel/ms13/spade,
 			/obj/item/ms13/twohanded/spear/throwing,
 			/obj/item/ms13/twohanded/hammer/rebar,
-			/obj/item/weldingtool/ms13
+			/obj/item/weldingtool/ms13,
+			/obj/item/pickaxe/ms13
 			)
 
 /obj/effect/spawner/random/ms13/melee/tier3

--- a/mojave/effects/spawners/lootdrop/miscloot.dm
+++ b/mojave/effects/spawners/lootdrop/miscloot.dm
@@ -89,8 +89,8 @@
 	name = "low tier random crafting spawner"
 	spawn_loot_chance = 65
 	loot = list(
-			/obj/item/stack/sheet/ms13/scrap_wood/two,
-			/obj/item/stack/sheet/ms13/plank,
+			/obj/item/stack/sheet/ms13/wood/scrap_wood/two,
+			/obj/item/stack/sheet/ms13/wood/plank,
 			/obj/item/stack/sheet/ms13/leather/two,
 			/obj/item/stack/sheet/ms13/thread/two,
 			/obj/item/stack/sheet/ms13/scrap_electronics/two,

--- a/mojave/effects/spawners/lootdrop/miscloot.dm
+++ b/mojave/effects/spawners/lootdrop/miscloot.dm
@@ -40,7 +40,8 @@
 			/obj/item/shovel/ms13/spade,
 			/obj/item/shovel/ms13/snow,
 			/obj/item/shovel/ms13/rake,
-			/obj/item/ms13/brick
+			/obj/item/ms13/brick,
+			/obj/item/pickaxe/ms13
 			)
 
 /obj/effect/spawner/random/ms13/tools/lights

--- a/mojave/flora/wasteplants.dm
+++ b/mojave/flora/wasteplants.dm
@@ -354,7 +354,7 @@
 					playsound(get_turf(src), 'sound/effects/meteorimpact.ogg', 80, FALSE, FALSE)
 					user.log_message("cut down [src] at [AREACOORD(src)]", LOG_ATTACK)
 					for(var/i=1 to log_amount)
-						new /obj/item/stack/sheet/ms13/log(get_turf(src))
+						new /obj/item/stack/sheet/ms13/wood/log(get_turf(src))
 					qdel(src)
 		else
 			user.visible_message("<span class='notice'>The [W] is uncapable of cutting down the [src].</span>")

--- a/mojave/items/crafting/materials.dm
+++ b/mojave/items/crafting/materials.dm
@@ -226,12 +226,16 @@
 
 //WOOD//
 
-/obj/item/stack/sheet/ms13/log
+/obj/item/stack/sheet/ms13/wood
+	name = "of any type of wood" //This makes it so crafting recipes state "2 of any type of wood". This base path is used so we can have crafting recipes, as the name implies, take any kind of wood.
+	desc = "I am a crafting parent type placeholder."
+
+/obj/item/stack/sheet/ms13/wood/log
 	name = "logs"
 	desc = "Sturdy wood logs."
 	singular_name = "log"
 	icon_state = "log"
-	merge_type = /obj/item/stack/sheet/ms13/log
+	merge_type = /obj/item/stack/sheet/ms13/wood/log
 	amount = 1
 	max_amount = 6
 	grid_width = 96
@@ -241,11 +245,11 @@ GLOBAL_LIST_INIT(log_recipes, list ( \
 	new/datum/stack_recipe("crude log wall", /turf/closed/wall/ms13/craftable/wood, 4, time = 40 SECONDS, one_per_turf = TRUE, on_floor = TRUE), \
 ))
 
-/obj/item/stack/sheet/ms13/log/get_main_recipes()
+/obj/item/stack/sheet/ms13/wood/log/get_main_recipes()
 	. = ..()
 	. += GLOB.log_recipes
 
-/obj/item/stack/sheet/ms13/log/attackby(obj/item/W, mob/user, params)
+/obj/item/stack/sheet/ms13/wood/log/attackby(obj/item/W, mob/user, params)
 	if(W.sharpness & SHARP_AXE)
 		if(amount > 1)
 			user.show_message(span_notice("You can only chop one log at a time!"), MSG_VISUAL)
@@ -253,23 +257,23 @@ GLOBAL_LIST_INIT(log_recipes, list ( \
 		user.show_message(span_notice("You begin chopping \the [src] into wood planks!"), MSG_VISUAL)
 		if(do_after(user, 4 SECONDS, target = src, interaction_key = DOAFTER_SOURCE_MAKEPLANKS))
 			user.show_message(span_notice("You make wood planks out of \the [src]!"), MSG_VISUAL)
-			new /obj/item/stack/sheet/ms13/plank/two(user.loc)
+			new /obj/item/stack/sheet/ms13/wood/plank/two(user.loc)
 			qdel(src)
 
-/obj/item/stack/sheet/ms13/scrap_wood
+/obj/item/stack/sheet/ms13/wood/scrap_wood
 	name = "scrap wood"
 	desc = "Various scrap, low quality pieces of wood."
 	singular_name = "scrap wood piece"
 	icon_state = "scrap_wood"
 	pickup_sound = 'mojave/sound/ms13weapons/meleesounds/wooden_pickup.ogg'
-	merge_type = /obj/item/stack/sheet/ms13/scrap_wood
+	merge_type = /obj/item/stack/sheet/ms13/wood/scrap_wood
 	amount = 1
 	max_amount = 10
 
-/obj/item/stack/sheet/ms13/scrap_wood/two
+/obj/item/stack/sheet/ms13/wood/scrap_wood/two
 	amount = 2
 
-/obj/item/stack/sheet/ms13/scrap_wood/five
+/obj/item/stack/sheet/ms13/wood/scrap_wood/five
 	amount = 5
 
 GLOBAL_LIST_INIT(scrap_wood_recipes, list ( \
@@ -278,11 +282,11 @@ GLOBAL_LIST_INIT(scrap_wood_recipes, list ( \
 	new/datum/stack_recipe("campfire", /obj/structure/bonfire/ms13/campfire, 5, time = 15 SECONDS, one_per_turf = TRUE, on_floor = TRUE), \
 ))
 
-/obj/item/stack/sheet/ms13/scrap_wood/get_main_recipes()
+/obj/item/stack/sheet/ms13/wood/scrap_wood/get_main_recipes()
 	. = ..()
 	. += GLOB.scrap_wood_recipes
 
-/obj/item/stack/sheet/ms13/plank
+/obj/item/stack/sheet/ms13/wood/plank
 	name = "wood planks"
 	desc = "Robust wood planks. Perfect for crafting."
 	singular_name = "wood plank"
@@ -290,17 +294,17 @@ GLOBAL_LIST_INIT(scrap_wood_recipes, list ( \
 	force = 10 //funny bonk
 	hitsound = list('mojave/sound/ms13weapons/meleesounds/wooden_hit1.ogg', 'mojave/sound/ms13weapons/meleesounds/wooden_hit2.ogg', 'mojave/sound/ms13weapons/meleesounds/wooden_hit3.ogg')
 	pickup_sound = 'mojave/sound/ms13weapons/meleesounds/wooden_pickup.ogg'
-	merge_type = /obj/item/stack/sheet/ms13/plank
+	merge_type = /obj/item/stack/sheet/ms13/wood/plank
 	amount = 1
 	max_amount = 8
 	grid_width = 96
 	grid_height = 32
 	novariants = FALSE
 
-/obj/item/stack/sheet/ms13/plank/two
+/obj/item/stack/sheet/ms13/wood/plank/two
 	amount = 2
 
-/obj/item/stack/sheet/ms13/plank/four
+/obj/item/stack/sheet/ms13/wood/plank/four
 	amount = 4
 
 GLOBAL_LIST_INIT(plank_recipes, list ( \
@@ -310,7 +314,7 @@ GLOBAL_LIST_INIT(plank_recipes, list ( \
 	new/datum/stack_recipe("campfire", /obj/structure/bonfire/ms13/campfire, 3, time = 15 SECONDS, one_per_turf = TRUE, on_floor = TRUE), \
 ))
 
-/obj/item/stack/sheet/ms13/plank/get_main_recipes()
+/obj/item/stack/sheet/ms13/wood/plank/get_main_recipes()
 	. = ..()
 	. += GLOB.plank_recipes
 

--- a/mojave/items/melee/claymore.dm
+++ b/mojave/items/melee/claymore.dm
@@ -38,6 +38,7 @@
 	toolspeed = 2
 	grid_width = 64
 	grid_height = 96
+	mining_mult = -0.65
 
 /obj/item/claymore/ms13/machete/gladius
 	name = "machete gladius"
@@ -146,6 +147,7 @@
 	throwforce = 10
 	grid_width = 64
 	grid_height = 128
+	mining_mult = -0.65
 	var/on = FALSE
 
 /obj/item/claymore/ms13/machete/shishkebab/attack_self(mob/user)

--- a/mojave/items/melee/hatchet.dm
+++ b/mojave/items/melee/hatchet.dm
@@ -26,6 +26,7 @@
 	log_pickup_and_drop = TRUE
 	grid_width = 64
 	grid_height = 96
+	mining_mult = -0.25
 
 /obj/item/hatchet/ms13/Initialize()
 	. = ..()
@@ -57,6 +58,7 @@
 	bare_wound_bonus = 5
 	sharpness = SHARP_IMPALING
 	tool_behaviour = TOOL_MINING
+	mining_mult = 2
 
 /obj/item/hatchet/ms13/tomahawk
 	name = "tomahawk"
@@ -74,3 +76,4 @@
 	embedding = list("embedded_pain_multiplier" = 2, "embed_chance" = 50, "embedded_fall_chance" = 25)
 	sharpness = SHARP_IMPALING
 	log_pickup_and_drop = TRUE
+	mining_mult = 0.75

--- a/mojave/items/melee/knife.dm
+++ b/mojave/items/melee/knife.dm
@@ -26,6 +26,7 @@
 	log_pickup_and_drop = TRUE
 	grid_width = 64
 	grid_height = 32
+	mining_mult = -0.75
 
 /obj/item/knife/ms13/Initialize()
 	. = ..()

--- a/mojave/items/melee/special.dm
+++ b/mojave/items/melee/special.dm
@@ -72,6 +72,7 @@
 	w_class = WEIGHT_CLASS_NORMAL
 	grid_width = 96
 	grid_height = 64
+	mining_mult = 0.5
 
 
 /* Not sure about this, commenting it out for now

--- a/mojave/items/melee/twohanded.dm
+++ b/mojave/items/melee/twohanded.dm
@@ -62,6 +62,7 @@
 	grid_height = 192
 	grid_width = 64
 	wield_info = /datum/wield_info/twohanded/fireaxe
+	mining_mult = -0.5
 
 /obj/item/ms13/twohanded/fireaxe/drylander
 	name = "\improper Drylander axe"
@@ -98,6 +99,7 @@
 	grid_height = 192
 	grid_width = 64
 	wield_info = /datum/wield_info/twohanded/bump_sword
+	mining_mult = -0.5
 
 /obj/item/ms13/twohanded/hammer
 	name = "sledge hammer"
@@ -119,6 +121,7 @@
 	grid_height = 192
 	grid_width = 64
 	wield_info = /datum/wield_info/twohanded/sledge
+	mining_mult = 1
 
 /obj/item/ms13/twohanded/hammer/rebar
 	name = "rebar club"
@@ -130,6 +133,7 @@
 	wound_bonus = 0
 	bare_wound_bonus = 0
 	wield_info = /datum/wield_info/twohanded/rebar
+	mining_mult = 0.5
 
 /obj/item/ms13/twohanded/hammer/super
 	name = "super sledge"
@@ -143,6 +147,7 @@
 	grid_height = 256
 	grid_width = 96
 	wield_info = /datum/wield_info/twohanded/super_sledge
+	mining_mult = 2
 
 /obj/item/ms13/twohanded/hammer/super/attack(mob/living/target, mob/living/user)
 	. = ..()
@@ -175,6 +180,7 @@
 	grid_height = 32
 	grid_width = 224
 	wield_info = /datum/wield_info/twohanded/metal_spear
+	mining_mult = -0.65
 
 /obj/item/ms13/twohanded/spear/knife
 	name = "knife spear"
@@ -247,6 +253,7 @@
 	toolspeed = 0.35
 	grid_height = 256
 	grid_width = 256
+	mining_mult = 0.5
 	var/on = FALSE
 	var/datum/looping_sound/saw/soundloop
 
@@ -302,6 +309,7 @@
 	grid_height = 256
 	grid_width = 256
 	hitsound = "swing_hit"
+	mining_mult = 0.65
 	var/on = FALSE
 
 /obj/item/ms13/twohanded/heavy/lance/attack_self(mob/user)

--- a/mojave/items/misc/fluff.dm
+++ b/mojave/items/misc/fluff.dm
@@ -161,7 +161,7 @@
 	if(do_after(user, 8 SECONDS, target = src, interaction_key = DOAFTER_SOURCE_DECON))
 		user.show_message(span_notice("You disassemble \the [src] into scrap and parts."), MSG_VISUAL)
 		new /obj/item/stack/sheet/ms13/cloth(loc, 3)
-		new /obj/item/stack/sheet/ms13/scrap_wood(loc, 2)
+		new /obj/item/stack/sheet/ms13/wood/scrap_wood(loc, 2)
 		qdel(src)
 
 /obj/item/ms13/fluff/trifoldflag/examine(mob/user)

--- a/mojave/items/misc/radios.dm
+++ b/mojave/items/misc/radios.dm
@@ -26,7 +26,7 @@
 		return FALSE
 	if(!listening)
 		return FALSE
-	
+
 	return TRUE //MOHAVE SUN EDIT: Changed this so that it plays only when someone is listening, but otherwhise can recieve, even when not being held.
 
 /obj/item/radio/ms13/broadcast
@@ -156,13 +156,13 @@
 /obj/item/radio/ms13/ham/receiver/radioking/wood/deconstruct(disassembled = TRUE)
 	if(!(flags_1 & NODECONSTRUCT_1))
 		if(disassembled)
-			new /obj/item/stack/sheet/ms13/scrap_wood(loc, 2)
+			new /obj/item/stack/sheet/ms13/wood/scrap_wood(loc, 2)
 			new /obj/item/stack/sheet/ms13/scrap_parts(loc, 2)
 			new /obj/item/stack/sheet/ms13/scrap_electronics(loc, 3)
 			new /obj/item/stack/sheet/ms13/scrap_copper(loc, 2)
 			new /obj/item/ms13/component/cell(loc)
 		else
-			new /obj/item/stack/sheet/ms13/scrap_wood(loc)
+			new /obj/item/stack/sheet/ms13/wood/scrap_wood(loc)
 			new /obj/item/stack/sheet/ms13/scrap_parts(loc)
 			new /obj/item/stack/sheet/ms13/scrap_electronics(loc)
 	qdel(src)

--- a/mojave/items/tools/tools.dm
+++ b/mojave/items/tools/tools.dm
@@ -28,6 +28,7 @@
 	log_pickup_and_drop = TRUE
 	grid_width = 32
 	grid_height = 64
+	mining_mult = 0.75
 
 /obj/item/ms13/hammer/Initialize()
 	. = ..()
@@ -60,6 +61,7 @@
 	log_pickup_and_drop = TRUE
 	grid_width = 96
 	grid_height = 32
+	mining_mult = -0.5
 
 /obj/item/ms13/handsaw/Initialize()
 	. = ..()
@@ -91,6 +93,7 @@
 	log_pickup_and_drop = TRUE
 	grid_width = 64
 	grid_height = 64
+	mining_mult = 1.2
 
 /obj/item/ms13/handdrill/Initialize()
 	. = ..()
@@ -290,6 +293,7 @@
 	slot_flags = ITEM_SLOT_BELT
 	grid_width = 64
 	grid_height = 64
+	mining_mult = -0.5
 
 /obj/item/shovel/ms13/snow
 	name = "snow shovel"
@@ -341,7 +345,7 @@
 	grid_height = 128
 	custom_materials = null
 	toolspeed = 1.5 //grim
-	mining_mult = 8
+	mining_mult = 5
 
 /obj/item/ms13/brick
 	name = "brick"
@@ -371,6 +375,7 @@
 	log_pickup_and_drop = TRUE
 	grid_width = 64
 	grid_height = 32
+	mining_mult = 0.75 //funny brick utility
 
 /obj/item/ms13/brick/Initialize()
 	. = ..()

--- a/mojave/modules/crafting/recipes/medical_recipes.dm
+++ b/mojave/modules/crafting/recipes/medical_recipes.dm
@@ -59,7 +59,7 @@
 	time = 10 SECONDS
 	tool_paths = list()
 	reqs = list(/obj/item/stack/sheet/ms13/cloth = 2,
-				/obj/item/stack/sheet/ms13/plank = 2)
+				/obj/item/stack/sheet/ms13/wood/plank = 2)
 	category = CAT_MEDICAL
 	crafting_interface = CRAFTING_BENCH_GENERAL
 

--- a/mojave/modules/crafting/recipes/recipes.dm
+++ b/mojave/modules/crafting/recipes/recipes.dm
@@ -27,7 +27,7 @@
 	time = 15 SECONDS
 	tool_behaviors = list(TOOL_KNIFE, TOOL_SAW, TOOL_SCREWDRIVER, TOOL_WRENCH)
 	tool_paths = list()
-	reqs = list(/obj/item/stack/sheet/ms13/plank = 3,
+	reqs = list(/obj/item/stack/sheet/ms13/wood/plank = 3,
 				/obj/item/stack/sheet/ms13/thread = 6,
 				/obj/item/stack/sheet/ms13/scrap_parts = 3,
 				/obj/item/stack/sheet/ms13/scrap = 3)
@@ -64,7 +64,7 @@
 	time = 8 SECONDS
 	tool_paths = list(/obj/item/ms13/hammer)
 	reqs = list(/obj/item/stack/sheet/ms13/scrap_steel = 4,
-				/obj/item/stack/sheet/ms13/plank = 2)
+				/obj/item/stack/sheet/ms13/wood = 2)
 	category = CAT_SMELTER
 	crafting_interface = CRAFTING_BENCH_SMELTER
 
@@ -74,7 +74,7 @@
 	time = 8 SECONDS
 	tool_paths = list(/obj/item/ms13/hammer)
 	reqs = list(/obj/item/stack/sheet/ms13/scrap_alu = 4,
-				/obj/item/stack/sheet/ms13/plank = 2)
+				/obj/item/stack/sheet/ms13/wood = 2)
 	category = CAT_SMELTER
 	crafting_interface = CRAFTING_BENCH_SMELTER
 
@@ -84,7 +84,7 @@
 	time = 8 SECONDS
 	tool_paths = list(/obj/item/ms13/hammer)
 	reqs = list(/obj/item/stack/sheet/ms13/scrap_lead = 4,
-				/obj/item/stack/sheet/ms13/plank = 2)
+				/obj/item/stack/sheet/ms13/wood = 2)
 	category = CAT_SMELTER
 	crafting_interface = CRAFTING_BENCH_SMELTER
 
@@ -94,7 +94,7 @@
 	time = 8 SECONDS
 	tool_paths = list(/obj/item/ms13/hammer)
 	reqs = list(/obj/item/stack/sheet/ms13/scrap_copper = 4,
-				/obj/item/stack/sheet/ms13/plank = 2)
+				/obj/item/stack/sheet/ms13/wood = 2)
 	category = CAT_SMELTER
 	crafting_interface = CRAFTING_BENCH_SMELTER
 
@@ -104,7 +104,7 @@
 	time = 8 SECONDS
 	tool_paths = list(/obj/item/ms13/hammer)
 	reqs = list(/obj/item/stack/sheet/ms13/scrap_brass = 4,
-				/obj/item/stack/sheet/ms13/plank = 2)
+				/obj/item/stack/sheet/ms13/wood = 2)
 	category = CAT_SMELTER
 	crafting_interface = CRAFTING_BENCH_SMELTER
 
@@ -114,7 +114,7 @@
 	time = 8 SECONDS
 	tool_paths = list(/obj/item/ms13/hammer)
 	reqs = list(/obj/item/stack/sheet/ms13/scrap_silver = 4,
-				/obj/item/stack/sheet/ms13/plank = 2)
+				/obj/item/stack/sheet/ms13/wood = 2)
 	category = CAT_SMELTER
 	crafting_interface = CRAFTING_BENCH_SMELTER
 
@@ -124,7 +124,7 @@
 	time = 8 SECONDS
 	tool_paths = list(/obj/item/ms13/hammer)
 	reqs = list(/obj/item/stack/sheet/ms13/scrap_gold = 4,
-				/obj/item/stack/sheet/ms13/plank = 2)
+				/obj/item/stack/sheet/ms13/wood = 2)
 	category = CAT_SMELTER
 	crafting_interface = CRAFTING_BENCH_SMELTER
 
@@ -134,7 +134,7 @@
 	time = 5 SECONDS
 	tool_paths = list()
 	reqs = list(/obj/item/stack/sheet/ms13/refined_steel = 1,
-				/obj/item/stack/sheet/ms13/plank = 1)
+				/obj/item/stack/sheet/ms13/wood = 2)
 	category = CAT_MELT
 	crafting_interface = CRAFTING_BENCH_SMELTER
 
@@ -144,7 +144,7 @@
 	time = 5 SECONDS
 	tool_paths = list()
 	reqs = list(/obj/item/stack/sheet/ms13/refined_alu = 1,
-				/obj/item/stack/sheet/ms13/plank = 1)
+				/obj/item/stack/sheet/ms13/wood = 2)
 	category = CAT_MELT
 	crafting_interface = CRAFTING_BENCH_SMELTER
 
@@ -154,7 +154,7 @@
 	time = 5 SECONDS
 	tool_paths = list()
 	reqs = list(/obj/item/stack/sheet/ms13/refined_lead = 1,
-				/obj/item/stack/sheet/ms13/plank = 1)
+				/obj/item/stack/sheet/ms13/wood = 2)
 	category = CAT_MELT
 	crafting_interface = CRAFTING_BENCH_SMELTER
 
@@ -164,7 +164,7 @@
 	time = 5 SECONDS
 	tool_paths = list()
 	reqs = list(/obj/item/stack/sheet/ms13/refined_copper = 1,
-				/obj/item/stack/sheet/ms13/plank = 1)
+				/obj/item/stack/sheet/ms13/wood = 2)
 	category = CAT_MELT
 	crafting_interface = CRAFTING_BENCH_SMELTER
 
@@ -174,7 +174,7 @@
 	time = 5 SECONDS
 	tool_paths = list()
 	reqs = list(/obj/item/stack/sheet/ms13/refined_brass = 1,
-				/obj/item/stack/sheet/ms13/plank = 1)
+				/obj/item/stack/sheet/ms13/wood = 2)
 	category = CAT_MELT
 	crafting_interface = CRAFTING_BENCH_SMELTER
 
@@ -184,7 +184,7 @@
 	time = 5 SECONDS
 	tool_paths = list()
 	reqs = list(/obj/item/stack/sheet/ms13/refined_silver = 1,
-				/obj/item/stack/sheet/ms13/plank = 1)
+				/obj/item/stack/sheet/ms13/wood = 2)
 	category = CAT_MELT
 	crafting_interface = CRAFTING_BENCH_SMELTER
 
@@ -194,7 +194,7 @@
 	time = 5 SECONDS
 	tool_paths = list()
 	reqs = list(/obj/item/stack/sheet/ms13/refined_gold = 1,
-				/obj/item/stack/sheet/ms13/plank = 1)
+				/obj/item/stack/sheet/ms13/wood = 2)
 	category = CAT_MELT
 	crafting_interface = CRAFTING_BENCH_SMELTER
 
@@ -204,7 +204,7 @@
 	time = 8 SECONDS
 	tool_paths = list(/obj/item/ms13/hammer)
 	reqs = list(/obj/item/stack/ms13/currency/ncr_coin = 8,
-				/obj/item/stack/sheet/ms13/plank = 1)
+				/obj/item/stack/sheet/ms13/wood = 1)
 	category = CAT_MELT
 	crafting_interface = CRAFTING_BENCH_SMELTER
 
@@ -214,7 +214,7 @@
 	time = 8 SECONDS
 	tool_paths = list(/obj/item/ms13/hammer)
 	reqs = list(/obj/item/stack/ms13/currency/denarius = 8,
-				/obj/item/stack/sheet/ms13/plank = 1)
+				/obj/item/stack/sheet/ms13/wood = 1)
 	category = CAT_MELT
 	crafting_interface = CRAFTING_BENCH_SMELTER
 
@@ -224,7 +224,7 @@
 	time = 8 SECONDS
 	tool_paths = list(/obj/item/ms13/hammer)
 	reqs = list(/obj/item/stack/ms13/currency/aurelius = 3,
-				/obj/item/stack/sheet/ms13/plank = 1)
+				/obj/item/stack/sheet/ms13/wood = 1)
 	category = CAT_MELT
 	crafting_interface = CRAFTING_BENCH_SMELTER
 
@@ -234,7 +234,7 @@
 	time = 5 SECONDS
 	tool_paths = list()
 	reqs = list(/obj/item/stack/ms13/currency/cap = 15,
-				/obj/item/stack/sheet/ms13/plank = 2)
+				/obj/item/stack/sheet/ms13/wood = 2)
 	category = CAT_MELT
 	crafting_interface = CRAFTING_BENCH_SMELTER
 
@@ -250,51 +250,51 @@
 
 /datum/crafting_recipe/smelt_copper
 	name = "refined copper from ore"
-	result = /obj/item/stack/sheet/ms13/refined_copper/two
+	result = /obj/item/stack/sheet/ms13/refined_copper
 	time = 8 SECONDS
 	tool_paths = list(/obj/item/ms13/hammer)
 	reqs = list(/obj/item/stack/sheet/ms13/nugget/nugget_copper = 4,
-				/obj/item/stack/sheet/ms13/plank = 2)
+				/obj/item/stack/sheet/ms13/wood = 2)
 	category = CAT_SMELTER
 	crafting_interface = CRAFTING_BENCH_SMELTER
 
 /datum/crafting_recipe/smelt_lead
 	name = "refined lead from ore"
-	result = /obj/item/stack/sheet/ms13/refined_lead/two
+	result = /obj/item/stack/sheet/ms13/refined_lead
 	time = 8 SECONDS
 	tool_paths = list(/obj/item/ms13/hammer)
 	reqs = list(/obj/item/stack/sheet/ms13/nugget/nugget_lead = 4,
-				/obj/item/stack/sheet/ms13/plank = 2)
+				/obj/item/stack/sheet/ms13/wood = 2)
 	category = CAT_SMELTER
 	crafting_interface = CRAFTING_BENCH_SMELTER
 
 /datum/crafting_recipe/smelt_alu
 	name = "refined aluminum from ore"
-	result = /obj/item/stack/sheet/ms13/refined_alu/two
+	result = /obj/item/stack/sheet/ms13/refined_alu
 	time = 8 SECONDS
 	tool_paths = list(/obj/item/ms13/hammer)
 	reqs = list(/obj/item/stack/sheet/ms13/nugget/nugget_alu = 4,
-				/obj/item/stack/sheet/ms13/plank = 2)
+				/obj/item/stack/sheet/ms13/wood = 2)
 	category = CAT_SMELTER
 	crafting_interface = CRAFTING_BENCH_SMELTER
 
 /datum/crafting_recipe/smelt_silver
 	name = "refined silver from ore"
-	result = /obj/item/stack/sheet/ms13/refined_silver/two
+	result = /obj/item/stack/sheet/ms13/refined_silver
 	time = 8 SECONDS
 	tool_paths = list(/obj/item/ms13/hammer)
 	reqs = list(/obj/item/stack/sheet/ms13/nugget/nugget_silver = 4,
-				/obj/item/stack/sheet/ms13/plank = 2)
+				/obj/item/stack/sheet/ms13/wood = 2)
 	category = CAT_SMELTER
 	crafting_interface = CRAFTING_BENCH_SMELTER
 
 /datum/crafting_recipe/smelt_gold
 	name = "refined gold from ore"
-	result = /obj/item/stack/sheet/ms13/refined_gold/two
+	result = /obj/item/stack/sheet/ms13/refined_gold
 	time = 8 SECONDS
 	tool_paths = list(/obj/item/ms13/hammer)
 	reqs = list(/obj/item/stack/sheet/ms13/nugget/nugget_gold = 4,
-				/obj/item/stack/sheet/ms13/plank = 2)
+				/obj/item/stack/sheet/ms13/wood = 2)
 	category = CAT_SMELTER
 	crafting_interface = CRAFTING_BENCH_SMELTER
 
@@ -304,28 +304,28 @@
 // 	time = 3 SECONDS
 //	tool_paths = list(/obj/item/ms13/hammer)
 // 	reqs = list(/obj/item/stack/sheet/ms13/nugget/nugget_uranium = 4,
-// 				/obj/item/stack/sheet/ms13/plank = 2)
+// 				/obj/item/stack/sheet/ms13/wood = 2)
 // 	category = CAT_SMELTER
 // 	crafting_interface = CRAFTING_BENCH_SMELTER
 
 /datum/crafting_recipe/smelt_iron
 	name = "refined steel from ore"
-	result = /obj/item/stack/sheet/ms13/refined_steel/two
-	time = 3 SECONDS
+	result = /obj/item/stack/sheet/ms13/refined_steel
+	time = 8 SECONDS
 	tool_paths = list(/obj/item/ms13/hammer)
 	reqs = list(/obj/item/stack/sheet/ms13/nugget/nugget_iron = 4,
 				/obj/item/stack/sheet/ms13/nugget/nugget_coal = 2,
-				/obj/item/stack/sheet/ms13/plank = 1)
+				/obj/item/stack/sheet/ms13/wood = 1)
 	category = CAT_SMELTER
 	crafting_interface = CRAFTING_BENCH_SMELTER
 
 /datum/crafting_recipe/smelt_zinc
-	name = "refined steel from ore"
-	result = /obj/item/stack/sheet/ms13/refined_brass/two
-	time = 3 SECONDS
+	name = "refined brass from ore"
+	result = /obj/item/stack/sheet/ms13/refined_brass
+	time = 8 SECONDS
 	tool_paths = list(/obj/item/ms13/hammer)
 	reqs = list(/obj/item/stack/sheet/ms13/nugget/nugget_copper = 3,
 				/obj/item/stack/sheet/ms13/nugget/nugget_zinc = 2,
-				/obj/item/stack/sheet/ms13/plank = 2)
+				/obj/item/stack/sheet/ms13/wood = 2)
 	category = CAT_SMELTER
 	crafting_interface = CRAFTING_BENCH_SMELTER

--- a/mojave/modules/crafting/recipes/recipes.dm
+++ b/mojave/modules/crafting/recipes/recipes.dm
@@ -59,9 +59,9 @@
 //SMELTER CRAFTING
 
 /datum/crafting_recipe/refined_steel
-	name = "smelt refined steel ingot"
+	name = "refined steel from scrap"
 	result = /obj/item/stack/sheet/ms13/refined_steel
-	time = 10 SECONDS
+	time = 8 SECONDS
 	tool_paths = list(/obj/item/ms13/hammer)
 	reqs = list(/obj/item/stack/sheet/ms13/scrap_steel = 4,
 				/obj/item/stack/sheet/ms13/plank = 2)
@@ -69,9 +69,9 @@
 	crafting_interface = CRAFTING_BENCH_SMELTER
 
 /datum/crafting_recipe/refined_alu
-	name = "smelt refined aluminum ingot"
+	name = "refined steel from scrap"
 	result = /obj/item/stack/sheet/ms13/refined_alu
-	time = 10 SECONDS
+	time = 8 SECONDS
 	tool_paths = list(/obj/item/ms13/hammer)
 	reqs = list(/obj/item/stack/sheet/ms13/scrap_alu = 4,
 				/obj/item/stack/sheet/ms13/plank = 2)
@@ -79,9 +79,9 @@
 	crafting_interface = CRAFTING_BENCH_SMELTER
 
 /datum/crafting_recipe/refined_lead
-	name = "smelt refined lead ingot"
+	name = "refined lead from scrap"
 	result = /obj/item/stack/sheet/ms13/refined_lead
-	time = 10 SECONDS
+	time = 8 SECONDS
 	tool_paths = list(/obj/item/ms13/hammer)
 	reqs = list(/obj/item/stack/sheet/ms13/scrap_lead = 4,
 				/obj/item/stack/sheet/ms13/plank = 2)
@@ -89,9 +89,9 @@
 	crafting_interface = CRAFTING_BENCH_SMELTER
 
 /datum/crafting_recipe/refined_copper
-	name = "smelt refined copper ingot"
+	name = "refined copper from scrap"
 	result = /obj/item/stack/sheet/ms13/refined_copper
-	time = 10 SECONDS
+	time = 8 SECONDS
 	tool_paths = list(/obj/item/ms13/hammer)
 	reqs = list(/obj/item/stack/sheet/ms13/scrap_copper = 4,
 				/obj/item/stack/sheet/ms13/plank = 2)
@@ -99,9 +99,9 @@
 	crafting_interface = CRAFTING_BENCH_SMELTER
 
 /datum/crafting_recipe/refined_brass
-	name = "smelt refined brass ingot"
+	name = "refined brass from scrap"
 	result = /obj/item/stack/sheet/ms13/refined_brass
-	time = 10 SECONDS
+	time = 8 SECONDS
 	tool_paths = list(/obj/item/ms13/hammer)
 	reqs = list(/obj/item/stack/sheet/ms13/scrap_brass = 4,
 				/obj/item/stack/sheet/ms13/plank = 2)
@@ -109,9 +109,9 @@
 	crafting_interface = CRAFTING_BENCH_SMELTER
 
 /datum/crafting_recipe/refined_silver
-	name = "smelt refined silver ingot"
+	name = "refined silver from scrap"
 	result = /obj/item/stack/sheet/ms13/refined_silver
-	time = 10 SECONDS
+	time = 8 SECONDS
 	tool_paths = list(/obj/item/ms13/hammer)
 	reqs = list(/obj/item/stack/sheet/ms13/scrap_silver = 4,
 				/obj/item/stack/sheet/ms13/plank = 2)
@@ -119,9 +119,9 @@
 	crafting_interface = CRAFTING_BENCH_SMELTER
 
 /datum/crafting_recipe/refined_gold
-	name = "smelt refined gold ingot"
+	name = "refined gold from scrap"
 	result = /obj/item/stack/sheet/ms13/refined_gold
-	time = 10 SECONDS
+	time = 8 SECONDS
 	tool_paths = list(/obj/item/ms13/hammer)
 	reqs = list(/obj/item/stack/sheet/ms13/scrap_gold = 4,
 				/obj/item/stack/sheet/ms13/plank = 2)
@@ -131,7 +131,7 @@
 /datum/crafting_recipe/melt_steel_beams
 	name = "melt down refined steel"
 	result = /obj/item/stack/sheet/ms13/scrap_steel/four
-	time = 6 SECONDS
+	time = 5 SECONDS
 	tool_paths = list()
 	reqs = list(/obj/item/stack/sheet/ms13/refined_steel = 1,
 				/obj/item/stack/sheet/ms13/plank = 1)
@@ -141,7 +141,7 @@
 /datum/crafting_recipe/melt_alu
 	name = "melt down refined aluminum"
 	result = /obj/item/stack/sheet/ms13/scrap_alu/four
-	time = 6 SECONDS
+	time = 5 SECONDS
 	tool_paths = list()
 	reqs = list(/obj/item/stack/sheet/ms13/refined_alu = 1,
 				/obj/item/stack/sheet/ms13/plank = 1)
@@ -151,7 +151,7 @@
 /datum/crafting_recipe/melt_lead
 	name = "melt down refined lead"
 	result = /obj/item/stack/sheet/ms13/scrap_lead/four
-	time = 6 SECONDS
+	time = 5 SECONDS
 	tool_paths = list()
 	reqs = list(/obj/item/stack/sheet/ms13/refined_lead = 1,
 				/obj/item/stack/sheet/ms13/plank = 1)
@@ -161,7 +161,7 @@
 /datum/crafting_recipe/melt_copper
 	name = "melt down refined copper"
 	result = /obj/item/stack/sheet/ms13/scrap_copper/four
-	time = 6 SECONDS
+	time = 5 SECONDS
 	tool_paths = list()
 	reqs = list(/obj/item/stack/sheet/ms13/refined_copper = 1,
 				/obj/item/stack/sheet/ms13/plank = 1)
@@ -171,7 +171,7 @@
 /datum/crafting_recipe/melt_brass
 	name = "melt down refined brass"
 	result = /obj/item/stack/sheet/ms13/scrap_brass/four
-	time = 6 SECONDS
+	time = 5 SECONDS
 	tool_paths = list()
 	reqs = list(/obj/item/stack/sheet/ms13/refined_brass = 1,
 				/obj/item/stack/sheet/ms13/plank = 1)
@@ -181,7 +181,7 @@
 /datum/crafting_recipe/melt_silver
 	name = "melt down refined silver"
 	result = /obj/item/stack/sheet/ms13/scrap_silver/four
-	time = 6 SECONDS
+	time = 5 SECONDS
 	tool_paths = list()
 	reqs = list(/obj/item/stack/sheet/ms13/refined_silver = 1,
 				/obj/item/stack/sheet/ms13/plank = 1)
@@ -191,7 +191,7 @@
 /datum/crafting_recipe/melt_gold
 	name = "melt down refined gold"
 	result = /obj/item/stack/sheet/ms13/scrap_gold/four
-	time = 6 SECONDS
+	time = 5 SECONDS
 	tool_paths = list()
 	reqs = list(/obj/item/stack/sheet/ms13/refined_gold = 1,
 				/obj/item/stack/sheet/ms13/plank = 1)
@@ -201,7 +201,7 @@
 /datum/crafting_recipe/melt_ncr
 	name = "melt down and reforge NCR coins"
 	result = /obj/item/stack/sheet/ms13/refined_gold
-	time = 10 SECONDS
+	time = 8 SECONDS
 	tool_paths = list(/obj/item/ms13/hammer)
 	reqs = list(/obj/item/stack/ms13/currency/ncr_coin = 8,
 				/obj/item/stack/sheet/ms13/plank = 1)
@@ -211,7 +211,7 @@
 /datum/crafting_recipe/melt_denarius
 	name = "melt down and reforge Legion denarii"
 	result = /obj/item/stack/sheet/ms13/refined_silver
-	time = 10 SECONDS
+	time = 8 SECONDS
 	tool_paths = list(/obj/item/ms13/hammer)
 	reqs = list(/obj/item/stack/ms13/currency/denarius = 8,
 				/obj/item/stack/sheet/ms13/plank = 1)
@@ -221,7 +221,7 @@
 /datum/crafting_recipe/melt_aurelius
 	name = "melt down and reforge Legion aurelii"
 	result = /obj/item/stack/sheet/ms13/refined_gold
-	time = 10 SECONDS
+	time = 8 SECONDS
 	tool_paths = list(/obj/item/ms13/hammer)
 	reqs = list(/obj/item/stack/ms13/currency/aurelius = 3,
 				/obj/item/stack/sheet/ms13/plank = 1)
@@ -231,7 +231,7 @@
 /datum/crafting_recipe/melt_bottlecap
 	name = "melt down bottle caps"
 	result = /obj/item/stack/sheet/ms13/scrap_alu/five
-	time = 6 SECONDS
+	time = 5 SECONDS
 	tool_paths = list()
 	reqs = list(/obj/item/stack/ms13/currency/cap = 15,
 				/obj/item/stack/sheet/ms13/plank = 2)
@@ -249,9 +249,9 @@
 	crafting_interface = CRAFTING_BENCH_SMELTER*/
 
 /datum/crafting_recipe/smelt_copper
-	name = "refine copper ore"
+	name = "refined copper from ore"
 	result = /obj/item/stack/sheet/ms13/refined_copper/two
-	time = 3 SECONDS
+	time = 8 SECONDS
 	tool_paths = list(/obj/item/ms13/hammer)
 	reqs = list(/obj/item/stack/sheet/ms13/nugget/nugget_copper = 4,
 				/obj/item/stack/sheet/ms13/plank = 2)
@@ -259,9 +259,9 @@
 	crafting_interface = CRAFTING_BENCH_SMELTER
 
 /datum/crafting_recipe/smelt_lead
-	name = "refine lead ore"
+	name = "refined lead from ore"
 	result = /obj/item/stack/sheet/ms13/refined_lead/two
-	time = 3 SECONDS
+	time = 8 SECONDS
 	tool_paths = list(/obj/item/ms13/hammer)
 	reqs = list(/obj/item/stack/sheet/ms13/nugget/nugget_lead = 4,
 				/obj/item/stack/sheet/ms13/plank = 2)
@@ -269,9 +269,9 @@
 	crafting_interface = CRAFTING_BENCH_SMELTER
 
 /datum/crafting_recipe/smelt_alu
-	name = "refine aluminum ore"
+	name = "refined aluminum from ore"
 	result = /obj/item/stack/sheet/ms13/refined_alu/two
-	time = 3 SECONDS
+	time = 8 SECONDS
 	tool_paths = list(/obj/item/ms13/hammer)
 	reqs = list(/obj/item/stack/sheet/ms13/nugget/nugget_alu = 4,
 				/obj/item/stack/sheet/ms13/plank = 2)
@@ -279,9 +279,9 @@
 	crafting_interface = CRAFTING_BENCH_SMELTER
 
 /datum/crafting_recipe/smelt_silver
-	name = "refine silver ore"
+	name = "refined silver from ore"
 	result = /obj/item/stack/sheet/ms13/refined_silver/two
-	time = 3 SECONDS
+	time = 8 SECONDS
 	tool_paths = list(/obj/item/ms13/hammer)
 	reqs = list(/obj/item/stack/sheet/ms13/nugget/nugget_silver = 4,
 				/obj/item/stack/sheet/ms13/plank = 2)
@@ -289,9 +289,9 @@
 	crafting_interface = CRAFTING_BENCH_SMELTER
 
 /datum/crafting_recipe/smelt_gold
-	name = "refine gold ore"
+	name = "refined gold from ore"
 	result = /obj/item/stack/sheet/ms13/refined_gold/two
-	time = 3 SECONDS
+	time = 8 SECONDS
 	tool_paths = list(/obj/item/ms13/hammer)
 	reqs = list(/obj/item/stack/sheet/ms13/nugget/nugget_gold = 4,
 				/obj/item/stack/sheet/ms13/plank = 2)
@@ -309,23 +309,23 @@
 // 	crafting_interface = CRAFTING_BENCH_SMELTER
 
 /datum/crafting_recipe/smelt_iron
-	name = "smelt steel"
+	name = "refined steel from ore"
 	result = /obj/item/stack/sheet/ms13/refined_steel/two
 	time = 3 SECONDS
 	tool_paths = list(/obj/item/ms13/hammer)
 	reqs = list(/obj/item/stack/sheet/ms13/nugget/nugget_iron = 4,
-				/obj/item/stack/sheet/ms13/nugget/nugget_coal = 4,
-				/obj/item/stack/sheet/ms13/plank = 2)
+				/obj/item/stack/sheet/ms13/nugget/nugget_coal = 2,
+				/obj/item/stack/sheet/ms13/plank = 1)
 	category = CAT_SMELTER
 	crafting_interface = CRAFTING_BENCH_SMELTER
 
 /datum/crafting_recipe/smelt_zinc
-	name = "alloy brass"
+	name = "refined steel from ore"
 	result = /obj/item/stack/sheet/ms13/refined_brass/two
 	time = 3 SECONDS
 	tool_paths = list(/obj/item/ms13/hammer)
-	reqs = list(/obj/item/stack/sheet/ms13/nugget/nugget_copper = 4,
-				/obj/item/stack/sheet/ms13/nugget/nugget_zinc = 4,
+	reqs = list(/obj/item/stack/sheet/ms13/nugget/nugget_copper = 3,
+				/obj/item/stack/sheet/ms13/nugget/nugget_zinc = 2,
 				/obj/item/stack/sheet/ms13/plank = 2)
 	category = CAT_SMELTER
 	crafting_interface = CRAFTING_BENCH_SMELTER

--- a/mojave/modules/crafting/recipes/weapon_recipes.dm
+++ b/mojave/modules/crafting/recipes/weapon_recipes.dm
@@ -22,7 +22,7 @@
 	reqs = list(/obj/item/stack/sheet/ms13/cloth = 3,
 				/obj/item/stack/sheet/ms13/scrap_steel = 6,
 				/obj/item/stack/sheet/ms13/scrap = 6,
-				/obj/item/stack/sheet/ms13/plank = 2)
+				/obj/item/stack/sheet/ms13/wood/plank = 2)
 	category = CAT_WEAPONS
 	crafting_interface = CRAFTING_BENCH_WEAPONS
 
@@ -44,7 +44,7 @@
 	time = 12 SECONDS
 	tool_behaviors = list(TOOL_SAW)
 	tool_paths = list(/obj/item/ms13/hammer)
-	reqs = list(/obj/item/stack/sheet/ms13/scrap_wood = 3,
+	reqs = list(/obj/item/stack/sheet/ms13/wood/scrap_wood = 3,
 				/obj/item/stack/sheet/ms13/cloth = 3,
 				/obj/item/stack/sheet/ms13/scrap = 6,
 				/obj/item/stack/sheet/ms13/scrap_steel = 6)
@@ -131,7 +131,7 @@
 	reqs = list(/obj/item/stack/sheet/ms13/cloth = 2,
 				/obj/item/stack/sheet/ms13/scrap_steel = 5,
 				/obj/item/stack/sheet/ms13/scrap = 5,
-				/obj/item/stack/sheet/ms13/plank = 2)
+				/obj/item/stack/sheet/ms13/wood/plank = 2)
 	category = CAT_WEAPONS
 	crafting_interface = CRAFTING_BENCH_WEAPONS
 
@@ -155,7 +155,7 @@
 	tool_behaviors = list(TOOL_SAW)
 	tool_paths = list(/obj/item/ms13/hammer)
 	trait = TRAIT_LEGION_SMITHING
-	reqs = list(/obj/item/stack/sheet/ms13/scrap_wood = 2,
+	reqs = list(/obj/item/stack/sheet/ms13/wood/scrap_wood = 2,
 				/obj/item/stack/sheet/ms13/cloth = 2,
 				/obj/item/stack/sheet/ms13/scrap = 5,
 				/obj/item/stack/sheet/ms13/scrap_steel = 5)

--- a/mojave/structures/bed.dm
+++ b/mojave/structures/bed.dm
@@ -35,7 +35,7 @@
 	name = "wood bed"
 	desc = "A panel bed made from wood."
 	icon_state = "wood_bed"
-	buildstacktype = /obj/item/stack/sheet/ms13/scrap_wood
+	buildstacktype = /obj/item/stack/sheet/ms13/wood/scrap_wood
 	buildstackamount = 1
 	hitted_sound = 'mojave/sound/ms13effects/impact/wood/wood_generic_3.wav'
 

--- a/mojave/structures/chairs.dm
+++ b/mojave/structures/chairs.dm
@@ -84,7 +84,7 @@
 	desc = "An antique wooden chair with a small green cushion."
 	icon_state = "wood_chair"
 	item_chair = /obj/item/chair/ms13/wood
-	buildstacktype = /obj/item/stack/sheet/ms13/scrap_wood
+	buildstacktype = /obj/item/stack/sheet/ms13/wood/scrap_wood
 	buildstackamount = 1
 
 /obj/structure/chair/ms13/wood/padded

--- a/mojave/structures/counter.dm
+++ b/mojave/structures/counter.dm
@@ -31,8 +31,8 @@
 	desc = "Not much can be said about this decrepit wooden counter except that its definitely seen better years."
 	icon_state = "wood_counter"
 	max_integrity = 150
-	frame = /obj/item/stack/sheet/ms13/scrap_wood
-	framestack = /obj/item/stack/sheet/ms13/scrap_wood
+	frame = /obj/item/stack/sheet/ms13/wood/scrap_wood
+	framestack = /obj/item/stack/sheet/ms13/wood/scrap_wood
 	framestackamount = 2
 
 /obj/structure/table/ms13/no_smooth/counter/wood/bend

--- a/mojave/structures/decorative.dm
+++ b/mojave/structures/decorative.dm
@@ -127,9 +127,9 @@
 //Turf Decor//
 
 /obj/structure/ms13/turfdecor
-	invisibility = INVISIBILITY_MAXIMUM
+	density = FALSE
 
-/obj/structure/ms13/turfdecor/drought
+/obj/structure/ms13/turfdecor/drought //this shit looks whack af right now
 	icon = 'mojave/icons/structure/turf_decor.dmi'
 	icon_state = "drought_1"
 

--- a/mojave/structures/decorative.dm
+++ b/mojave/structures/decorative.dm
@@ -578,9 +578,9 @@
 /obj/structure/ms13/cave_decor/sign_left/deconstruct(disassembled = TRUE)
 	if(!(flags_1 & NODECONSTRUCT_1))
 		if(disassembled)
-			new /obj/item/stack/sheet/ms13/scrap_wood(loc, 2)
+			new /obj/item/stack/sheet/ms13/wood/scrap_wood(loc, 2)
 		else
-			new /obj/item/stack/sheet/ms13/scrap_wood(loc)
+			new /obj/item/stack/sheet/ms13/wood/scrap_wood(loc)
 	qdel(src)
 
 /obj/structure/ms13/cave_decor/sign_left/sign_right
@@ -601,9 +601,9 @@
 /obj/structure/ms13/cave_decor/sign_left/deconstruct(disassembled = TRUE)
 	if(!(flags_1 & NODECONSTRUCT_1))
 		if(disassembled)
-			new /obj/item/stack/sheet/ms13/plank(loc)
+			new /obj/item/stack/sheet/ms13/wood/plank(loc)
 		else
-			new /obj/item/stack/sheet/ms13/scrap_wood(loc)
+			new /obj/item/stack/sheet/ms13/wood/scrap_wood(loc)
 	qdel(src)
 
 /obj/structure/ms13/cave_decor/boards/Initialize(mapload)
@@ -664,9 +664,9 @@
 /obj/structure/ms13/cave_decor/support/deconstruct(disassembled = TRUE)
 	if(!(flags_1 & NODECONSTRUCT_1))
 		if(disassembled)
-			new /obj/item/stack/sheet/ms13/plank(loc, 4)
+			new /obj/item/stack/sheet/ms13/wood/plank(loc, 4)
 		else
-			new /obj/item/stack/sheet/ms13/scrap_wood(loc, 3)
+			new /obj/item/stack/sheet/ms13/wood/scrap_wood(loc, 3)
 	qdel(src)
 
 /obj/structure/ms13/cave_decor/support/beams

--- a/mojave/structures/doors.dm
+++ b/mojave/structures/doors.dm
@@ -259,13 +259,13 @@
 	icon_state = "wood_closed"
 	door_type = "wood"
 	frametype = "wood"
-	assemblytype = /obj/item/stack/sheet/ms13/scrap_wood
+	assemblytype = /obj/item/stack/sheet/ms13/wood/scrap_wood
 	hitted_sound = 'mojave/sound/ms13effects/wood_door_hit.ogg'
 
 /obj/machinery/door/unpowered/ms13/wood/deconstruct(disassembled = TRUE)
 	if(!(flags_1 & NODECONSTRUCT_1))
 		playsound(src, 'mojave/sound/ms13effects/wood_door_break.ogg', 100, TRUE)
-		new /obj/item/stack/sheet/ms13/scrap_wood/two(loc)
+		new /obj/item/stack/sheet/ms13/wood/scrap_wood/two(loc)
 		for(var/obj/item/I in src)
 			I.forceMove(loc)
 	qdel(src)

--- a/mojave/structures/fires.dm
+++ b/mojave/structures/fires.dm
@@ -47,7 +47,7 @@
 
 /obj/structure/bonfire/ms13/campfire/deconstruct(disassembled = TRUE)
 	if(!(flags_1 & NODECONSTRUCT_1))
-		new /obj/item/stack/sheet/ms13/scrap_wood(loc, 2)
+		new /obj/item/stack/sheet/ms13/wood/scrap_wood(loc, 2)
 	qdel(src)
 
 

--- a/mojave/structures/furniture.dm
+++ b/mojave/structures/furniture.dm
@@ -31,13 +31,13 @@
 /obj/structure/ms13/tv/deconstruct(disassembled = TRUE)
 	if(!(flags_1 & NODECONSTRUCT_1))
 		if(disassembled)
-			new /obj/item/stack/sheet/ms13/scrap_wood(loc)
+			new /obj/item/stack/sheet/ms13/wood/scrap_wood(loc)
 			new /obj/item/stack/sheet/ms13/scrap_parts(loc)
 			new /obj/item/stack/sheet/ms13/glass(loc)
 			new /obj/item/stack/sheet/ms13/scrap_electronics/two(loc)
 			new /obj/item/stack/sheet/ms13/scrap_copper/two(loc)
 		else
-			new /obj/item/stack/sheet/ms13/scrap_wood(loc)
+			new /obj/item/stack/sheet/ms13/wood/scrap_wood(loc)
 			new /obj/item/stack/sheet/ms13/glass(loc)
 			new /obj/item/stack/sheet/ms13/scrap_electronics(loc)
 			new /obj/item/stack/sheet/ms13/scrap_copper(loc)
@@ -86,7 +86,7 @@
 /obj/structure/ms13/tv/wooden/deconstruct(disassembled = TRUE)
 	if(!(flags_1 & NODECONSTRUCT_1))
 		if(disassembled)
-			new /obj/item/stack/sheet/ms13/scrap_wood(loc, 3)
+			new /obj/item/stack/sheet/ms13/wood/scrap_wood(loc, 3)
 			new /obj/item/stack/sheet/ms13/scrap_parts(loc, 2)
 			new /obj/item/stack/sheet/ms13/glass(loc, 3)
 			new /obj/item/stack/sheet/ms13/scrap_electronics(loc, 3)
@@ -265,7 +265,7 @@
 	name = "store shelf"
 	desc = "A proud american consumerism displayer, seems commercialism wasn't fully wiped out as intended."
 	icon_state = "store_shelf"
-	materialtype = /obj/item/stack/sheet/ms13/scrap_wood
+	materialtype = /obj/item/stack/sheet/ms13/wood/scrap_wood
 	hitted_sound = 'mojave/sound/ms13effects/impact/metal/metal_generic_2.wav'
 
 /obj/structure/ms13/storage/store/metal
@@ -276,7 +276,7 @@
 	name = "bookshelf"
 	desc = "Holder of knowledge, master of all."
 	icon_state = "bookshelf"
-	materialtype = /obj/item/stack/sheet/ms13/scrap_wood
+	materialtype = /obj/item/stack/sheet/ms13/wood/scrap_wood
 	hitted_sound = 'mojave/sound/ms13effects/impact/wood/wood_generic_1.wav'
 
 /obj/structure/ms13/storage/shelf
@@ -290,7 +290,7 @@
 	name = "wood shelf"
 	desc = "Used for storing just about anything you could think of."
 	icon_state = "wood_shelf"
-	materialtype = /obj/item/stack/sheet/ms13/scrap_wood
+	materialtype = /obj/item/stack/sheet/ms13/wood/scrap_wood
 
 /obj/structure/ms13/storage/shelf/wood/alt
 	icon_state = "wood_shelf-alt"
@@ -324,7 +324,7 @@
 	name = "wood shelf"
 	desc = "An extra large, wood shelf, used for storing just about anything you could think of while upkeeping your rustic tones."
 	icon_state = "wood_shelf"
-	materialtype = /obj/item/stack/sheet/ms13/scrap_wood
+	materialtype = /obj/item/stack/sheet/ms13/wood/scrap_wood
 
 /obj/structure/ms13/storage/large/shelf/wood/alt
 	icon_state = "wood_shelf-alt"
@@ -333,13 +333,13 @@
 	name = "wood shelf"
 	desc = "A large wooden shelf set. There are drawers below for additional storage."
 	icon_state = "wood_shelf_big"
-	materialtype = /obj/item/stack/sheet/ms13/scrap_wood
+	materialtype = /obj/item/stack/sheet/ms13/wood/scrap_wood
 
 /obj/structure/ms13/storage/large/clothing
 	name = "clothing rack"
 	desc = "And they say fashion is dead."
 	icon_state = "clothing_rack"
-	materialtype = /obj/item/stack/sheet/ms13/scrap_wood
+	materialtype = /obj/item/stack/sheet/ms13/wood/scrap_wood
 	max_integrity = 250
 
 /obj/structure/ms13/storage/large/medical
@@ -358,7 +358,7 @@
 	name = "showcase shelf"
 	desc = "A pyramid of shelving units, ready to display wares to the eager world."
 	icon_state = "showcase"
-	materialtype = /obj/item/stack/sheet/ms13/scrap_wood
+	materialtype = /obj/item/stack/sheet/ms13/wood/scrap_wood
 
 // Dresser Stuff //
 
@@ -589,7 +589,7 @@
 		user.show_message(span_notice("You begin chopping \the [src] into scraps of wood!"), MSG_VISUAL)
 		if(do_after(user, 10 SECONDS * W.toolspeed, target = src, interaction_key = DOAFTER_SOURCE_MAKEPLANKS))
 			user.show_message(span_notice("You make wood scraps out of \the [src]!"), MSG_VISUAL)
-			new /obj/item/stack/sheet/ms13/scrap_wood(loc, 4)
+			new /obj/item/stack/sheet/ms13/wood/scrap_wood(loc, 4)
 			qdel(src)
 
 /obj/structure/ms13/fruit_empty/examine(mob/user)

--- a/mojave/structures/obstacles.dm
+++ b/mojave/structures/obstacles.dm
@@ -858,10 +858,10 @@
 /obj/structure/railing/ms13/wood/deconstruct(disassembled = TRUE)
 	if(!(flags_1 & NODECONSTRUCT_1))
 		if(disassembled)
-			new /obj/item/stack/sheet/ms13/plank(loc, 3)
+			new /obj/item/stack/sheet/ms13/wood/plank(loc, 3)
 			new /obj/item/stack/sheet/ms13/scrap_parts(loc, 2)
 		else
-			new /obj/item/stack/sheet/ms13/scrap_wood(loc, 2)
+			new /obj/item/stack/sheet/ms13/wood/scrap_wood(loc, 2)
 	qdel(src)
 
 /obj/structure/railing/ms13/wood/examine(mob/user)
@@ -929,10 +929,10 @@
 /obj/structure/ms13/barricade/deconstruct(disassembled = TRUE)
 	if(!(flags_1 & NODECONSTRUCT_1))
 		if(disassembled)
-			new /obj/item/stack/sheet/ms13/plank(loc, 2)
+			new /obj/item/stack/sheet/ms13/wood/plank(loc, 2)
 			new /obj/item/stack/sheet/ms13/scrap_parts(loc)
 		else
-			new /obj/item/stack/sheet/ms13/scrap_wood(loc)
+			new /obj/item/stack/sheet/ms13/wood/scrap_wood(loc)
 	qdel(src)
 
 /obj/structure/ms13/barricade/examine(mob/user)

--- a/mojave/structures/ores.dm
+++ b/mojave/structures/ores.dm
@@ -3,7 +3,6 @@
 	desc = "Full of valuable errors to sell to coders!"
 	icon = 'mojave/icons/structure/deposits.dmi'
 	icon_state = ""
-	max_integrity = 400
 	density = FALSE
 	anchored = TRUE
 	resistance_flags = UNACIDABLE | FIRE_PROOF | LAVA_PROOF
@@ -38,6 +37,7 @@
 /obj/structure/ms13/ore_deposit/Initialize()
 	. = ..()
 	max_integrity = rand(380, 525)
+	atom_integrity = max_integrity
 
 /obj/structure/ms13/ore_deposit/copper
 	name = "copper ore deposit"

--- a/mojave/structures/ores.dm
+++ b/mojave/structures/ores.dm
@@ -7,7 +7,7 @@
 	density = FALSE
 	anchored = TRUE
 	resistance_flags = UNACIDABLE | FIRE_PROOF | LAVA_PROOF
-	armor = list(MELEE = 45, BULLET = 90, LASER = 90, ENERGY = 90, BOMB = 0, BIO = 100, FIRE = 100, ACID = 100)
+	armor = list(MELEE = 20, BULLET = 90, LASER = 90, ENERGY = 90, BOMB = 0, BIO = 100, FIRE = 100, ACID = 100)
 	hitted_sound = 'sound/effects/break_stone.ogg'
 	var/deposit_type = null
 	var/last_act = 0
@@ -16,7 +16,7 @@
 //Ore deposit mining process
 
 /obj/structure/ms13/ore_deposit/attackby(obj/item/W, mob/user)
-	src.mining_bonus_damage = W.force * W.mining_mult 
+	src.mining_bonus_damage = W.force * W.mining_mult
 	W.force += mining_bonus_damage
 	. = ..()
 	W.force -= mining_bonus_damage
@@ -28,7 +28,7 @@
 /obj/structure/ms13/ore_deposit/deconstruct(disassembled = TRUE)
 	if(!(flags_1 & NODECONSTRUCT_1))
 		if(!disassembled)
-			new deposit_type(src.loc, rand(2,6))
+			new deposit_type(src.loc, rand(2,5))
 	qdel(src)
 
 //deposits
@@ -37,7 +37,7 @@
 
 /obj/structure/ms13/ore_deposit/Initialize()
 	. = ..()
-	max_integrity = rand(340, 490)
+	max_integrity = rand(380, 525)
 
 /obj/structure/ms13/ore_deposit/copper
 	name = "copper ore deposit"
@@ -219,9 +219,8 @@
 //Deposit generation
 
 //currently not spawning in uranium deposits as there is no use for them
-#define DEPOSIT_SPAWN_LIST list(/obj/structure/ms13/ore_deposit/gold = 1, /obj/structure/ms13/ore_deposit/silver = 2, /obj/structure/ms13/ore_deposit/alu = 6, /obj/structure/ms13/ore_deposit/lead = 6, /obj/structure/ms13/ore_deposit/copper = 5, /obj/structure/ms13/ore_deposit/coal = 5, /obj/structure/ms13/ore_deposit/iron = 3)
-#define DEPOSIT_SPONTANEOUS 		4
-#define DEPOSIT_WEIGHT			2
+#define DEPOSIT_SPAWN_LIST list(/obj/structure/ms13/ore_deposit/gold = 1, /obj/structure/ms13/ore_deposit/silver = 3, /obj/structure/ms13/ore_deposit/alu = 4, /obj/structure/ms13/ore_deposit/lead = 5, /obj/structure/ms13/ore_deposit/copper = 5, /obj/structure/ms13/ore_deposit/coal = 4, /obj/structure/ms13/ore_deposit/iron = 4, /obj/structure/ms13/ore_deposit/zinc = 4) //The total sum of this right now is 30, so finding prob is X/30. If you change these numbers please update this comment.
+#define DEPOSIT_SPAWN_CHANCE	2.5
 
 /turf/open/floor/plating/ms13/ground/mountain/Initialize()
 	. = ..()
@@ -229,7 +228,7 @@
 	//spontaneously spawn deposits
 	if( (locate(/obj/machinery) in src) || (locate(/obj/structure) in src) ) //can't put ores on a tile that has already has stuff
 		return
-	if(prob(DEPOSIT_SPONTANEOUS))
+	if(prob(DEPOSIT_SPAWN_CHANCE))
 		randDeposit = pick_weight(DEPOSIT_SPAWN_LIST) //Create a new deposit object at this location, and assign var
 		new randDeposit(src)
 		. = TRUE //in case we ever need this to return if we spawned
@@ -240,7 +239,7 @@
 	var/randDeposit = null
 	if( (locate(/obj/machinery) in src) || (locate(/obj/structure) in src) )
 		return
-	if(prob(DEPOSIT_SPONTANEOUS))
+	if(prob(DEPOSIT_SPAWN_CHANCE))
 		randDeposit = pick_weight(DEPOSIT_SPAWN_LIST)
 		new randDeposit(src)
 		. = TRUE

--- a/mojave/structures/storage/crates.dm
+++ b/mojave/structures/storage/crates.dm
@@ -18,7 +18,7 @@
 	icon_state = "wood_crate"
 	density = TRUE
 	anchored = TRUE
-	material_drop = /obj/item/stack/sheet/ms13/scrap_wood
+	material_drop = /obj/item/stack/sheet/ms13/wood/scrap_wood
 	material_drop_amount = 2
 	delivery_icon = "deliverybox"
 	integrity_failure = 0 //Makes the crate break when integrity reaches 0, instead of opening and becoming an invisible sprite.
@@ -76,10 +76,10 @@
 /obj/structure/closet/crate/ms13/woodcrate/deconstruct(disassembled = TRUE)
 	if(!(flags_1 & NODECONSTRUCT_1))
 		if(disassembled)
-			new /obj/item/stack/sheet/ms13/plank(loc, 2)
+			new /obj/item/stack/sheet/ms13/wood/plank(loc, 2)
 			new /obj/item/stack/sheet/ms13/scrap_parts(loc, 2)
 		else
-			new /obj/item/stack/sheet/ms13/scrap_wood(loc)
+			new /obj/item/stack/sheet/ms13/wood/scrap_wood(loc)
 			new /obj/item/stack/sheet/ms13/scrap_parts(loc)
 	var/turf/T = get_turf(src)
 	for(var/atom/movable/AM in contents)
@@ -165,7 +165,7 @@
 	name = "wooden footlocker"
 	desc = "The best way to store various supplies."
 	icon_state = "footlocker_wood"
-	material_drop = /obj/item/stack/sheet/ms13/scrap_wood
+	material_drop = /obj/item/stack/sheet/ms13/wood/scrap_wood
 	material_drop_amount = 2
 	projectile_passchance = 90
 	hitted_sound = 'mojave/sound/ms13effects/impact/wood/wood_generic_1.wav'

--- a/mojave/structures/table.dm
+++ b/mojave/structures/table.dm
@@ -57,8 +57,8 @@
 	max_integrity = 150
 	smoothing_groups = list(SMOOTH_GROUP_MS13_TABLE_WOOD)
 	canSmoothWith = list(SMOOTH_GROUP_MS13_TABLE_WOOD)
-	frame = /obj/item/stack/sheet/ms13/scrap_wood
-	framestack = /obj/item/stack/sheet/ms13/scrap_wood
+	frame = /obj/item/stack/sheet/ms13/wood/scrap_wood
+	framestack = /obj/item/stack/sheet/ms13/wood/scrap_wood
 	framestackamount = 2
 
 /obj/structure/table/ms13/wood/bar
@@ -84,7 +84,7 @@
 	desc = "Four wooden legs with four framing wooden rods for a wooden table. You could easily pass through this."
 	icon_state = "tableframe_wood"
 	resistance_flags = FLAMMABLE
-	framestack = /obj/item/stack/sheet/ms13/scrap_wood
+	framestack = /obj/item/stack/sheet/ms13/wood/scrap_wood
 	framestackamount = 2
 
 // Player-Made tables //
@@ -184,7 +184,7 @@
 	desc = "A simple round wooden table. You wish you could make something this nice."
 	icon_state = "table_wood_round"
 	max_integrity = 150
-	frame = /obj/item/stack/sheet/ms13/scrap_wood
+	frame = /obj/item/stack/sheet/ms13/wood/scrap_wood
 
 /obj/structure/table/ms13/no_smooth/wood/square
 	name = "wood table"
@@ -213,7 +213,7 @@
 	desc = "A large oval shaped wood table. Perfect for displaying the 200 year old family photos you found."
 	icon_state = "table_wood_wide_oval"
 	max_integrity = 200
-	frame = /obj/item/stack/sheet/ms13/scrap_wood/two
+	frame = /obj/item/stack/sheet/ms13/wood/scrap_wood/two
 
 /obj/structure/table/ms13/no_smooth/large/wood/square
 	desc = "A large rectangular wood table. Very sturdy."
@@ -244,7 +244,7 @@
 	desc = "Shoot the dice with your friends. Preferably not literally."
 	icon_state = "dice_dirty"
 	max_integrity = 150
-	frame = /obj/item/stack/sheet/ms13/scrap_wood
+	frame = /obj/item/stack/sheet/ms13/wood/scrap_wood
 
 /obj/structure/table/ms13/no_smooth/dice/pristine
 	icon_state = "dice_clean"
@@ -254,7 +254,7 @@
 	name = "cable reel"
 	desc = "An old cable reel for holding, you guessed it, cable. Now all it's good for though is holding your stuff."
 	icon_state = "cable_reel"
-	frame = /obj/item/stack/sheet/ms13/scrap_wood
+	frame = /obj/item/stack/sheet/ms13/wood/scrap_wood
 
 // Misc Large tables //
 
@@ -263,7 +263,7 @@
 	desc = "A favourite of students and drunkards alike. Watch out for sharks!"
 	icon_state = "table_pool"
 	max_integrity = 200
-	frame = /obj/item/stack/sheet/ms13/scrap_wood/two
+	frame = /obj/item/stack/sheet/ms13/wood/scrap_wood/two
 
 /obj/structure/table/ms13/no_smooth/large/cards
 	name = "cards table"

--- a/mojave/turfs/plating.dm
+++ b/mojave/turfs/plating.dm
@@ -1,13 +1,13 @@
 #define WALL_SMOOTHING SMOOTH_GROUP_MS13_SIDEWALK, SMOOTH_GROUP_MS13_WALL, SMOOTH_GROUP_MS13_WALL_METAL, SMOOTH_GROUP_MS13_WALL_WOOD, SMOOTH_GROUP_MS13_WALL_SCRAP, SMOOTH_GROUP_MS13_LOW_WALL,SMOOTH_GROUP_MS13_WALL_ADOBE, SMOOTH_GROUP_MS13_WALL_BRICK, SMOOTH_GROUP_MS13_WALL_REINFORCED, SMOOTH_GROUP_MS13_WINDOW, SMOOTH_GROUP_MS13_MINERALS
 #define DESERT_SMOOTHING SMOOTH_GROUP_MS13_DESERT, SMOOTH_GROUP_MS13_SIDEWALK, SMOOTH_GROUP_MS13_TILE, SMOOTH_GROUP_MS13_SNOW, SMOOTH_GROUP_MS13_ROAD, SMOOTH_GROUP_MS13_WATER
 #define GRASS_SPONTANEOUS 		2.5
-#define GRASS_WEIGHT 			2.5
+#define GRASS_WEIGHT 			2.4
 #define SHROOM_WEIGHT			5
 #define LUSH_PLANT_SPAWN_LIST list(/obj/structure/flora/ms13/tree/tallpine/snow = 7, /obj/structure/flora/ms13/forage/xander = 1, /obj/structure/flora/ms13/forage/brocflower = 1, /obj/structure/flora/ms13/forage/tarberry = 1, /obj/structure/flora/ms13/forage/blackberry = 1, /obj/structure/flora/ms13/forage/mutfruit = 1, /obj/structure/flora/ms13/forage/ashrose = 1, /obj/structure/flora/ms13/forage/wildcarrot = 1, /obj/structure/flora/ms13/forage/aster = 1)
 #define DESOLATE_PLANT_SPAWN_LIST list(/obj/structure/flora/grass/wasteland/snow = 10)
 #define MUSHROOM_SPAWN_LIST list(/obj/structure/flora/ms13/forage/mushroom = 5, /obj/structure/flora/ms13/forage/mushroom/glowing = 5, /obj/structure/flora/ms13/forage/brainshroom = 1, /obj/structure/flora/ms13/forage/fireshroom = 1,/obj/structure/flora/ms13/forage/gutshroom = 1, /obj/structure/flora/ms13/forage/lure = 1, /obj/structure/flora/ms13/forage/nara= 1)
-#define DESERT_LUSH_PLANT_SPAWN_LIST list(/obj/structure/flora/ms13/tree/drought/dead = 2, /obj/structure/flora/ms13/cactus = 2, /obj/structure/flora/ms13/cactus/tall = 2, /obj/structure/flora/ms13/leafy = 1.5, /obj/structure/ms13/turfdecor/drought = 4, /obj/structure/flora/ms13/forage/xander/drought = 1.5, /obj/structure/flora/ms13/forage/brocflower/drought = 1.5, /obj/structure/flora/ms13/forage/ashrose/drought = 1.5, /obj/structure/flora/ms13/forage/aster/drought = 1.5, /obj/structure/flora/ms13/forage/yucca = 1.5, /obj/structure/flora/ms13/forage/barrel_cactus = 2)
-#define DESERT_DESOLATE_PLANT_SPAWN_LIST list(/obj/structure/flora/grass/wasteland = 6, /obj/structure/flora/ms13/leafy = 1, /obj/structure/flora/ms13/cactus = 1)
+#define DESERT_LUSH_PLANT_SPAWN_LIST list(/obj/structure/flora/grass/wasteland = 2.5, /obj/structure/flora/ms13/tree/drought/dead = 2, /obj/structure/flora/ms13/cactus = 2.5, /obj/structure/flora/ms13/cactus/tall = 2.5, /obj/structure/flora/ms13/leafy = 2, /obj/structure/flora/ms13/forage/xander/drought = 1.5, /obj/structure/flora/ms13/forage/brocflower/drought = 1.5, /obj/structure/flora/ms13/forage/ashrose/drought = 1, /obj/structure/flora/ms13/forage/aster/drought = 1, /obj/structure/flora/ms13/forage/yucca = 1.5, /obj/structure/flora/ms13/forage/barrel_cactus = 2)
+#define DESERT_DESOLATE_PLANT_SPAWN_LIST list(/obj/structure/flora/grass/wasteland = 6, /obj/structure/flora/ms13/leafy = 1, /obj/structure/flora/ms13/cactus = 1, /obj/structure/flora/ms13/cactus/tall = 1)
 
 #define TURF_LAYER_SNOW 2.003
 #define TURF_LAYER_SNOW_BORDER 2.2

--- a/mojave/turfs/plating.dm
+++ b/mojave/turfs/plating.dm
@@ -1,12 +1,12 @@
 #define WALL_SMOOTHING SMOOTH_GROUP_MS13_SIDEWALK, SMOOTH_GROUP_MS13_WALL, SMOOTH_GROUP_MS13_WALL_METAL, SMOOTH_GROUP_MS13_WALL_WOOD, SMOOTH_GROUP_MS13_WALL_SCRAP, SMOOTH_GROUP_MS13_LOW_WALL,SMOOTH_GROUP_MS13_WALL_ADOBE, SMOOTH_GROUP_MS13_WALL_BRICK, SMOOTH_GROUP_MS13_WALL_REINFORCED, SMOOTH_GROUP_MS13_WINDOW, SMOOTH_GROUP_MS13_MINERALS
 #define DESERT_SMOOTHING SMOOTH_GROUP_MS13_DESERT, SMOOTH_GROUP_MS13_SIDEWALK, SMOOTH_GROUP_MS13_TILE, SMOOTH_GROUP_MS13_SNOW, SMOOTH_GROUP_MS13_ROAD, SMOOTH_GROUP_MS13_WATER
 #define GRASS_SPONTANEOUS 		2.5
-#define GRASS_WEIGHT 			2.75
+#define GRASS_WEIGHT 			2.5
 #define SHROOM_WEIGHT			5
 #define LUSH_PLANT_SPAWN_LIST list(/obj/structure/flora/ms13/tree/tallpine/snow = 7, /obj/structure/flora/ms13/forage/xander = 1, /obj/structure/flora/ms13/forage/brocflower = 1, /obj/structure/flora/ms13/forage/tarberry = 1, /obj/structure/flora/ms13/forage/blackberry = 1, /obj/structure/flora/ms13/forage/mutfruit = 1, /obj/structure/flora/ms13/forage/ashrose = 1, /obj/structure/flora/ms13/forage/wildcarrot = 1, /obj/structure/flora/ms13/forage/aster = 1)
 #define DESOLATE_PLANT_SPAWN_LIST list(/obj/structure/flora/grass/wasteland/snow = 10)
 #define MUSHROOM_SPAWN_LIST list(/obj/structure/flora/ms13/forage/mushroom = 5, /obj/structure/flora/ms13/forage/mushroom/glowing = 5, /obj/structure/flora/ms13/forage/brainshroom = 1, /obj/structure/flora/ms13/forage/fireshroom = 1,/obj/structure/flora/ms13/forage/gutshroom = 1, /obj/structure/flora/ms13/forage/lure = 1, /obj/structure/flora/ms13/forage/nara= 1)
-#define DESERT_LUSH_PLANT_SPAWN_LIST list(/obj/structure/flora/ms13/tree/drought/dead = 2, /obj/structure/flora/ms13/cactus = 2, /obj/structure/flora/ms13/cactus/tall = 2, /obj/structure/flora/ms13/leafy = 1.5, /obj/structure/ms13/turfdecor/drought = 8, /obj/structure/flora/ms13/forage/xander/drought = 1.5, /obj/structure/flora/ms13/forage/brocflower/drought = 1.5, /obj/structure/flora/ms13/forage/ashrose/drought = 1.5, /obj/structure/flora/ms13/forage/aster/drought = 1.5, /obj/structure/flora/ms13/forage/yucca = 1.5, /obj/structure/flora/ms13/forage/barrel_cactus = 2)
+#define DESERT_LUSH_PLANT_SPAWN_LIST list(/obj/structure/flora/ms13/tree/drought/dead = 2, /obj/structure/flora/ms13/cactus = 2, /obj/structure/flora/ms13/cactus/tall = 2, /obj/structure/flora/ms13/leafy = 1.5, /obj/structure/ms13/turfdecor/drought = 4, /obj/structure/flora/ms13/forage/xander/drought = 1.5, /obj/structure/flora/ms13/forage/brocflower/drought = 1.5, /obj/structure/flora/ms13/forage/ashrose/drought = 1.5, /obj/structure/flora/ms13/forage/aster/drought = 1.5, /obj/structure/flora/ms13/forage/yucca = 1.5, /obj/structure/flora/ms13/forage/barrel_cactus = 2)
 #define DESERT_DESOLATE_PLANT_SPAWN_LIST list(/obj/structure/flora/grass/wasteland = 6, /obj/structure/flora/ms13/leafy = 1, /obj/structure/flora/ms13/cactus = 1)
 
 #define TURF_LAYER_SNOW 2.003

--- a/mojave/turfs/plating.dm
+++ b/mojave/turfs/plating.dm
@@ -1,13 +1,13 @@
 #define WALL_SMOOTHING SMOOTH_GROUP_MS13_SIDEWALK, SMOOTH_GROUP_MS13_WALL, SMOOTH_GROUP_MS13_WALL_METAL, SMOOTH_GROUP_MS13_WALL_WOOD, SMOOTH_GROUP_MS13_WALL_SCRAP, SMOOTH_GROUP_MS13_LOW_WALL,SMOOTH_GROUP_MS13_WALL_ADOBE, SMOOTH_GROUP_MS13_WALL_BRICK, SMOOTH_GROUP_MS13_WALL_REINFORCED, SMOOTH_GROUP_MS13_WINDOW, SMOOTH_GROUP_MS13_MINERALS
 #define DESERT_SMOOTHING SMOOTH_GROUP_MS13_DESERT, SMOOTH_GROUP_MS13_SIDEWALK, SMOOTH_GROUP_MS13_TILE, SMOOTH_GROUP_MS13_SNOW, SMOOTH_GROUP_MS13_ROAD, SMOOTH_GROUP_MS13_WATER
-#define GRASS_SPONTANEOUS 		2
-#define GRASS_WEIGHT 			2
+#define GRASS_SPONTANEOUS 		2.5
+#define GRASS_WEIGHT 			2.75
 #define SHROOM_WEIGHT			5
 #define LUSH_PLANT_SPAWN_LIST list(/obj/structure/flora/ms13/tree/tallpine/snow = 7, /obj/structure/flora/ms13/forage/xander = 1, /obj/structure/flora/ms13/forage/brocflower = 1, /obj/structure/flora/ms13/forage/tarberry = 1, /obj/structure/flora/ms13/forage/blackberry = 1, /obj/structure/flora/ms13/forage/mutfruit = 1, /obj/structure/flora/ms13/forage/ashrose = 1, /obj/structure/flora/ms13/forage/wildcarrot = 1, /obj/structure/flora/ms13/forage/aster = 1)
 #define DESOLATE_PLANT_SPAWN_LIST list(/obj/structure/flora/grass/wasteland/snow = 10)
 #define MUSHROOM_SPAWN_LIST list(/obj/structure/flora/ms13/forage/mushroom = 5, /obj/structure/flora/ms13/forage/mushroom/glowing = 5, /obj/structure/flora/ms13/forage/brainshroom = 1, /obj/structure/flora/ms13/forage/fireshroom = 1,/obj/structure/flora/ms13/forage/gutshroom = 1, /obj/structure/flora/ms13/forage/lure = 1, /obj/structure/flora/ms13/forage/nara= 1)
-#define DESERT_LUSH_PLANT_SPAWN_LIST list(/obj/structure/flora/ms13/tree/drought/dead = 2, /obj/structure/flora/ms13/cactus = 2.5, /obj/structure/flora/ms13/cactus/tall = 2.5, /obj/structure/flora/ms13/leafy = 1, /obj/structure/ms13/turfdecor/drought = 10, /obj/structure/flora/ms13/forage/xander/drought = 1, /obj/structure/flora/ms13/forage/brocflower/drought = 1, /obj/structure/flora/ms13/forage/ashrose/drought = 1, /obj/structure/flora/ms13/forage/aster/drought = 1, /obj/structure/flora/ms13/forage/yucca = 1, /obj/structure/flora/ms13/forage/barrel_cactus = 1)
-#define DESERT_DESOLATE_PLANT_SPAWN_LIST list(/obj/structure/flora/grass/wasteland = 8, /obj/structure/flora/ms13/leafy = 1)
+#define DESERT_LUSH_PLANT_SPAWN_LIST list(/obj/structure/flora/ms13/tree/drought/dead = 2, /obj/structure/flora/ms13/cactus = 2, /obj/structure/flora/ms13/cactus/tall = 2, /obj/structure/flora/ms13/leafy = 1.5, /obj/structure/ms13/turfdecor/drought = 8, /obj/structure/flora/ms13/forage/xander/drought = 1.5, /obj/structure/flora/ms13/forage/brocflower/drought = 1.5, /obj/structure/flora/ms13/forage/ashrose/drought = 1.5, /obj/structure/flora/ms13/forage/aster/drought = 1.5, /obj/structure/flora/ms13/forage/yucca = 1.5, /obj/structure/flora/ms13/forage/barrel_cactus = 2)
+#define DESERT_DESOLATE_PLANT_SPAWN_LIST list(/obj/structure/flora/grass/wasteland = 6, /obj/structure/flora/ms13/leafy = 1, /obj/structure/flora/ms13/cactus = 1)
 
 #define TURF_LAYER_SNOW 2.003
 #define TURF_LAYER_SNOW_BORDER 2.2

--- a/mojave/turfs/wall.dm
+++ b/mojave/turfs/wall.dm
@@ -375,7 +375,7 @@
 	icon = 'mojave/icons/turf/walls/woodfresh.dmi'
 	frill_icon = 'mojave/icons/turf/walls/woodfresh_frill.dmi'
 	girder_type = null
-	sheet_type = /obj/item/stack/sheet/ms13/log
+	sheet_type = /obj/item/stack/sheet/ms13/wood/log
 	sheet_amount = 2
 	slicing_duration = 30 SECONDS
 


### PR DESCRIPTION
## About The Pull Request

Tweaks mining spawn rates to be a little more reasonable and also more LORE ACCURATE to the common mineral make up of Arizona. Copper and lead are the most common, followed by zinc, iron, coal, and aluminum, followed closely by silver, and gold is very rare. 

Also changes smelting to accept any kind of wood and in doing so I had to repath all of the wood. Otherwise this PR is just small tweaks like adding the pickaxe to tool and melee spawners since it has a use besides caving people's heads in now and rebalancing some of the smelter recipes for making refined ingots from ore. 

Also adjusts plant spawn rates to make them a decent bit more common and also make the plant variety make a little more sense. 

## Why It's Good For The Game

I love tweaking