### PR TITLE
Kills off the fluff usage for MS13 subtypes

### DIFF
--- a/_maps/map_files/CombatArena/CombatArena_Desert.dmm
+++ b/_maps/map_files/CombatArena/CombatArena_Desert.dmm
@@ -84,7 +84,7 @@
 /turf/open/floor/ms13/concrete,
 /area/ms13/factory)
 "bA" = (
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 10
 	},
 /turf/open/floor/wood/ms13/common,
@@ -265,7 +265,7 @@
 /turf/open/floor/wood/ms13/common,
 /area/ms13/town)
 "eZ" = (
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 1
 	},
 /turf/open/floor/ms13/concrete,
@@ -296,7 +296,7 @@
 /turf/open/floor/wood/ms13/carpet/shaggy/blue,
 /area/ms13/town)
 "fB" = (
-/obj/structure/fluff/ms13/trash/papers,
+/obj/structure/ms13/trash/papers,
 /turf/open/floor/ms13/concrete,
 /area/ms13/rangeroutpost/building)
 "fC" = (
@@ -319,7 +319,7 @@
 /turf/open/floor/wood/ms13/common,
 /area/ms13/town)
 "fV" = (
-/obj/structure/fluff/ms13/barrel/single/red,
+/obj/structure/ms13/barrel/single/red,
 /turf/open/floor/plating/ms13/ground/desert,
 /area/ms13/desert)
 "fY" = (
@@ -1099,7 +1099,7 @@
 /turf/open/floor/plating/ms13/ground/sidewalk,
 /area/ms13/desert)
 "sz" = (
-/obj/structure/fluff/ms13/barrel/single/grey/one,
+/obj/structure/ms13/barrel/single/grey/one,
 /turf/open/floor/ms13/concrete,
 /area/ms13/factory)
 "sO" = (
@@ -1336,7 +1336,7 @@
 /turf/open/floor/ms13/concrete,
 /area/ms13/rangeroutpost/building)
 "wF" = (
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 4
 	},
 /turf/open/floor/plating/ms13/ground/desert,
@@ -1540,7 +1540,7 @@
 /turf/open/floor/plating/ms13/ground/desert,
 /area/ms13/legioncamp)
 "Al" = (
-/obj/structure/fluff/ms13/barrel/single/grey/two,
+/obj/structure/ms13/barrel/single/grey/two,
 /turf/open/floor/ms13/concrete,
 /area/ms13/factory)
 "Am" = (
@@ -1619,7 +1619,7 @@
 /turf/open/floor/wood/ms13/common,
 /area/ms13/legioncamp/building)
 "BC" = (
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 10
 	},
 /turf/open/floor/plating/ms13/ground/road,
@@ -2565,7 +2565,7 @@
 /turf/open/floor/plating/ms13/roof/metal/rusty,
 /area/ms13/factory)
 "Qc" = (
-/obj/structure/fluff/ms13/barrel/single/hazard/three,
+/obj/structure/ms13/barrel/single/hazard/three,
 /turf/open/floor/ms13/concrete,
 /area/ms13/factory)
 "Qd" = (
@@ -2649,7 +2649,7 @@
 /turf/open/floor/wood/ms13/common,
 /area/ms13/legioncamp/building)
 "RA" = (
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 9
 	},
 /obj/structure/filingcabinet/ms13{
@@ -2733,7 +2733,7 @@
 /turf/open/openspace/ms13,
 /area/ms13/factory)
 "Ti" = (
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 4
 	},
 /obj/machinery/light/ms13/bulb{
@@ -2908,7 +2908,7 @@
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/legioncamp/building)
 "Vc" = (
-/obj/structure/fluff/ms13/trash/papers,
+/obj/structure/ms13/trash/papers,
 /turf/open/floor/plating/ms13/ground/desert,
 /area/ms13/desert)
 "Vm" = (
@@ -2994,7 +2994,7 @@
 /turf/open/floor/ms13/concrete,
 /area/ms13/rangeroutpost/building)
 "Wx" = (
-/obj/structure/fluff/ms13/barrel/single/warning/one,
+/obj/structure/ms13/barrel/single/warning/one,
 /turf/open/floor/ms13/concrete,
 /area/ms13/factory)
 "WA" = (
@@ -3032,7 +3032,7 @@
 /turf/open/floor/wood/ms13/common,
 /area/ms13/legioncamp/building)
 "WQ" = (
-/obj/structure/fluff/ms13/barrel/single/hazard/one,
+/obj/structure/ms13/barrel/single/hazard/one,
 /turf/open/floor/ms13/concrete,
 /area/ms13/factory)
 "WU" = (
@@ -3146,7 +3146,7 @@
 /turf/open/floor/ms13/concrete,
 /area/ms13/rangeroutpost/building)
 "Yn" = (
-/obj/structure/fluff/ms13/barrel/single/red/three,
+/obj/structure/ms13/barrel/single/red/three,
 /turf/open/floor/plating/ms13/ground/desert,
 /area/ms13/desert)
 "Yr" = (

--- a/_maps/map_files/Drought/Drought.dmm
+++ b/_maps/map_files/Drought/Drought.dmm
@@ -16,7 +16,7 @@
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "aar" = (
-/obj/structure/fluff/ms13/barrel/double/yellow/one,
+/obj/structure/ms13/barrel/double/yellow/one,
 /turf/open/floor/plating/ms13/ground/desert,
 /area/ms13/desert)
 "aaI" = (
@@ -33,7 +33,7 @@
 /turf/open/floor/ms13/concrete/small,
 /area/ms13/water_baron/interior)
 "acj" = (
-/obj/structure/fluff/ms13/barrel/single/hazard,
+/obj/structure/ms13/barrel/single/hazard,
 /obj/structure/ms13/pipes/horizontal/random_alt,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
@@ -197,7 +197,7 @@
 /turf/open/floor/plating/ms13/ground/desertalt,
 /area/ms13/desert)
 "akQ" = (
-/obj/structure/fluff/ms13/barrel/double/yellow/one,
+/obj/structure/ms13/barrel/double/yellow/one,
 /turf/open/floor/plating/ms13/ground/desertalt,
 /area/ms13/desert)
 "akS" = (
@@ -319,7 +319,7 @@
 /turf/open/floor/ms13/metal/grate,
 /area/ms13/desert)
 "arp" = (
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 6
 	},
 /obj/structure/noticeboard/ms13/cork,
@@ -487,7 +487,7 @@
 /turf/open/floor/ms13/tile/large/cream,
 /area/ms13/factory)
 "aFx" = (
-/obj/structure/fluff/ms13/barrel/single/red/three,
+/obj/structure/ms13/barrel/single/red/three,
 /turf/open/floor/plating/ms13/ground/desertalt,
 /area/ms13/desert)
 "aFF" = (
@@ -609,11 +609,11 @@
 /turf/open/floor/ms13/tile/large/cream,
 /area/ms13/town)
 "aLP" = (
-/obj/structure/fluff/ms13/barrel/single/red/one,
+/obj/structure/ms13/barrel/single/red/one,
 /turf/open/floor/plating/ms13/ground/desert,
 /area/ms13/desert)
 "aMe" = (
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 8
 	},
 /turf/open/floor/wood/ms13/wide,
@@ -709,7 +709,7 @@
 /turf/open/floor/ms13/tile/large/white,
 /area/ms13/town)
 "aQh" = (
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 1;
 	pixel_x = 4;
 	pixel_y = 4
@@ -852,7 +852,7 @@
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "aXG" = (
-/obj/structure/fluff/ms13/barrel/quadruple/red,
+/obj/structure/ms13/barrel/quadruple/red,
 /turf/open/floor/plating/ms13/ground/desert,
 /area/ms13/water_baron)
 "aXT" = (
@@ -1207,11 +1207,11 @@
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "bwL" = (
-/obj/structure/fluff/ms13/barrel/single/flammable,
+/obj/structure/ms13/barrel/single/flammable,
 /turf/open/floor/plating/ms13/ground/desertalt,
 /area/ms13/desert)
 "bxd" = (
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 1
 	},
 /turf/open/floor/ms13/tile/full/green,
@@ -1388,7 +1388,7 @@
 /turf/open/floor/ms13/concrete,
 /area/ms13/town)
 "bFR" = (
-/obj/structure/fluff/ms13/barrel/quadruple/red/one,
+/obj/structure/ms13/barrel/quadruple/red/one,
 /turf/open/floor/ms13/concrete/small,
 /area/ms13/water_baron/interior)
 "bGb" = (
@@ -1608,7 +1608,7 @@
 /turf/open/floor/plating/ms13/ground/desertalt,
 /area/ms13/legioncamp/building)
 "bSi" = (
-/obj/structure/fluff/ms13/barrel/single/flammable/two,
+/obj/structure/ms13/barrel/single/flammable/two,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "bSj" = (
@@ -1970,7 +1970,7 @@
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/factory)
 "ckD" = (
-/obj/structure/fluff/ms13/barrel/single/hazard/two,
+/obj/structure/ms13/barrel/single/hazard/two,
 /turf/open/floor/plating/ms13/ground/desertalt,
 /area/ms13/desert)
 "ckQ" = (
@@ -2086,7 +2086,7 @@
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/drylanders/building)
 "cpC" = (
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 8
 	},
 /turf/open/floor/ms13/concrete/industrial,
@@ -2348,7 +2348,7 @@
 /turf/open/floor/wood/ms13/common,
 /area/ms13/town)
 "cII" = (
-/obj/structure/fluff/ms13/barrel/single/flammable/two,
+/obj/structure/ms13/barrel/single/flammable/two,
 /turf/open/floor/ms13/concrete,
 /area/ms13/town)
 "cJr" = (
@@ -2839,7 +2839,7 @@
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "dmA" = (
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	pixel_y = -28
 	},
 /obj/structure/table/ms13/no_smooth/large/wood/desk{
@@ -3351,7 +3351,7 @@
 /turf/open/floor/wood/ms13/carpet/shaggy,
 /area/ms13/town)
 "dSR" = (
-/obj/structure/fluff/ms13/barrel/single/hazard/one,
+/obj/structure/ms13/barrel/single/hazard/one,
 /obj/machinery/light/ms13{
 	dir = 8
 	},
@@ -3364,7 +3364,7 @@
 /turf/open/floor/plating/ms13/ground/desert,
 /area/ms13/desert)
 "dTa" = (
-/obj/structure/fluff/ms13/trash/papers,
+/obj/structure/ms13/trash/papers,
 /obj/machinery/light/ms13/bulb{
 	dir = 4
 	},
@@ -3517,7 +3517,7 @@
 /turf/open/floor/plating/ms13/ground/mountain/drought,
 /area/ms13/underground/mountain)
 "ehO" = (
-/obj/structure/fluff/ms13/trash/papers,
+/obj/structure/ms13/trash/papers,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "ehQ" = (
@@ -3698,7 +3698,7 @@
 /obj/structure/table/ms13/no_smooth/large/wood/desk{
 	dir = 4
 	},
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 5;
 	pixel_x = 1;
 	pixel_y = 15
@@ -3728,7 +3728,7 @@
 /area/ms13/legioncamp)
 "etm" = (
 /obj/structure/table/ms13/metal/alt,
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 1;
 	pixel_x = 4;
 	pixel_y = 4
@@ -3811,7 +3811,7 @@
 /turf/open/floor/ms13/concrete,
 /area/ms13/water_baron/interior)
 "ewg" = (
-/obj/structure/fluff/ms13/barrel/triple/red/one,
+/obj/structure/ms13/barrel/triple/red/one,
 /turf/open/floor/plating/ms13/ground/desertalt,
 /area/ms13/desert)
 "ewo" = (
@@ -3922,7 +3922,7 @@
 /obj/structure/railing/ms13/wood{
 	dir = 1
 	},
-/obj/structure/fluff/ms13/barrel/quadruple/red/two,
+/obj/structure/ms13/barrel/quadruple/red/two,
 /turf/open/floor/plating/ms13/ground/desertalt,
 /area/ms13/town)
 "eHk" = (
@@ -4064,7 +4064,7 @@
 /turf/open/floor/wood/ms13/common,
 /area/ms13/town)
 "eOZ" = (
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 1;
 	pixel_x = 4;
 	pixel_y = 4
@@ -4292,7 +4292,7 @@
 /obj/effect/decal/cleanable/glass{
 	dir = 8
 	},
-/obj/structure/fluff/ms13/barrel/double/red/two,
+/obj/structure/ms13/barrel/double/red/two,
 /turf/open/floor/plating/ms13/ground/mountain/drought,
 /area/ms13/town)
 "fcV" = (
@@ -4361,7 +4361,7 @@
 /turf/open/floor/plating/ms13/ground/desertalt,
 /area/ms13/rangeroutpost)
 "fgs" = (
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 5
 	},
 /turf/open/floor/ms13/concrete/industrial,
@@ -4401,7 +4401,7 @@
 /turf/open/floor/plating/ms13/ground/mountain/drought,
 /area/ms13/drylanders/building)
 "fji" = (
-/obj/structure/fluff/ms13/barrel/quadruple/red/two,
+/obj/structure/ms13/barrel/quadruple/red/two,
 /turf/open/floor/ms13/concrete,
 /area/ms13/town)
 "fjo" = (
@@ -4418,7 +4418,7 @@
 /obj/structure/ms13/barricade{
 	dir = 4
 	},
-/obj/structure/fluff/ms13/barrel/double/red/one,
+/obj/structure/ms13/barrel/double/red/one,
 /turf/open/floor/plating/ms13/ground/desertalt,
 /area/ms13/town)
 "fkC" = (
@@ -4759,7 +4759,7 @@
 /area/ms13/town)
 "fJg" = (
 /obj/structure/table/ms13/no_smooth/wood/square,
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 1
 	},
 /turf/open/floor/wood/ms13/wide,
@@ -5022,7 +5022,7 @@
 /obj/machinery/light/ms13{
 	dir = 1
 	},
-/obj/structure/fluff/ms13/barrel/quadruple/red/two,
+/obj/structure/ms13/barrel/quadruple/red/two,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "fVv" = (
@@ -5744,7 +5744,7 @@
 /turf/open/floor/plating/ms13/ground/road,
 /area/ms13/desert)
 "gMW" = (
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 8
 	},
 /obj/structure/ms13/foundation/variantfour{
@@ -5801,7 +5801,7 @@
 /turf/open/floor/ms13/concrete/small,
 /area/ms13/water_baron/interior)
 "gQA" = (
-/obj/structure/fluff/ms13/barrel/single/warning/one,
+/obj/structure/ms13/barrel/single/warning/one,
 /turf/open/floor/plating/ms13/ground/desert,
 /area/ms13/desert)
 "gQT" = (
@@ -6163,7 +6163,7 @@
 /turf/open/floor/ms13/tile,
 /area/ms13/town)
 "hop" = (
-/obj/structure/fluff/ms13/barrel/quadruple/yellow,
+/obj/structure/ms13/barrel/quadruple/yellow,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "hoJ" = (
@@ -6217,7 +6217,7 @@
 /obj/machinery/ms13/terminal{
 	dir = 4
 	},
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 1;
 	pixel_y = -15
 	},
@@ -6314,7 +6314,7 @@
 /obj/item/ms13/fluff/burnt_book{
 	pixel_y = 3
 	},
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 1;
 	pixel_x = 4;
 	pixel_y = 12
@@ -6806,7 +6806,7 @@
 /turf/open/floor/ms13/concrete/small,
 /area/ms13/water_baron/interior)
 "iaV" = (
-/obj/structure/fluff/ms13/barrel/double/red/one,
+/obj/structure/ms13/barrel/double/red/one,
 /turf/open/floor/plating/ms13/ground/desert,
 /area/ms13/desert)
 "ibs" = (
@@ -6954,7 +6954,7 @@
 /turf/open/floor/ms13/concrete,
 /area/ms13/town)
 "iiS" = (
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 10
 	},
 /mob/living/basic/ms13/ghoul/brown,
@@ -7078,7 +7078,7 @@
 /turf/open/floor/ms13/concrete,
 /area/ms13/water_baron/interior)
 "irf" = (
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 6;
 	pixel_y = 14
 	},
@@ -7258,14 +7258,14 @@
 /turf/open/floor/ms13/metal/grate/border,
 /area/ms13/water_baron/interior)
 "iEn" = (
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 1
 	},
 /mob/living/basic/ms13/ghoul/brown,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "iEt" = (
-/obj/structure/fluff/ms13/barrel/quadruple/red,
+/obj/structure/ms13/barrel/quadruple/red,
 /obj/machinery/light/ms13,
 /turf/open/floor/ms13/concrete/small,
 /area/ms13/water_baron/interior)
@@ -7404,7 +7404,7 @@
 /turf/open/floor/wood/ms13/carpet/shaggy,
 /area/ms13/town)
 "iLo" = (
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 9
 	},
 /turf/open/floor/ms13/concrete/industrial,
@@ -7593,7 +7593,7 @@
 /obj/structure/ms13/barricade{
 	dir = 8
 	},
-/obj/structure/fluff/ms13/barrel/quadruple/red/two,
+/obj/structure/ms13/barrel/quadruple/red/two,
 /turf/open/floor/plating/ms13/ground/desertalt,
 /area/ms13/town)
 "iYM" = (
@@ -8268,7 +8268,7 @@
 /area/ms13/legioncamp)
 "jOM" = (
 /obj/structure/noticeboard/ms13/cork,
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 9
 	},
 /turf/open/floor/wood/ms13/wide,
@@ -8615,7 +8615,7 @@
 /turf/open/floor/plating/ms13/ground/mountain/drought,
 /area/ms13/town)
 "knc" = (
-/obj/structure/fluff/ms13/barrel/quadruple/red/two,
+/obj/structure/ms13/barrel/quadruple/red/two,
 /turf/open/floor/ms13/metal/pipe,
 /area/ms13/water_baron/interior)
 "kof" = (
@@ -8784,7 +8784,7 @@
 /turf/closed/wall/ms13/siding,
 /area/ms13/town)
 "kyd" = (
-/obj/structure/fluff/ms13/barrel/double/yellow/two,
+/obj/structure/ms13/barrel/double/yellow/two,
 /turf/open/floor/plating/ms13/ground/desertalt,
 /area/ms13/desert)
 "kyC" = (
@@ -8842,7 +8842,7 @@
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "kBh" = (
-/obj/structure/fluff/ms13/barrel/single/hazard,
+/obj/structure/ms13/barrel/single/hazard,
 /turf/open/floor/plating/ms13/ground/desert,
 /area/ms13/desert)
 "kBi" = (
@@ -9767,7 +9767,7 @@
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "ltL" = (
-/obj/structure/fluff/ms13/trash/papers,
+/obj/structure/ms13/trash/papers,
 /turf/open/floor/wood/ms13/mosaic,
 /area/ms13/town)
 "lua" = (
@@ -10339,7 +10339,7 @@
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "met" = (
-/obj/structure/fluff/ms13/barrel/double/red,
+/obj/structure/ms13/barrel/double/red,
 /turf/open/floor/plating/ms13/ground/desert,
 /area/ms13/desert)
 "mfh" = (
@@ -10743,7 +10743,7 @@
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "mDO" = (
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 4
 	},
 /turf/open/floor/ms13/tile/large/cream,
@@ -10847,7 +10847,7 @@
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "mJM" = (
-/obj/structure/fluff/ms13/barrel/single/yellow/one,
+/obj/structure/ms13/barrel/single/yellow/one,
 /turf/open/floor/plating/ms13/ground/desertalt,
 /area/ms13/desert)
 "mJN" = (
@@ -11238,7 +11238,7 @@
 	},
 /area/ms13/water_baron/interior)
 "nmF" = (
-/obj/structure/fluff/ms13/barrel/quadruple/red/one,
+/obj/structure/ms13/barrel/quadruple/red/one,
 /turf/open/floor/plating/ms13/ground/sidewalk,
 /area/ms13/town)
 "nmM" = (
@@ -11467,7 +11467,7 @@
 /turf/open/floor/ms13/metal/pipe,
 /area/ms13/water_baron/interior)
 "nAH" = (
-/obj/structure/fluff/ms13/barrel/triple/red,
+/obj/structure/ms13/barrel/triple/red,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "nBb" = (
@@ -11533,7 +11533,7 @@
 	},
 /area/ms13/water_baron/interior)
 "nEa" = (
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 6
 	},
 /turf/open/floor/wood/ms13/wide,
@@ -11544,7 +11544,7 @@
 /turf/open/floor/plating/ms13/ground/road,
 /area/ms13/desert)
 "nFb" = (
-/obj/structure/fluff/ms13/barrel/quadruple/red/one,
+/obj/structure/ms13/barrel/quadruple/red/one,
 /turf/open/floor/plating/ms13/ground/desert,
 /area/ms13/desert)
 "nFw" = (
@@ -11800,7 +11800,7 @@
 /turf/open/floor/wood/ms13/common,
 /area/ms13/town)
 "nUg" = (
-/obj/structure/fluff/ms13/barrel/double/grey/two,
+/obj/structure/ms13/barrel/double/grey/two,
 /turf/open/floor/plating/ms13/ground/desert,
 /area/ms13/water_baron)
 "nUG" = (
@@ -11996,7 +11996,7 @@
 /turf/open/floor/plating/ms13/ground/desertalt,
 /area/ms13/desert)
 "ofT" = (
-/obj/structure/fluff/ms13/barrel/single/red/one,
+/obj/structure/ms13/barrel/single/red/one,
 /turf/open/floor/plating/ms13/ground/desertalt,
 /area/ms13/desert)
 "ogL" = (
@@ -12163,7 +12163,7 @@
 /turf/open/floor/wood/ms13/carpet/shaggy/blue,
 /area/ms13/town)
 "osm" = (
-/obj/structure/fluff/ms13/barrel/quadruple/red/one,
+/obj/structure/ms13/barrel/quadruple/red/one,
 /turf/open/floor/ms13/concrete,
 /area/ms13/desert)
 "osr" = (
@@ -12188,7 +12188,7 @@
 /area/ms13/desert)
 "otb" = (
 /obj/item/reagent_containers/food/drinks/mug/ms13,
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	pixel_x = 1;
 	pixel_y = -4
 	},
@@ -12228,7 +12228,7 @@
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/drylanders/building)
 "ovd" = (
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 4
 	},
 /turf/open/floor/wood/ms13/wide,
@@ -13025,7 +13025,7 @@
 /turf/open/floor/ms13/concrete,
 /area/ms13/town)
 "poD" = (
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 1;
 	pixel_x = 4;
 	pixel_y = 4
@@ -13130,7 +13130,7 @@
 /turf/open/floor/plating/ms13/ground/sidewalk,
 /area/ms13/desert)
 "puZ" = (
-/obj/structure/fluff/ms13/barrel/quadruple/red,
+/obj/structure/ms13/barrel/quadruple/red,
 /turf/open/floor/plating/ms13/ground/desert,
 /area/ms13/desert)
 "pvl" = (
@@ -13283,7 +13283,7 @@
 /turf/open/floor/ms13/tile,
 /area/ms13/town)
 "pBn" = (
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 4
 	},
 /obj/item/reagent_containers/glass/bucket/ms13,
@@ -13417,7 +13417,7 @@
 /turf/open/floor/plating/ms13/ground/desert,
 /area/ms13/desert)
 "pHE" = (
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 10
 	},
 /turf/open/floor/wood/ms13/wide,
@@ -13579,7 +13579,7 @@
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "pSV" = (
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 9
 	},
 /turf/open/floor/wood/ms13/wide,
@@ -13704,7 +13704,7 @@
 /turf/open/floor/ms13/concrete,
 /area/ms13/rangeroutpost/building)
 "qgL" = (
-/obj/structure/fluff/ms13/barrel/quadruple/red/two,
+/obj/structure/ms13/barrel/quadruple/red/two,
 /turf/open/floor/plating/ms13/ground/desert,
 /area/ms13/desert)
 "qgT" = (
@@ -13735,7 +13735,7 @@
 /turf/open/floor/ms13/tile/large/cream,
 /area/ms13/town)
 "qhT" = (
-/obj/structure/fluff/ms13/barrel/quadruple/red/one,
+/obj/structure/ms13/barrel/quadruple/red/one,
 /turf/open/floor/plating/ms13/ground/desertalt,
 /area/ms13/desert)
 "qiy" = (
@@ -14337,7 +14337,7 @@
 /turf/open/floor/wood/ms13/carpet/shaggy,
 /area/ms13/town)
 "qIw" = (
-/obj/structure/fluff/ms13/barrel/single/yellow/two,
+/obj/structure/ms13/barrel/single/yellow/two,
 /turf/open/floor/plating/ms13/ground/desert,
 /area/ms13/desert)
 "qJE" = (
@@ -14451,7 +14451,7 @@
 /obj/item/reagent_containers/food/drinks/mug/ms13{
 	pixel_y = 8
 	},
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 1
 	},
 /turf/open/floor/wood/ms13/carpet/green,
@@ -14734,7 +14734,7 @@
 /turf/open/floor/ms13/tile/large/cafeteria,
 /area/ms13/factory)
 "rjS" = (
-/obj/structure/fluff/ms13/trash/papers,
+/obj/structure/ms13/trash/papers,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "rkf" = (
@@ -14978,7 +14978,7 @@
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "ruY" = (
-/obj/structure/fluff/ms13/barrel/quadruple/red/two,
+/obj/structure/ms13/barrel/quadruple/red/two,
 /turf/open/floor/plating/ms13/ground/desert,
 /area/ms13/water_baron)
 "rvz" = (
@@ -15153,7 +15153,7 @@
 /turf/open/floor/ms13/concrete/bricks,
 /area/ms13/water_baron/interior)
 "rDB" = (
-/obj/structure/fluff/ms13/barrel/quadruple/red/one,
+/obj/structure/ms13/barrel/quadruple/red/one,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "rEm" = (
@@ -15987,7 +15987,7 @@
 /turf/open/floor/ms13/tile/brown/big,
 /area/ms13/town)
 "sCz" = (
-/obj/structure/fluff/ms13/barrel/single/red/two,
+/obj/structure/ms13/barrel/single/red/two,
 /turf/open/floor/ms13/concrete,
 /area/ms13/town)
 "sDa" = (
@@ -16145,7 +16145,7 @@
 /obj/structure/table/ms13/no_smooth/large/metal{
 	dir = 4
 	},
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 1;
 	pixel_x = 4;
 	pixel_y = 4
@@ -16349,14 +16349,14 @@
 	pixel_x = -6;
 	pixel_y = 1
 	},
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 1;
 	pixel_x = 14
 	},
 /turf/open/floor/wood/ms13/carpet/shaggy,
 /area/ms13/town)
 "taZ" = (
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 10
 	},
 /obj/item/folder/ms13/brown{
@@ -16397,7 +16397,7 @@
 /turf/open/openspace/ms13,
 /area/ms13/drylanders/building)
 "tcS" = (
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 9
 	},
 /obj/item/pen/ms13{
@@ -16660,7 +16660,7 @@
 /turf/open/floor/ms13/tile/full/green,
 /area/ms13/town)
 "trp" = (
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 4
 	},
 /obj/structure/ms13/foundation/variantfive{
@@ -16760,7 +16760,7 @@
 /obj/item/ms13/fluff/burnt_book{
 	pixel_y = -7
 	},
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 4
 	},
 /turf/open/floor/wood/ms13/wide,
@@ -17333,7 +17333,7 @@
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/factory)
 "uca" = (
-/obj/structure/fluff/ms13/trash/papers,
+/obj/structure/ms13/trash/papers,
 /turf/open/floor/ms13/concrete,
 /area/ms13/town)
 "ucA" = (
@@ -17403,7 +17403,7 @@
 	pixel_x = 10;
 	pixel_y = 9
 	},
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 1
 	},
 /turf/open/floor/ms13/concrete/industrial,
@@ -17615,7 +17615,7 @@
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/factory)
 "utS" = (
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 4
 	},
 /turf/open/floor/ms13/concrete/industrial,
@@ -17768,10 +17768,10 @@
 /turf/open/floor/wood/ms13/mosaic,
 /area/ms13/town)
 "uGb" = (
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 1
 	},
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 1
 	},
 /turf/open/floor/wood/ms13/common,
@@ -18069,7 +18069,7 @@
 /turf/open/floor/plating/ms13/ground/desertalt,
 /area/ms13/water_baron)
 "uVI" = (
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 5
 	},
 /turf/open/floor/wood/ms13/wide,
@@ -18330,7 +18330,7 @@
 /turf/open/floor/ms13/concrete/small,
 /area/ms13/water_baron/interior)
 "viq" = (
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 4
 	},
 /obj/effect/spawner/random/ms13/currency/drought/lowrandom,
@@ -18709,7 +18709,7 @@
 /turf/open/floor/ms13/metal/grate,
 /area/ms13/desert)
 "vFo" = (
-/obj/structure/fluff/ms13/barrel/single/hazard/two,
+/obj/structure/ms13/barrel/single/hazard/two,
 /obj/structure/ms13/pipes/vertical/east/corner/down,
 /turf/open/floor/ms13/concrete,
 /area/ms13/desert)
@@ -18896,7 +18896,7 @@
 /turf/open/floor/ms13/concrete,
 /area/ms13/water_baron/interior)
 "vSP" = (
-/obj/structure/fluff/ms13/barrel/triple/yellow/two,
+/obj/structure/ms13/barrel/triple/yellow/two,
 /turf/open/floor/plating/ms13/ground/desert,
 /area/ms13/desert)
 "vTg" = (
@@ -18930,7 +18930,7 @@
 /turf/open/floor/ms13/concrete,
 /area/ms13/desert)
 "vUT" = (
-/obj/structure/fluff/ms13/barrel/single/redalt/two,
+/obj/structure/ms13/barrel/single/redalt/two,
 /turf/open/floor/plating/ms13/ground/desertalt,
 /area/ms13/desert)
 "vVp" = (
@@ -19571,7 +19571,7 @@
 /turf/open/floor/ms13/concrete,
 /area/ms13/water_baron/interior)
 "wQC" = (
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 4;
 	pixel_x = -3;
 	pixel_y = -20
@@ -19587,7 +19587,7 @@
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "wQH" = (
-/obj/structure/fluff/ms13/trash/papers,
+/obj/structure/ms13/trash/papers,
 /obj/structure/filingcabinet/ms13/empty{
 	dir = 4
 	},
@@ -19608,7 +19608,7 @@
 /area/ms13/town)
 "wQM" = (
 /obj/structure/chair/office/ms13/red,
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 9
 	},
 /turf/open/floor/wood/ms13/common,
@@ -19748,7 +19748,7 @@
 /turf/open/floor/plating/ms13/ground/desertalt,
 /area/ms13/desert)
 "wZo" = (
-/obj/structure/fluff/ms13/barrel/quadruple/yellow/one,
+/obj/structure/ms13/barrel/quadruple/yellow/one,
 /turf/open/floor/plating/ms13/ground/desert,
 /area/ms13/desert)
 "wZC" = (
@@ -20073,7 +20073,7 @@
 /turf/open/floor/wood/ms13/mosaic,
 /area/ms13/town)
 "xtX" = (
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 1;
 	pixel_x = 20;
 	pixel_y = 4
@@ -20178,7 +20178,7 @@
 /obj/machinery/light/ms13{
 	dir = 1
 	},
-/obj/structure/fluff/ms13/barrel/double/grey,
+/obj/structure/ms13/barrel/double/grey,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "xCf" = (

--- a/_maps/map_files/Drought/Drought_above.dmm
+++ b/_maps/map_files/Drought/Drought_above.dmm
@@ -965,7 +965,7 @@
 /area/ms13/town)
 "ds" = (
 /obj/structure/ms13/pipes/piped,
-/obj/structure/fluff/ms13/barrel/quadruple/red/two,
+/obj/structure/ms13/barrel/quadruple/red/two,
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /turf/open/floor/ms13/concrete/small,
 /area/ms13/water_baron/interior)
@@ -1208,10 +1208,10 @@
 /area/ms13/underground/mountain)
 "eg" = (
 /obj/structure/table/ms13/wood/constructed,
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 10
 	},
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 8
 	},
 /obj/item/ms13/fluff/alarmclock{
@@ -1259,7 +1259,7 @@
 "ep" = (
 /obj/structure/table/ms13/wood,
 /obj/item/folder/ms13/brown,
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 1
 	},
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
@@ -1437,7 +1437,7 @@
 /obj/structure/ms13/lamp{
 	pixel_y = 12
 	},
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 8
 	},
 /obj/item/ms13/fluff/ashtray{
@@ -1986,7 +1986,7 @@
 /obj/item/ms13/fluff/burnt_book{
 	pixel_y = 3
 	},
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 5
 	},
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
@@ -2272,7 +2272,7 @@
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "hO" = (
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 5
 	},
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
@@ -2333,7 +2333,7 @@
 /turf/open/openspace/ms13,
 /area/ms13/desert)
 "hX" = (
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 8
 	},
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
@@ -2579,7 +2579,7 @@
 /obj/item/ms13/fluff/burnt_book{
 	pixel_y = -11
 	},
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 9
 	},
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
@@ -2639,7 +2639,7 @@
 /turf/open/floor/ms13/tile/blue,
 /area/ms13/town)
 "iY" = (
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 9
 	},
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
@@ -2794,7 +2794,7 @@
 /area/ms13/town)
 "jB" = (
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 5
 	},
 /turf/open/floor/wood/ms13/mosaic,
@@ -3984,7 +3984,7 @@
 /turf/open/floor/wood/ms13/mosaic,
 /area/ms13/town)
 "nJ" = (
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 9
 	},
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
@@ -4127,7 +4127,7 @@
 	pixel_y = -1
 	},
 /obj/item/folder/ms13/brown,
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 1
 	},
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
@@ -4292,7 +4292,7 @@
 /area/ms13/water_baron/interior)
 "oM" = (
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
-/obj/structure/fluff/ms13/trash/papers,
+/obj/structure/ms13/trash/papers,
 /obj/structure/filingcabinet/ms13/short{
 	dir = 8
 	},
@@ -4566,7 +4566,7 @@
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "pM" = (
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 10
 	},
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
@@ -4576,7 +4576,7 @@
 /obj/structure/table/ms13/no_smooth/counter/wood/bend{
 	dir = 4
 	},
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	pixel_x = 6;
 	pixel_y = 7
 	},
@@ -5404,7 +5404,7 @@
 /obj/structure/ms13/phone/black{
 	pixel_y = 8
 	},
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 1;
 	pixel_x = 20;
 	pixel_y = 4
@@ -6273,7 +6273,7 @@
 /turf/open/floor/ms13/concrete,
 /area/ms13/water_baron/interior)
 "vL" = (
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 9
 	},
 /obj/item/folder/ms13/brown,
@@ -6368,7 +6368,7 @@
 /area/ms13/desert)
 "vZ" = (
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 10
 	},
 /turf/open/floor/wood/ms13/wide,
@@ -6443,7 +6443,7 @@
 	},
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /obj/item/pen/ms13,
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 1;
 	pixel_y = -2
 	},
@@ -6756,7 +6756,7 @@
 /turf/open/floor/ms13/concrete,
 /area/ms13/water_baron/interior)
 "xv" = (
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 4
 	},
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
@@ -7068,7 +7068,7 @@
 /obj/structure/ms13/lamp{
 	pixel_y = 12
 	},
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 1
 	},
 /obj/effect/spawner/random/ms13/crafting/electrical,
@@ -7129,7 +7129,7 @@
 /turf/open/floor/ms13/tile/fancy,
 /area/ms13/town)
 "yO" = (
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 10
 	},
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
@@ -8059,7 +8059,7 @@
 /turf/open/floor/wood/ms13/common,
 /area/ms13/water_baron/interior)
 "Ch" = (
-/obj/structure/fluff/ms13/trash/papers,
+/obj/structure/ms13/trash/papers,
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
@@ -8164,7 +8164,7 @@
 /obj/structure/table/ms13/no_smooth/large/metal/desk{
 	dir = 4
 	},
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 1;
 	pixel_x = 6
 	},
@@ -8515,7 +8515,7 @@
 /area/ms13/town)
 "DV" = (
 /obj/structure/table/ms13/wood/constructed,
-/obj/structure/fluff/ms13/trash/papers,
+/obj/structure/ms13/trash/papers,
 /obj/effect/spawner/random/ms13/medical/surgical,
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /turf/open/floor/wood/ms13/mosaic,
@@ -8770,7 +8770,7 @@
 "ET" = (
 /obj/structure/table/ms13/no_smooth/wood/square,
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 1;
 	pixel_x = 6
 	},
@@ -8818,7 +8818,7 @@
 /area/ms13/town)
 "EZ" = (
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
-/obj/structure/fluff/ms13/trash/papers,
+/obj/structure/ms13/trash/papers,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "Fa" = (
@@ -9741,7 +9741,7 @@
 "Ih" = (
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /obj/structure/chair/comfy/ms13/ergo,
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 1;
 	pixel_x = 6
 	},
@@ -9818,7 +9818,7 @@
 /obj/structure/ms13/rug/rubber{
 	dir = 4
 	},
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 1;
 	pixel_x = 4;
 	pixel_y = 4
@@ -9968,7 +9968,7 @@
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "IS" = (
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 4;
 	pixel_y = -20
 	},
@@ -10129,7 +10129,7 @@
 	pixel_x = 6;
 	pixel_y = 5
 	},
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 1;
 	pixel_y = -2
 	},
@@ -10329,7 +10329,7 @@
 /area/ms13/town)
 "Kc" = (
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 5
 	},
 /turf/open/floor/wood/ms13/wide,
@@ -10337,7 +10337,7 @@
 "Ke" = (
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /obj/structure/table/ms13/metal/grate,
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 9
 	},
 /obj/machinery/light/ms13,
@@ -10601,7 +10601,7 @@
 /area/ms13/town)
 "KY" = (
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 5
 	},
 /obj/structure/ms13/lamp{
@@ -10781,7 +10781,7 @@
 /area/ms13/drylanders)
 "LG" = (
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 4
 	},
 /turf/open/floor/wood/ms13/carpet,
@@ -11201,7 +11201,7 @@
 /obj/machinery/ms13/terminal/crafted{
 	dir = 4
 	},
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 5;
 	pixel_y = -8
 	},
@@ -12016,7 +12016,7 @@
 /turf/open/floor/plating/ms13/roof/wood,
 /area/ms13/town)
 "PV" = (
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 1
 	},
 /obj/structure/ms13/lamp{
@@ -12340,7 +12340,7 @@
 /area/ms13/town)
 "QZ" = (
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
-/obj/structure/fluff/ms13/barrel/double/yellow/two,
+/obj/structure/ms13/barrel/double/yellow/two,
 /turf/open/floor/ms13/concrete,
 /area/ms13/water_baron/interior)
 "Ra" = (
@@ -12674,7 +12674,7 @@
 /turf/closed/wall/ms13/siding/red,
 /area/ms13/town)
 "Sk" = (
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	pixel_y = 6
 	},
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
@@ -12882,7 +12882,7 @@
 /area/ms13/town)
 "SY" = (
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 8
 	},
 /obj/item/chair/ms13/metal/office/blue/broken,
@@ -13394,7 +13394,7 @@
 /obj/structure/ms13/rug/fancy{
 	dir = 1
 	},
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 1
 	},
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
@@ -13842,7 +13842,7 @@
 /obj/structure/table/ms13/no_smooth/large/wood/desk{
 	dir = 4
 	},
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 1;
 	pixel_x = 4;
 	pixel_y = 4
@@ -13922,7 +13922,7 @@
 /area/ms13/town)
 "WD" = (
 /obj/structure/table/ms13/wood,
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 1
 	},
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
@@ -14022,7 +14022,7 @@
 /area/ms13/town)
 "WW" = (
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 9
 	},
 /obj/structure/ms13/storage/bookshelf{
@@ -14240,7 +14240,7 @@
 /obj/structure/ms13/barricade{
 	dir = 8
 	},
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 5
 	},
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
@@ -14299,7 +14299,7 @@
 /area/ms13/town)
 "XV" = (
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
-/obj/structure/fluff/ms13/barrel/quadruple/red/one,
+/obj/structure/ms13/barrel/quadruple/red/one,
 /turf/open/floor/ms13/concrete,
 /area/ms13/water_baron/interior)
 "XX" = (
@@ -14636,7 +14636,7 @@
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "Zp" = (
-/obj/structure/fluff/ms13/trash/papers,
+/obj/structure/ms13/trash/papers,
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)

--- a/_maps/map_files/Drought/Drought_below.dmm
+++ b/_maps/map_files/Drought/Drought_below.dmm
@@ -5,7 +5,7 @@
 /turf/open/floor/plating/ms13/ground/mountain/drought,
 /area/ms13/underground/mountain)
 "ac" = (
-/obj/structure/fluff/ms13/barrel/quadruple/red/two,
+/obj/structure/ms13/barrel/quadruple/red/two,
 /turf/open/floor/plating/ms13/ground/desertalt,
 /area/ms13/town)
 "ad" = (
@@ -92,7 +92,7 @@
 /area/ms13/town)
 "aM" = (
 /obj/structure/table/ms13/metal/alt,
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 1;
 	pixel_x = 4;
 	pixel_y = 4
@@ -158,7 +158,7 @@
 /turf/open/floor/ms13/tile/blue,
 /area/ms13/underground/mountain_bunker)
 "bn" = (
-/obj/structure/fluff/ms13/barrel/quadruple/yellow/one,
+/obj/structure/ms13/barrel/quadruple/yellow/one,
 /turf/open/floor/plating/ms13/ground/desertalt,
 /area/ms13/town)
 "bv" = (
@@ -833,7 +833,7 @@
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "gf" = (
-/obj/structure/fluff/ms13/barrel/triple/red/one,
+/obj/structure/ms13/barrel/triple/red/one,
 /turf/open/floor/plating/ms13/ground/desertalt,
 /area/ms13/town)
 "gg" = (
@@ -954,7 +954,7 @@
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "gW" = (
-/obj/structure/fluff/ms13/barrel/double/red/one,
+/obj/structure/ms13/barrel/double/red/one,
 /obj/structure/ms13/pipes/horizontal/box,
 /turf/open/floor/ms13/concrete,
 /area/ms13/town)
@@ -963,7 +963,7 @@
 /turf/open/floor/plating/ms13/ground/desert,
 /area/ms13/desert)
 "hb" = (
-/obj/structure/fluff/ms13/barrel/single/redalt/two,
+/obj/structure/ms13/barrel/single/redalt/two,
 /turf/open/floor/plating/ms13/ground/desertalt,
 /area/ms13/town)
 "hd" = (
@@ -1190,7 +1190,7 @@
 /area/ms13/town)
 "iE" = (
 /obj/structure/ms13/cave_decor/support/beams,
-/obj/structure/fluff/ms13/barrel/double/red/one,
+/obj/structure/ms13/barrel/double/red/one,
 /turf/open/floor/plating/ms13/ground/desertalt,
 /area/ms13/town)
 "iF" = (
@@ -1317,7 +1317,7 @@
 /turf/open/floor/plating/ms13/ground/mountain/drought,
 /area/ms13/underground/mountain)
 "jD" = (
-/obj/structure/fluff/ms13/barrel/quadruple/red/one,
+/obj/structure/ms13/barrel/quadruple/red/one,
 /obj/structure/ms13/pipes/horizontal/down/single{
 	dir = 1
 	},
@@ -1483,7 +1483,7 @@
 /turf/open/floor/plating/ms13/ground/mountain/drought,
 /area/ms13/underground/mountain)
 "kH" = (
-/obj/structure/fluff/ms13/barrel/single/yellow,
+/obj/structure/ms13/barrel/single/yellow,
 /turf/open/floor/plating/ms13/ground/desert,
 /area/ms13/underground/mountain)
 "kI" = (
@@ -1562,7 +1562,7 @@
 /turf/open/floor/ms13/concrete/bricks,
 /area/ms13/town)
 "ls" = (
-/obj/structure/fluff/ms13/barrel/double/grey/one,
+/obj/structure/ms13/barrel/double/grey/one,
 /turf/open/floor/ms13/concrete,
 /area/ms13/town)
 "lt" = (
@@ -1747,7 +1747,7 @@
 /turf/open/floor/ms13/metal/grate,
 /area/ms13/underground/mountain_bunker)
 "mS" = (
-/obj/structure/fluff/ms13/barrel/quadruple/red/one,
+/obj/structure/ms13/barrel/quadruple/red/one,
 /turf/open/floor/plating/ms13/ground/mountain/drought,
 /area/ms13/underground/mountain)
 "mT" = (
@@ -1767,7 +1767,7 @@
 /turf/open/floor/ms13/tile/blue/long,
 /area/ms13/underground/mountain_bunker)
 "mY" = (
-/obj/structure/fluff/ms13/barrel/quadruple/red/one,
+/obj/structure/ms13/barrel/quadruple/red/one,
 /turf/open/floor/plating/ms13/ground/desertalt,
 /area/ms13/town)
 "nb" = (
@@ -2110,7 +2110,7 @@
 /area/ms13/town)
 "pm" = (
 /obj/structure/ms13/cave_decor/support/wall/broken,
-/obj/structure/fluff/ms13/barrel/quadruple/red/two,
+/obj/structure/ms13/barrel/quadruple/red/two,
 /turf/open/floor/plating/ms13/ground/desertalt,
 /area/ms13/town)
 "pr" = (
@@ -2158,7 +2158,7 @@
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "pF" = (
-/obj/structure/fluff/ms13/barrel/double/red/one,
+/obj/structure/ms13/barrel/double/red/one,
 /turf/open/floor/plating/ms13/ground/desertalt,
 /area/ms13/town)
 "pI" = (
@@ -2432,7 +2432,7 @@
 /turf/open/floor/plating/ms13/ground/desertalt,
 /area/ms13/town)
 "rC" = (
-/obj/structure/fluff/ms13/barrel/double/yellow/two,
+/obj/structure/ms13/barrel/double/yellow/two,
 /obj/machinery/light/ms13{
 	dir = 8
 	},
@@ -2876,7 +2876,7 @@
 /turf/open/floor/plating/ms13/ground/desertalt,
 /area/ms13/town)
 "ux" = (
-/obj/structure/fluff/ms13/barrel/double/grey/two,
+/obj/structure/ms13/barrel/double/grey/two,
 /turf/open/floor/ms13/concrete,
 /area/ms13/town)
 "uz" = (
@@ -3061,7 +3061,7 @@
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "vO" = (
-/obj/structure/fluff/ms13/barrel/single/flammable/one,
+/obj/structure/ms13/barrel/single/flammable/one,
 /obj/structure/ms13/storage/vent,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
@@ -3093,7 +3093,7 @@
 /turf/open/floor/ms13/tile/blue,
 /area/ms13/town)
 "wa" = (
-/obj/structure/fluff/ms13/barrel/single/grey/two,
+/obj/structure/ms13/barrel/single/grey/two,
 /obj/machinery/light/ms13/bulb/industrial{
 	dir = 4
 	},
@@ -3101,7 +3101,7 @@
 /area/ms13/town)
 "wb" = (
 /obj/structure/ms13/cave_decor/support/wall,
-/obj/structure/fluff/ms13/barrel/quadruple/red/two,
+/obj/structure/ms13/barrel/quadruple/red/two,
 /turf/open/floor/plating/ms13/ground/desertalt,
 /area/ms13/town)
 "wc" = (
@@ -3231,7 +3231,7 @@
 /turf/open/floor/plating/ms13/ground/desertalt,
 /area/ms13/town)
 "wK" = (
-/obj/structure/fluff/ms13/barrel/quadruple/red/one,
+/obj/structure/ms13/barrel/quadruple/red/one,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "wN" = (
@@ -3638,7 +3638,7 @@
 /turf/open/floor/plating/ms13/ground/desertalt,
 /area/ms13/town)
 "zU" = (
-/obj/structure/fluff/ms13/barrel/triple/red/two,
+/obj/structure/ms13/barrel/triple/red/two,
 /turf/open/floor/plating/ms13/ground/desertalt,
 /area/ms13/town)
 "zV" = (
@@ -3809,7 +3809,7 @@
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "Bm" = (
-/obj/structure/fluff/ms13/barrel/single/hazard/two,
+/obj/structure/ms13/barrel/single/hazard/two,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "Bp" = (
@@ -4007,7 +4007,7 @@
 /turf/open/floor/ms13/metal/grate,
 /area/ms13/town)
 "CL" = (
-/obj/structure/fluff/ms13/barrel/quadruple/red/one,
+/obj/structure/ms13/barrel/quadruple/red/one,
 /turf/open/floor/plating/ms13/ground/desert,
 /area/ms13/underground/mountain)
 "CP" = (
@@ -4108,7 +4108,7 @@
 /turf/open/floor/ms13/concrete,
 /area/ms13/underground/mountain_bunker)
 "DC" = (
-/obj/structure/fluff/ms13/barrel/quadruple/yellow/one,
+/obj/structure/ms13/barrel/quadruple/yellow/one,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "DF" = (
@@ -4269,7 +4269,7 @@
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "Ex" = (
-/obj/structure/fluff/ms13/barrel/double/red/two,
+/obj/structure/ms13/barrel/double/red/two,
 /obj/item/reagent_containers/food/drinks/bottle/ms13/trooper_beer{
 	pixel_x = -1;
 	pixel_y = 10
@@ -4310,7 +4310,7 @@
 /turf/open/floor/plating/ms13/ground/desertalt,
 /area/ms13/town)
 "EH" = (
-/obj/structure/fluff/ms13/barrel/quadruple/grey,
+/obj/structure/ms13/barrel/quadruple/grey,
 /turf/open/floor/ms13/concrete,
 /area/ms13/town)
 "EI" = (
@@ -4325,7 +4325,7 @@
 /turf/open/floor/plating/ms13/ground/desertalt,
 /area/ms13/town)
 "EL" = (
-/obj/structure/fluff/ms13/barrel/quadruple/grey,
+/obj/structure/ms13/barrel/quadruple/grey,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "EM" = (
@@ -4392,7 +4392,7 @@
 /turf/open/floor/ms13/metal,
 /area/ms13/underground/mountain_bunker)
 "Fx" = (
-/obj/structure/fluff/ms13/barrel/triple/yellow/two,
+/obj/structure/ms13/barrel/triple/yellow/two,
 /turf/open/floor/plating/ms13/ground/desertalt,
 /area/ms13/town)
 "FA" = (
@@ -4454,7 +4454,7 @@
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "FZ" = (
-/obj/structure/fluff/ms13/barrel/triple/yellow/three,
+/obj/structure/ms13/barrel/triple/yellow/three,
 /turf/open/floor/plating/ms13/ground/desertalt,
 /area/ms13/town)
 "Gb" = (
@@ -4735,7 +4735,7 @@
 /turf/open/floor/ms13/tile/large/cream,
 /area/ms13/town)
 "Ic" = (
-/obj/structure/fluff/ms13/barrel/single/yellow/one,
+/obj/structure/ms13/barrel/single/yellow/one,
 /turf/open/floor/plating/ms13/ground/desertalt,
 /area/ms13/town)
 "Id" = (
@@ -4759,7 +4759,7 @@
 /turf/open/floor/ms13/concrete,
 /area/ms13/town)
 "Ik" = (
-/obj/structure/fluff/ms13/barrel/single/redalt/one,
+/obj/structure/ms13/barrel/single/redalt/one,
 /turf/open/floor/plating/ms13/ground/desertalt,
 /area/ms13/town)
 "Im" = (
@@ -4796,7 +4796,7 @@
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "IB" = (
-/obj/structure/fluff/ms13/barrel/triple/grey/one,
+/obj/structure/ms13/barrel/triple/grey/one,
 /obj/structure/ms13/pipes/horizontal/end{
 	dir = 1
 	},
@@ -5065,7 +5065,7 @@
 /turf/open/floor/plating/ms13/ground/mountain/drought,
 /area/ms13/underground/mountain)
 "KH" = (
-/obj/structure/fluff/ms13/barrel/double/red/two,
+/obj/structure/ms13/barrel/double/red/two,
 /turf/open/floor/ms13/concrete,
 /area/ms13/town)
 "KJ" = (
@@ -5301,7 +5301,7 @@
 /turf/open/floor/ms13/tile/large/cream,
 /area/ms13/town)
 "Mm" = (
-/obj/structure/fluff/ms13/barrel/double/red/two,
+/obj/structure/ms13/barrel/double/red/two,
 /turf/open/floor/plating/ms13/ground/desertalt,
 /area/ms13/town)
 "Mr" = (
@@ -5411,7 +5411,7 @@
 /area/ms13/town)
 "Ni" = (
 /obj/structure/ms13/cave_decor/support,
-/obj/structure/fluff/ms13/barrel/double/yellow/one,
+/obj/structure/ms13/barrel/double/yellow/one,
 /obj/structure/ms13/lamp/mining_lamp{
 	pixel_y = 30
 	},
@@ -5428,7 +5428,7 @@
 /turf/open/floor/ms13/concrete,
 /area/ms13/underground/mountain_bunker)
 "Nl" = (
-/obj/structure/fluff/ms13/barrel/triple/red,
+/obj/structure/ms13/barrel/triple/red,
 /obj/structure/ms13/lamp/mining_lamp{
 	pixel_y = 30
 	},
@@ -5781,7 +5781,7 @@
 /turf/open/floor/ms13/concrete/bricks,
 /area/ms13/town)
 "Pz" = (
-/obj/structure/fluff/ms13/barrel/single/flammable/two,
+/obj/structure/ms13/barrel/single/flammable/two,
 /turf/open/floor/ms13/concrete,
 /area/ms13/town)
 "PB" = (
@@ -5886,11 +5886,11 @@
 /turf/open/floor/plating/ms13/ground/desertalt,
 /area/ms13/town)
 "Qm" = (
-/obj/structure/fluff/ms13/barrel/quadruple/yellow/one,
+/obj/structure/ms13/barrel/quadruple/yellow/one,
 /turf/open/floor/plating/ms13/ground/desert,
 /area/ms13/underground/mountain)
 "Qo" = (
-/obj/structure/fluff/ms13/barrel/double/yellow/one,
+/obj/structure/ms13/barrel/double/yellow/one,
 /turf/open/floor/plating/ms13/ground/desertalt,
 /area/ms13/town)
 "Qs" = (
@@ -5979,7 +5979,7 @@
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "QV" = (
-/obj/structure/fluff/ms13/barrel/single/grey/three,
+/obj/structure/ms13/barrel/single/grey/three,
 /turf/open/floor/ms13/concrete,
 /area/ms13/town)
 "QW" = (
@@ -6632,7 +6632,7 @@
 /turf/open/floor/plating/ms13/ground/sidewalk,
 /area/ms13/underground/mountain)
 "VH" = (
-/obj/structure/fluff/ms13/barrel/single/flammable/one,
+/obj/structure/ms13/barrel/single/flammable/one,
 /turf/open/floor/plating/ms13/ground/desert,
 /area/ms13/underground/mountain)
 "VJ" = (
@@ -6641,7 +6641,7 @@
 /turf/open/floor/ms13/concrete,
 /area/ms13/underground/mountain_bunker)
 "VK" = (
-/obj/structure/fluff/ms13/barrel/single/red/one,
+/obj/structure/ms13/barrel/single/red/one,
 /obj/machinery/light/ms13{
 	dir = 8
 	},
@@ -6667,12 +6667,12 @@
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "VW" = (
-/obj/structure/fluff/ms13/barrel/triple/red/one,
-/obj/structure/fluff/ms13/barrel/triple/red/one,
+/obj/structure/ms13/barrel/triple/red/one,
+/obj/structure/ms13/barrel/triple/red/one,
 /turf/open/floor/plating/ms13/ground/desertalt,
 /area/ms13/town)
 "VX" = (
-/obj/structure/fluff/ms13/barrel/double/grey,
+/obj/structure/ms13/barrel/double/grey,
 /obj/structure/ms13/storage/vent,
 /obj/structure/ms13/pipes/horizontal/valve,
 /turf/open/floor/ms13/concrete,

--- a/_maps/map_files/Mammoth/Mammoth.dmm
+++ b/_maps/map_files/Mammoth/Mammoth.dmm
@@ -291,7 +291,7 @@
 /turf/open/floor/ms13/tile,
 /area/ms13/town)
 "ahM" = (
-/obj/structure/fluff/ms13/mammoth_sign,
+/obj/structure/ms13/mammoth_sign,
 /turf/open/floor/plating/ms13/ground/snow,
 /area/ms13/snow/lightforest)
 "aib" = (
@@ -832,7 +832,7 @@
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "ayv" = (
-/obj/structure/fluff/ms13/trash/papers,
+/obj/structure/ms13/trash/papers,
 /obj/structure/filingcabinet/ms13/short{
 	dir = 8
 	},
@@ -1019,7 +1019,7 @@
 /turf/open/floor/wood/ms13/mosaic,
 /area/ms13/town)
 "aHo" = (
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 8
 	},
 /turf/open/floor/ms13/tile/full/navy,
@@ -1750,7 +1750,7 @@
 /turf/open/floor/ms13/metal/warning,
 /area/ms13/underground/tunnel/maintenance)
 "bei" = (
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 6
 	},
 /turf/open/floor/wood/ms13/wide,
@@ -2336,7 +2336,7 @@
 /area/ms13/town)
 "bAV" = (
 /obj/structure/ms13/storage/vent,
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 1
 	},
 /turf/open/floor/wood/ms13/wide,
@@ -2524,7 +2524,7 @@
 /area/ms13/underground/vault_atrium_middle)
 "bFJ" = (
 /obj/structure/ms13/rug/fancy,
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 8
 	},
 /turf/open/floor/wood/ms13/common,
@@ -2602,7 +2602,7 @@
 /obj/structure/ms13/rug/fancy{
 	dir = 1
 	},
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 10
 	},
 /turf/open/floor/wood/ms13/wide,
@@ -3123,7 +3123,7 @@
 /turf/open/floor/wood/ms13/carpet/shaggy/green,
 /area/ms13/town)
 "bYv" = (
-/obj/structure/fluff/ms13/trash/papers,
+/obj/structure/ms13/trash/papers,
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 6
 	},
@@ -3395,7 +3395,7 @@
 /area/ms13/town)
 "chS" = (
 /obj/structure/table/ms13/wood,
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 1
 	},
 /turf/open/floor/wood/ms13/carpet/green,
@@ -3497,7 +3497,7 @@
 /turf/open/floor/plating/ms13/ground/road,
 /area/ms13/underground/tunnel)
 "ckn" = (
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 8
 	},
 /turf/open/floor/wood/ms13/wide,
@@ -3565,7 +3565,7 @@
 /obj/structure/chair/office/ms13/red{
 	dir = 4
 	},
-/obj/structure/fluff/ms13/trash/papers,
+/obj/structure/ms13/trash/papers,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "cnh" = (
@@ -3712,7 +3712,7 @@
 /turf/open/floor/wood/ms13/carpet,
 /area/ms13/town)
 "csN" = (
-/obj/structure/fluff/ms13/barrel/single/toxic/one,
+/obj/structure/ms13/barrel/single/toxic/one,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/underground/tunnel/maintenance)
 "ctn" = (
@@ -3997,7 +3997,7 @@
 /obj/structure/chair/office/ms13/blue{
 	dir = 8
 	},
-/obj/structure/fluff/ms13/trash/papers,
+/obj/structure/ms13/trash/papers,
 /turf/open/floor/wood/ms13/common,
 /area/ms13/town)
 "cCW" = (
@@ -4628,7 +4628,7 @@
 /turf/open/floor/plating/ms13/ground/mountain,
 /area/ms13/underground/mountain)
 "cYd" = (
-/obj/structure/fluff/ms13/barrel/single/toxic/four,
+/obj/structure/ms13/barrel/single/toxic/four,
 /turf/open/floor/plating/ms13/ground/road,
 /area/ms13/town)
 "cYe" = (
@@ -5574,7 +5574,7 @@
 /turf/open/floor/ms13/tile/blue/long,
 /area/ms13/town)
 "dCQ" = (
-/obj/structure/fluff/ms13/barrel/double/waste,
+/obj/structure/ms13/barrel/double/waste,
 /turf/open/floor/ms13/concrete,
 /area/ms13/underground/tunnel/maintenance)
 "dDv" = (
@@ -6080,7 +6080,7 @@
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "dSZ" = (
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 5
 	},
 /turf/open/floor/wood/ms13/wide,
@@ -6536,7 +6536,7 @@
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "ehg" = (
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 6
 	},
 /turf/open/floor/wood/ms13/common,
@@ -7167,7 +7167,7 @@
 /turf/open/floor/ms13/tile/full/green,
 /area/ms13/town)
 "ezq" = (
-/obj/structure/fluff/ms13/trash/papers,
+/obj/structure/ms13/trash/papers,
 /obj/effect/spawner/random/ms13/food/trash,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
@@ -7975,7 +7975,7 @@
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "eXi" = (
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 1
 	},
 /obj/structure/chair/comfy/ms13/ergo{
@@ -8020,7 +8020,7 @@
 /turf/open/floor/wood/ms13/mosaic,
 /area/ms13/town)
 "eYf" = (
-/obj/structure/fluff/ms13/barrel/single/toxic/one,
+/obj/structure/ms13/barrel/single/toxic/one,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "eYm" = (
@@ -8132,7 +8132,7 @@
 /turf/open/floor/ms13/tile/large/cafeteria,
 /area/ms13/town)
 "faP" = (
-/obj/structure/fluff/ms13/barrel/single/toxic/two,
+/obj/structure/ms13/barrel/single/toxic/two,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "faS" = (
@@ -8472,7 +8472,7 @@
 /turf/open/floor/ms13/metal,
 /area/ms13/underground/vault_atrium_middle)
 "fld" = (
-/obj/structure/fluff/ms13/trash/papers,
+/obj/structure/ms13/trash/papers,
 /turf/open/floor/wood/ms13/common,
 /area/ms13/town)
 "flq" = (
@@ -8714,7 +8714,7 @@
 /turf/open/floor/ms13/tile/blue,
 /area/ms13/town)
 "frX" = (
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 10
 	},
 /turf/open/floor/ms13/tile/full/navy,
@@ -8788,7 +8788,7 @@
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "ftm" = (
-/obj/structure/fluff/ms13/barrel/single/toxic/four,
+/obj/structure/ms13/barrel/single/toxic/four,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "ftw" = (
@@ -9361,7 +9361,7 @@
 /turf/open/floor/ms13/tile/large/white,
 /area/ms13/town)
 "fMi" = (
-/obj/structure/fluff/ms13/barrel/single/toxic/four,
+/obj/structure/ms13/barrel/single/toxic/four,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/underground/tunnel/maintenance)
 "fMl" = (
@@ -9450,7 +9450,7 @@
 /turf/open/floor/ms13/metal,
 /area/ms13/underground/bos)
 "fPe" = (
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 1;
 	pixel_x = 4;
 	pixel_y = -6
@@ -9458,7 +9458,7 @@
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "fPr" = (
-/obj/structure/fluff/ms13/barrel/triple/waste/two,
+/obj/structure/ms13/barrel/triple/waste/two,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/underground/tunnel/maintenance)
 "fPF" = (
@@ -9535,7 +9535,7 @@
 /turf/open/floor/wood/ms13/mosaic,
 /area/ms13/town)
 "fQV" = (
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 4
 	},
 /turf/open/floor/wood/ms13/mosaic,
@@ -13714,7 +13714,7 @@
 /area/ms13/town)
 "iba" = (
 /obj/structure/table/ms13/metal,
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 1
 	},
 /turf/open/floor/wood/ms13/wide,
@@ -13866,7 +13866,7 @@
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "ieR" = (
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 10
 	},
 /turf/open/floor/wood/ms13/carpet,
@@ -14174,7 +14174,7 @@
 /obj/machinery/door/poddoor/shutters/ms13/horizontal/indestructible/red/left/pre_open{
 	id = "bank_shutters"
 	},
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 1
 	},
 /turf/open/floor/wood/ms13/mosaic,
@@ -14307,7 +14307,7 @@
 /turf/open/floor/wood/ms13/common,
 /area/ms13/town)
 "irw" = (
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 9
 	},
 /turf/open/floor/wood/ms13/mosaic,
@@ -14346,7 +14346,7 @@
 /turf/open/floor/wood/ms13/carpet,
 /area/ms13/town)
 "isy" = (
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 10
 	},
 /obj/item/paper/ms13/prewritten/mayor_password,
@@ -14414,7 +14414,7 @@
 /turf/open/floor/ms13/concrete,
 /area/ms13/underground/tunnel/maintenance)
 "itY" = (
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 4
 	},
 /obj/structure/chair/ms13/wood{
@@ -14526,7 +14526,7 @@
 /turf/open/floor/wood/ms13/mosaic,
 /area/ms13/town)
 "ixR" = (
-/obj/structure/fluff/ms13/trash/papers,
+/obj/structure/ms13/trash/papers,
 /turf/open/floor/wood/ms13/mosaic,
 /area/ms13/town)
 "ixX" = (
@@ -14935,7 +14935,7 @@
 /turf/open/floor/wood/ms13/common,
 /area/ms13/town)
 "iLj" = (
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 10
 	},
 /obj/structure/ms13/rug/fancy,
@@ -15339,7 +15339,7 @@
 /obj/machinery/light/ms13{
 	dir = 8
 	},
-/obj/structure/fluff/ms13/barrel/single/grey/two,
+/obj/structure/ms13/barrel/single/grey/two,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "iXv" = (
@@ -15443,7 +15443,7 @@
 /turf/closed/wall/ms13/vault,
 /area/ms13/underground/vault_atrium_middle)
 "iZz" = (
-/obj/structure/fluff/ms13/barrel/single/redalt,
+/obj/structure/ms13/barrel/single/redalt,
 /turf/open/floor/ms13/concrete/small,
 /area/ms13/town)
 "iZV" = (
@@ -15793,7 +15793,7 @@
 /obj/structure/chair/office/ms13/red{
 	dir = 1
 	},
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 1
 	},
 /turf/open/floor/wood/ms13/mosaic,
@@ -15946,7 +15946,7 @@
 	dir = 4
 	},
 /obj/structure/ms13/foundation/mosaic,
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 4
 	},
 /turf/open/floor/plating/ms13/ground/mountain,
@@ -16116,7 +16116,7 @@
 /area/ms13/town)
 "jrG" = (
 /obj/structure/ms13/foundation/mosaic/variantfour,
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 10
 	},
 /turf/open/floor/plating/ms13/ground/mountain,
@@ -16450,7 +16450,7 @@
 /obj/structure/chair/office/ms13/red{
 	dir = 1
 	},
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 8
 	},
 /turf/open/floor/wood/ms13/carpet/blue,
@@ -16558,14 +16558,14 @@
 /turf/open/floor/wood/ms13/mosaic,
 /area/ms13/town)
 "jEq" = (
-/obj/structure/fluff/ms13/trash/papers,
+/obj/structure/ms13/trash/papers,
 /obj/machinery/light/ms13{
 	dir = 8
 	},
 /turf/open/floor/wood/ms13/carpet/blue,
 /area/ms13/town)
 "jEv" = (
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 8
 	},
 /turf/open/floor/wood/ms13/carpet/blue,
@@ -16636,7 +16636,7 @@
 /turf/open/openspace/ms13,
 /area/ms13/underground/vault_atrium_middle)
 "jFW" = (
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 9
 	},
 /turf/open/floor/ms13/tile/full/navy,
@@ -18546,7 +18546,7 @@
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "kIu" = (
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 8
 	},
 /obj/machinery/light/ms13{
@@ -19248,7 +19248,7 @@
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "ldM" = (
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 4
 	},
 /turf/open/floor/wood/ms13/wide,
@@ -19570,7 +19570,7 @@
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "lqa" = (
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 10
 	},
 /turf/open/floor/wood/ms13/wide,
@@ -19661,7 +19661,7 @@
 /turf/open/floor/ms13/tile/full/green,
 /area/ms13/town)
 "lsV" = (
-/obj/structure/fluff/ms13/trash/papers,
+/obj/structure/ms13/trash/papers,
 /turf/open/floor/wood/ms13/carpet,
 /area/ms13/town)
 "lua" = (
@@ -20089,7 +20089,7 @@
 /turf/open/floor/ms13/tile/large/cream,
 /area/ms13/supermarket)
 "lHe" = (
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 1
 	},
 /turf/open/floor/wood/ms13/wide,
@@ -20231,7 +20231,7 @@
 /area/ms13/town)
 "lLr" = (
 /obj/structure/ms13/storage/vent,
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 8
 	},
 /turf/open/floor/wood/ms13/wide,
@@ -20377,7 +20377,7 @@
 /area/ms13/town)
 "lSz" = (
 /obj/structure/ms13/wall_decor/clock,
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 9
 	},
 /turf/open/floor/wood/ms13/wide,
@@ -20788,7 +20788,7 @@
 /turf/open/floor/ms13/tile/large/cafeteria,
 /area/ms13/underground/vault_atrium_middle)
 "mej" = (
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 4
 	},
 /turf/open/floor/ms13/concrete/industrial,
@@ -22239,7 +22239,7 @@
 /obj/structure/chair/office/ms13/blue{
 	dir = 1
 	},
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 9
 	},
 /turf/open/floor/ms13/tile/full/navy,
@@ -22917,7 +22917,7 @@
 /area/ms13/town)
 "nwj" = (
 /obj/effect/decal/cleanable/oil/slippery,
-/obj/structure/fluff/ms13/barrel/single/flammable,
+/obj/structure/ms13/barrel/single/flammable,
 /turf/open/floor/ms13/concrete,
 /area/ms13/town)
 "nwn" = (
@@ -23820,7 +23820,7 @@
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "oau" = (
-/obj/structure/fluff/ms13/ncrflag,
+/obj/structure/ms13/ncrflag,
 /turf/open/floor/plating/ms13/ground/snow,
 /area/ms13/snow/lightforest)
 "oaA" = (
@@ -23864,7 +23864,7 @@
 /turf/open/floor/plating/ms13/ground/mountain,
 /area/ms13/underground/mountain)
 "obJ" = (
-/obj/structure/fluff/ms13/mammoth_sign,
+/obj/structure/ms13/mammoth_sign,
 /turf/open/floor/plating/ms13/ground/snow,
 /area/ms13)
 "obM" = (
@@ -24436,7 +24436,7 @@
 /turf/closed/wall/ms13/scrap/blue,
 /area/ms13/ncr)
 "opL" = (
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 1
 	},
 /turf/open/floor/wood/ms13/wide,
@@ -24469,7 +24469,7 @@
 /turf/open/floor/ms13/tile/large/cafeteria,
 /area/ms13/supermarket)
 "oqH" = (
-/obj/structure/fluff/ms13/trash/papers,
+/obj/structure/ms13/trash/papers,
 /obj/structure/chair/ms13/wood,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
@@ -25148,7 +25148,7 @@
 /turf/open/floor/ms13/tile/long,
 /area/ms13/supermarket)
 "oPw" = (
-/obj/structure/fluff/ms13/trash/papers,
+/obj/structure/ms13/trash/papers,
 /obj/item/ms13/fluff/ruined_book,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
@@ -25259,7 +25259,7 @@
 /turf/open/floor/ms13/tile/large/cafeteria,
 /area/ms13/town)
 "oVq" = (
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 9
 	},
 /turf/open/floor/wood/ms13/wide,
@@ -25387,7 +25387,7 @@
 /turf/open/floor/ms13/tile,
 /area/ms13/town)
 "oXU" = (
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 6
 	},
 /turf/open/floor/wood/ms13/carpet/green,
@@ -26067,7 +26067,7 @@
 	},
 /area/ms13/underground/vault_atrium_middle)
 "pFO" = (
-/obj/structure/fluff/ms13/barrel/single/toxic/two,
+/obj/structure/ms13/barrel/single/toxic/two,
 /turf/open/floor/ms13/concrete/small,
 /area/ms13/underground/tunnel/maintenance)
 "pFZ" = (
@@ -26646,7 +26646,7 @@
 /obj/machinery/ms13/terminal/wasteland{
 	dir = 8
 	},
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 1;
 	pixel_x = 4;
 	pixel_y = -16
@@ -26751,7 +26751,7 @@
 /turf/open/floor/plating/ms13/ground/road,
 /area/ms13)
 "qtf" = (
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 5
 	},
 /turf/open/floor/wood/ms13/mosaic,
@@ -26918,7 +26918,7 @@
 /turf/open/floor/ms13/tile/long,
 /area/ms13/supermarket)
 "qFZ" = (
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 8
 	},
 /turf/open/floor/ms13/concrete/industrial,
@@ -28827,7 +28827,7 @@
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "sSV" = (
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 10
 	},
 /turf/open/floor/wood/ms13/carpet/shaggy/green,
@@ -29726,7 +29726,7 @@
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "tSB" = (
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 8
 	},
 /turf/open/floor/wood/ms13/carpet/green,
@@ -30878,7 +30878,7 @@
 /turf/open/floor/wood/ms13/carpet/shaggy,
 /area/ms13/town)
 "vrf" = (
-/obj/structure/fluff/ms13/barrel/single/toxic/three,
+/obj/structure/ms13/barrel/single/toxic/three,
 /turf/open/floor/plating/ms13/ground/road,
 /area/ms13/town)
 "vrx" = (
@@ -32165,7 +32165,7 @@
 /turf/open/floor/wood/ms13/common,
 /area/ms13/town)
 "xax" = (
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 1
 	},
 /turf/open/floor/wood/ms13/mosaic,
@@ -32325,7 +32325,7 @@
 /area/ms13/town)
 "xiz" = (
 /obj/structure/table/ms13/metal,
-/obj/structure/fluff/ms13/trash/papers,
+/obj/structure/ms13/trash/papers,
 /turf/open/floor/wood/ms13/common,
 /area/ms13/ncr)
 "xiV" = (
@@ -32830,7 +32830,7 @@
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "xKP" = (
-/obj/structure/fluff/ms13/trash/papers,
+/obj/structure/ms13/trash/papers,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "xKZ" = (
@@ -33107,7 +33107,7 @@
 /turf/open/floor/wood/ms13/mosaic,
 /area/ms13/town)
 "yaI" = (
-/obj/structure/fluff/ms13/barrel/double/red,
+/obj/structure/ms13/barrel/double/red,
 /turf/open/floor/ms13/concrete,
 /area/ms13/town)
 "ybr" = (

--- a/_maps/map_files/Mammoth/Mammoth_above.dmm
+++ b/_maps/map_files/Mammoth/Mammoth_above.dmm
@@ -25,7 +25,7 @@
 /area/ms13/town)
 "aad" = (
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 1
 	},
 /turf/open/floor/wood/ms13/wide,
@@ -148,7 +148,7 @@
 /area/ms13)
 "aaC" = (
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/mountain,
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 10
 	},
 /turf/open/floor/ms13/metal,
@@ -187,7 +187,7 @@
 /turf/open/floor/wood/ms13/common,
 /area/ms13/town)
 "aaI" = (
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 10
 	},
 /turf/open/floor/wood/ms13/mosaic,
@@ -301,7 +301,7 @@
 /area/ms13/underground/tunnel/maintenance)
 "abe" = (
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 4
 	},
 /turf/open/floor/wood/ms13/mosaic,
@@ -1111,7 +1111,7 @@
 /area/ms13/town)
 "adX" = (
 /obj/structure/chair/comfy/ms13/ergo,
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 8
 	},
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
@@ -1282,7 +1282,7 @@
 /area/ms13/town)
 "aeE" = (
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 1
 	},
 /turf/open/floor/wood/ms13/carpet,
@@ -2195,7 +2195,7 @@
 /area/ms13/town)
 "aic" = (
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 9
 	},
 /turf/open/floor/wood/ms13/common,
@@ -2622,7 +2622,7 @@
 /area/ms13/town)
 "ajJ" = (
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 4
 	},
 /turf/open/floor/wood/ms13/carpet,
@@ -2655,7 +2655,7 @@
 /turf/open/floor/ms13/tile/full/navy,
 /area/ms13/town)
 "ajQ" = (
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 9
 	},
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
@@ -2714,7 +2714,7 @@
 /area/ms13/town)
 "ajY" = (
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 1;
 	pixel_x = 4;
 	pixel_y = 4
@@ -3333,7 +3333,7 @@
 /area/ms13/town)
 "amw" = (
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/mountain,
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 9
 	},
 /turf/open/floor/ms13/metal,
@@ -3501,7 +3501,7 @@
 /turf/open/floor/wood/ms13/mosaic,
 /area/ms13/town)
 "ana" = (
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 10
 	},
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
@@ -3950,7 +3950,7 @@
 /area/ms13/underground/bos)
 "aoO" = (
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 4
 	},
 /turf/open/floor/ms13/concrete/industrial,
@@ -4051,7 +4051,7 @@
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "aph" = (
-/obj/structure/fluff/ms13/trash/papers,
+/obj/structure/ms13/trash/papers,
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /turf/open/floor/ms13/tile,
 /area/ms13/town)
@@ -4485,7 +4485,7 @@
 /area/ms13/town)
 "aqY" = (
 /obj/structure/table/ms13/wood,
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 1
 	},
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
@@ -4500,7 +4500,7 @@
 /obj/structure/ms13/foundation/wide/varianttwo{
 	dir = 1
 	},
-/obj/structure/fluff/ms13/trash/papers,
+/obj/structure/ms13/trash/papers,
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /turf/open/openspace/ms13,
 /area/ms13/town)
@@ -5004,7 +5004,7 @@
 	dir = 8
 	},
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/mountain,
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 1
 	},
 /turf/open/floor/ms13/metal,
@@ -5208,7 +5208,7 @@
 /obj/machinery/light/ms13/broken{
 	dir = 1
 	},
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 10
 	},
 /turf/open/floor/ms13/tile/large/cream,
@@ -5380,7 +5380,7 @@
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/ncr)
 "auJ" = (
-/obj/structure/fluff/ms13/trash/papers,
+/obj/structure/ms13/trash/papers,
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /turf/open/floor/wood/ms13/mosaic,
 /area/ms13/town)
@@ -5719,7 +5719,7 @@
 	dir = 1
 	},
 /obj/structure/ms13/rug/fancy,
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 1
 	},
 /obj/item/ms13/fluff/ruined_book{
@@ -5800,7 +5800,7 @@
 /turf/open/floor/ms13/concrete,
 /area/ms13/town)
 "awo" = (
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 4
 	},
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
@@ -5896,7 +5896,7 @@
 /turf/open/openspace/ms13,
 /area/ms13/underground/tunnel/maintenance)
 "awK" = (
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 4
 	},
 /obj/machinery/light/ms13/bulb{
@@ -6748,7 +6748,7 @@
 /turf/open/floor/ms13/metal,
 /area/ms13/underground/tunnel/maintenance)
 "aAc" = (
-/obj/structure/fluff/ms13/trash/papers,
+/obj/structure/ms13/trash/papers,
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /obj/machinery/light/ms13/bulb,
 /turf/open/floor/wood/ms13/common,
@@ -7038,7 +7038,7 @@
 "aBg" = (
 /obj/structure/table/ms13/wood,
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 1
 	},
 /turf/open/floor/wood/ms13/carpet,
@@ -7397,7 +7397,7 @@
 "aCE" = (
 /obj/structure/table/ms13/metal,
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/mountain,
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 1
 	},
 /turf/open/floor/ms13/metal,
@@ -7962,7 +7962,7 @@
 /area/ms13/town)
 "aEK" = (
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 10
 	},
 /turf/open/floor/wood/ms13/mosaic,
@@ -8023,7 +8023,7 @@
 /area/ms13/underground/tunnel/maintenance)
 "aEZ" = (
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/mountain,
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 1
 	},
 /turf/open/floor/ms13/metal,
@@ -8183,7 +8183,7 @@
 /area/ms13/town)
 "aFF" = (
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
-/obj/structure/fluff/ms13/trash/papers,
+/obj/structure/ms13/trash/papers,
 /turf/open/floor/wood/ms13/carpet,
 /area/ms13/town)
 "aFG" = (
@@ -8556,7 +8556,7 @@
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "aHd" = (
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 4
 	},
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
@@ -8689,7 +8689,7 @@
 /turf/open/floor/ms13/concrete,
 /area/ms13/town)
 "aHF" = (
-/obj/structure/fluff/ms13/trash/papers,
+/obj/structure/ms13/trash/papers,
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/mountain,
 /turf/open/floor/ms13/metal,
 /area/ms13/underground/tunnel/maintenance)
@@ -9014,7 +9014,7 @@
 /turf/open/floor/wood/ms13/mosaic,
 /area/ms13/town)
 "aIX" = (
-/obj/structure/fluff/ms13/trash/papers,
+/obj/structure/ms13/trash/papers,
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
@@ -9099,7 +9099,7 @@
 /area/ms13/underground/tunnel/maintenance)
 "aJq" = (
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 1
 	},
 /turf/open/floor/ms13/tile/brown/big,
@@ -9431,7 +9431,7 @@
 /area/ms13/town)
 "aKL" = (
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 9
 	},
 /turf/open/floor/wood/ms13/mosaic,
@@ -9573,7 +9573,7 @@
 /turf/open/floor/ms13/metal/plate,
 /area/ms13/underground/tunnel/maintenance)
 "aLj" = (
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 10
 	},
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
@@ -9628,7 +9628,7 @@
 /turf/open/floor/plating/ms13/roof,
 /area/ms13/town)
 "aLw" = (
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 9
 	},
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
@@ -9746,7 +9746,7 @@
 /area/ms13/town)
 "aLV" = (
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/mountain,
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 4
 	},
 /turf/open/floor/ms13/metal,
@@ -10388,7 +10388,7 @@
 /area/ms13/town)
 "aOF" = (
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/mountain,
-/obj/structure/fluff/ms13/barrel/single/hazard/one,
+/obj/structure/ms13/barrel/single/hazard/one,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/underground/tunnel/maintenance)
 "aOG" = (
@@ -10416,7 +10416,7 @@
 /obj/structure/table/ms13/no_smooth/large/metal/desk{
 	dir = 4
 	},
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 1;
 	pixel_x = 4;
 	pixel_y = 4
@@ -11330,7 +11330,7 @@
 /turf/open/floor/ms13/tile/brown,
 /area/ms13/town)
 "aSh" = (
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 9
 	},
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
@@ -11368,7 +11368,7 @@
 /obj/structure/chair/comfy/ms13/ergo{
 	dir = 8
 	},
-/obj/structure/fluff/ms13/trash/papers,
+/obj/structure/ms13/trash/papers,
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
@@ -11382,7 +11382,7 @@
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "aSs" = (
-/obj/structure/fluff/ms13/trash/papers,
+/obj/structure/ms13/trash/papers,
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /turf/open/floor/ms13/tile/long,
 /area/ms13/town)
@@ -11523,7 +11523,7 @@
 /turf/open/floor/ms13/concrete,
 /area/ms13/town)
 "aSV" = (
-/obj/structure/fluff/ms13/trash/papers,
+/obj/structure/ms13/trash/papers,
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /obj/effect/spawner/random/ms13/medical/highrandom,
 /obj/structure/closet/ms13/wall/firstaid,
@@ -11637,7 +11637,7 @@
 /turf/open/floor/ms13/metal,
 /area/ms13/underground/tunnel/maintenance)
 "aTn" = (
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 5
 	},
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
@@ -11935,7 +11935,7 @@
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "aUA" = (
-/obj/structure/fluff/ms13/trash/papers,
+/obj/structure/ms13/trash/papers,
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /turf/open/floor/ms13/tile/large/cream,
 /area/ms13/town)
@@ -12130,7 +12130,7 @@
 /area/ms13/ncr)
 "aVj" = (
 /obj/structure/table/ms13/wood,
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 1;
 	pixel_x = 4;
 	pixel_y = -6
@@ -12429,7 +12429,7 @@
 /area/ms13/ncr)
 "aWy" = (
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 8
 	},
 /turf/open/floor/ms13/concrete/industrial,
@@ -12666,7 +12666,7 @@
 /area/ms13/town)
 "aXv" = (
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 10
 	},
 /turf/open/floor/wood/ms13/carpet/shaggy,
@@ -13163,7 +13163,7 @@
 /area/ms13/underground/mountain)
 "aZn" = (
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 5
 	},
 /obj/machinery/light/ms13/bulb{
@@ -13345,7 +13345,7 @@
 /turf/open/floor/ms13/metal/plate,
 /area/ms13/underground/tunnel/maintenance)
 "aZU" = (
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 8
 	},
 /turf/open/floor/ms13/concrete/industrial,
@@ -13408,7 +13408,7 @@
 /area/ms13/town)
 "bgf" = (
 /obj/structure/table/ms13/metal/grate,
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 1
 	},
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
@@ -13532,10 +13532,10 @@
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "bvr" = (
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 8
 	},
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 4
 	},
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
@@ -13834,7 +13834,7 @@
 /area/ms13/town)
 "cei" = (
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 6
 	},
 /turf/open/floor/wood/ms13/mosaic,
@@ -15043,7 +15043,7 @@
 /area/ms13/town)
 "eCW" = (
 /obj/item/ammo_casing/ms13/spent,
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 5
 	},
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
@@ -15370,7 +15370,7 @@
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "ftB" = (
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 5
 	},
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
@@ -15493,7 +15493,7 @@
 /area/ms13/town)
 "fFM" = (
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 6
 	},
 /turf/open/floor/wood/ms13/carpet,
@@ -15775,7 +15775,7 @@
 /area/ms13/town)
 "glk" = (
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 4
 	},
 /turf/open/floor/wood/ms13/wide,
@@ -16108,7 +16108,7 @@
 /obj/structure/table/ms13/no_smooth/large/wood/desk/alt{
 	dir = 4
 	},
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 1;
 	pixel_x = 4;
 	pixel_y = 4
@@ -16154,7 +16154,7 @@
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "hcG" = (
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 8
 	},
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
@@ -16248,7 +16248,7 @@
 /area/ms13/town)
 "hnp" = (
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 1
 	},
 /turf/open/floor/ms13/tile/long,
@@ -16319,7 +16319,7 @@
 /turf/open/floor/plating/ms13/roof/metal/rusty,
 /area/ms13/town)
 "hva" = (
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 1
 	},
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
@@ -16692,7 +16692,7 @@
 	dir = 8
 	},
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 8
 	},
 /turf/open/floor/ms13/concrete/industrial,
@@ -16913,7 +16913,7 @@
 /turf/open/floor/ms13/tile/long,
 /area/ms13/town)
 "iLx" = (
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 5
 	},
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
@@ -16947,7 +16947,7 @@
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "iNr" = (
-/obj/structure/fluff/ms13/trash/papers,
+/obj/structure/ms13/trash/papers,
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /turf/open/floor/wood/ms13/carpet/shaggy/green,
 /area/ms13/supermarket)
@@ -17648,7 +17648,7 @@
 /turf/open/openspace/ms13,
 /area/ms13/underground/mountain)
 "kkt" = (
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 4
 	},
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
@@ -18311,10 +18311,10 @@
 /turf/open/floor/wood/ms13/carpet/shaggy/green,
 /area/ms13/town)
 "ltA" = (
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 4
 	},
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 8
 	},
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/mountain,
@@ -18462,7 +18462,7 @@
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "lLf" = (
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 6
 	},
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
@@ -18906,7 +18906,7 @@
 /area/ms13/town)
 "mJt" = (
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 1
 	},
 /turf/open/floor/wood/ms13/carpet/shaggy,
@@ -19323,7 +19323,7 @@
 /area/ms13/town)
 "nEc" = (
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 10
 	},
 /turf/open/floor/ms13/tile/long,
@@ -19745,7 +19745,7 @@
 /obj/machinery/light/ms13{
 	dir = 8
 	},
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 1;
 	pixel_x = 4;
 	pixel_y = 4
@@ -19808,7 +19808,7 @@
 /obj/structure/table/ms13/no_smooth/large/wood/desk{
 	dir = 4
 	},
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 1
 	},
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
@@ -19878,7 +19878,7 @@
 /area/ms13/town)
 "oIs" = (
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 5
 	},
 /turf/open/floor/ms13/tile/large/cream,
@@ -20233,7 +20233,7 @@
 	pixel_y = 14
 	},
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 5
 	},
 /obj/effect/spawner/random/ms13/currency/mammoth/prewar/lowrandom,
@@ -20310,7 +20310,7 @@
 /area/ms13/ncr)
 "pBL" = (
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 9
 	},
 /turf/open/floor/wood/ms13/wide,
@@ -20342,7 +20342,7 @@
 /area/ms13/town)
 "pEk" = (
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 9
 	},
 /turf/open/floor/ms13/concrete/industrial,
@@ -20446,7 +20446,7 @@
 /turf/open/floor/wood/ms13/carpet/shaggy,
 /area/ms13/town)
 "pNI" = (
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 6
 	},
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
@@ -20564,7 +20564,7 @@
 /area/ms13/town)
 "qgv" = (
 /obj/structure/noticeboard/ms13/cork,
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 8
 	},
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
@@ -20792,7 +20792,7 @@
 /area/ms13/town)
 "qHK" = (
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
-/obj/structure/fluff/ms13/trash/papers,
+/obj/structure/ms13/trash/papers,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "qJA" = (
@@ -20988,7 +20988,7 @@
 /turf/open/floor/wood/ms13/mosaic,
 /area/ms13/town)
 "reR" = (
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 10
 	},
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
@@ -21424,7 +21424,7 @@
 /area/ms13/supermarket)
 "rZx" = (
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
-/obj/structure/fluff/ms13/trash/papers,
+/obj/structure/ms13/trash/papers,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "saa" = (
@@ -21435,7 +21435,7 @@
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "sde" = (
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 6
 	},
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
@@ -21511,7 +21511,7 @@
 /area/ms13/town)
 "sjq" = (
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 8
 	},
 /turf/open/floor/ms13/tile/large/cream,
@@ -21658,7 +21658,7 @@
 /area/ms13/town)
 "syO" = (
 /obj/structure/table/ms13/wood,
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 1;
 	pixel_x = 4;
 	pixel_y = 4
@@ -21732,7 +21732,7 @@
 /area/ms13/town)
 "sNd" = (
 /obj/structure/table/ms13/no_smooth/large/wood/desk,
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 1;
 	pixel_x = 4;
 	pixel_y = 4
@@ -21843,7 +21843,7 @@
 /obj/structure/ms13/barricade{
 	dir = 8
 	},
-/obj/structure/fluff/ms13/trash/papers,
+/obj/structure/ms13/trash/papers,
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /turf/open/floor/wood/ms13/carpet,
 /area/ms13/town)
@@ -22231,7 +22231,7 @@
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "tRa" = (
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 4
 	},
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
@@ -22292,7 +22292,7 @@
 /area/ms13/town)
 "tVo" = (
 /obj/structure/table/ms13/wood,
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 1;
 	pixel_x = 4;
 	pixel_y = 4
@@ -22323,7 +22323,7 @@
 /area/ms13/town)
 "tYn" = (
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
-/obj/structure/fluff/ms13/trash/papers,
+/obj/structure/ms13/trash/papers,
 /turf/open/floor/ms13/tile/long,
 /area/ms13/town)
 "tYA" = (
@@ -22374,7 +22374,7 @@
 /turf/open/floor/wood/ms13/carpet,
 /area/ms13/town)
 "ubw" = (
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 10
 	},
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
@@ -22852,7 +22852,7 @@
 /area/ms13/town)
 "vkR" = (
 /obj/structure/table/ms13/metal/grate,
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 1
 	},
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
@@ -23037,8 +23037,8 @@
 	pixel_x = 6;
 	pixel_y = 8
 	},
-/obj/structure/fluff/ms13/trash/papers,
-/obj/structure/fluff/ms13/trash/papers,
+/obj/structure/ms13/trash/papers,
+/obj/structure/ms13/trash/papers,
 /obj/structure/bed/ms13/mattress/old,
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /turf/open/floor/wood/ms13/common,
@@ -23178,10 +23178,10 @@
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "wgA" = (
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 1
 	},
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 1;
 	pixel_x = 4;
 	pixel_y = 4
@@ -23382,7 +23382,7 @@
 /turf/open/floor/ms13/tile/large/cream,
 /area/ms13/town)
 "wAD" = (
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 8
 	},
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,

--- a/_maps/map_files/Mammoth/Mammoth_below.dmm
+++ b/_maps/map_files/Mammoth/Mammoth_below.dmm
@@ -3,7 +3,7 @@
 /turf/open/floor/ms13/concrete/industrial/walkway,
 /area/ms13/town)
 "aad" = (
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 10
 	},
 /turf/open/floor/ms13/concrete,
@@ -1180,10 +1180,10 @@
 /turf/open/ms13/water/sewer/shallow,
 /area/ms13/underground/mountain)
 "aeT" = (
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 4
 	},
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 9
 	},
 /turf/open/floor/ms13/concrete/industrial,
@@ -3194,7 +3194,7 @@
 /turf/open/floor/plating/ms13/ground/mountain,
 /area/ms13/underground/vault_atrium_lower)
 "anj" = (
-/obj/structure/fluff/ms13/barrel/quadruple/red/two,
+/obj/structure/ms13/barrel/quadruple/red/two,
 /turf/open/floor/ms13/tile/full/green,
 /area/ms13/underground/army_bunker)
 "anm" = (
@@ -3752,7 +3752,7 @@
 /turf/open/floor/ms13/concrete/industrial/alt,
 /area/ms13/town)
 "apK" = (
-/obj/structure/fluff/ms13/barrel/double/waste,
+/obj/structure/ms13/barrel/double/waste,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/underground/underground_town)
 "apL" = (
@@ -4110,7 +4110,7 @@
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/underground/army_bunker)
 "aro" = (
-/obj/structure/fluff/ms13/barrel/single/toxic/four,
+/obj/structure/ms13/barrel/single/toxic/four,
 /turf/open/floor/ms13/metal,
 /area/ms13/underground/enclave_base)
 "arp" = (
@@ -6416,7 +6416,7 @@
 /obj/effect/turf_decal/trimline/yellow/line{
 	dir = 4
 	},
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 8
 	},
 /turf/open/floor/ms13/concrete/industrial,
@@ -7634,7 +7634,7 @@
 /turf/open/floor/ms13/tile/navy,
 /area/ms13/underground/enclave_base)
 "aGs" = (
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 5
 	},
 /turf/open/floor/ms13/tile/blue/long,
@@ -8735,7 +8735,7 @@
 "aLf" = (
 /obj/structure/table/ms13/wood,
 /obj/effect/spawner/random/ms13/melee/unique,
-/obj/structure/fluff/ms13/trash/papers,
+/obj/structure/ms13/trash/papers,
 /turf/open/floor/wood/ms13/carpet/green,
 /area/ms13/town)
 "aLh" = (
@@ -10514,7 +10514,7 @@
 /turf/open/floor/ms13/sewer,
 /area/ms13/underground/subway)
 "aSK" = (
-/obj/structure/fluff/ms13/barrel/single/toxic/four,
+/obj/structure/ms13/barrel/single/toxic/four,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/underground/underground_town)
 "aSL" = (
@@ -11235,7 +11235,7 @@
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/underground/underground_town)
 "aVT" = (
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 1;
 	pixel_x = 4;
 	pixel_y = -6
@@ -12022,7 +12022,7 @@
 /turf/open/floor/ms13/concrete,
 /area/ms13/underground/underground_town)
 "aZm" = (
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 9
 	},
 /turf/open/floor/ms13/concrete/industrial,
@@ -12262,7 +12262,7 @@
 /area/ms13/town)
 "bgR" = (
 /obj/machinery/light/ms13,
-/obj/structure/fluff/ms13/barrel/single/toxic/one,
+/obj/structure/ms13/barrel/single/toxic/one,
 /turf/open/floor/ms13/metal,
 /area/ms13/underground/enclave_base)
 "bhy" = (
@@ -12290,7 +12290,7 @@
 /turf/open/ms13/water/sewer/medium,
 /area/ms13/underground/sewer)
 "blW" = (
-/obj/structure/fluff/ms13/barrel/triple/waste,
+/obj/structure/ms13/barrel/triple/waste,
 /turf/open/floor/plating/ms13/ground/mountain,
 /area/ms13/underground/mountain)
 "bmE" = (
@@ -12443,7 +12443,7 @@
 /turf/open/floor/ms13/sewer,
 /area/ms13/underground/sewer)
 "bGn" = (
-/obj/structure/fluff/ms13/barrel/single/redalt/three,
+/obj/structure/ms13/barrel/single/redalt/three,
 /turf/open/floor/plating/ms13/ground/mountain,
 /area/ms13/underground/mountain)
 "bGp" = (
@@ -12494,7 +12494,7 @@
 /turf/open/floor/ms13/metal,
 /area/ms13/town)
 "bPt" = (
-/obj/structure/fluff/ms13/barrel/triple/waste/two,
+/obj/structure/ms13/barrel/triple/waste/two,
 /turf/open/floor/plating/ms13/ground/mountain,
 /area/ms13/underground/mountain)
 "bPM" = (
@@ -12505,7 +12505,7 @@
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "bRZ" = (
-/obj/structure/fluff/ms13/barrel/single/toxic/three,
+/obj/structure/ms13/barrel/single/toxic/three,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/underground/underground_town)
 "bSd" = (
@@ -12604,7 +12604,7 @@
 /turf/open/floor/ms13/tile/navy,
 /area/ms13/town)
 "cfy" = (
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 5
 	},
 /turf/open/floor/wood/ms13/wide,
@@ -12650,7 +12650,7 @@
 /turf/open/floor/plating/ms13/ground/mountain,
 /area/ms13/underground/mountain)
 "cld" = (
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 6
 	},
 /turf/open/floor/ms13/concrete,
@@ -12760,7 +12760,7 @@
 /turf/open/floor/ms13/sewer,
 /area/ms13/underground/underground_town)
 "cyt" = (
-/obj/structure/fluff/ms13/trash/papers,
+/obj/structure/ms13/trash/papers,
 /mob/living/basic/ms13/ghoul/radioactive,
 /turf/open/floor/ms13/tile/blue/long,
 /area/ms13/town)
@@ -12826,7 +12826,7 @@
 /turf/open/floor/ms13/concrete,
 /area/ms13/underground/bos)
 "cKc" = (
-/obj/structure/fluff/ms13/barrel/single/toxic/two,
+/obj/structure/ms13/barrel/single/toxic/two,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/underground/underground_town)
 "cKF" = (
@@ -13300,7 +13300,7 @@
 /turf/open/floor/ms13/concrete,
 /area/ms13/underground/subway)
 "dTu" = (
-/obj/structure/fluff/ms13/barrel/single/waste/one,
+/obj/structure/ms13/barrel/single/waste/one,
 /turf/open/floor/plating/ms13/ground/mountain,
 /area/ms13/underground/mountain)
 "dTJ" = (
@@ -13372,7 +13372,7 @@
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/underground/underground_town)
 "edM" = (
-/obj/structure/fluff/ms13/barrel/single/toxic/three,
+/obj/structure/ms13/barrel/single/toxic/three,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/underground/underground_town)
 "een" = (
@@ -13721,7 +13721,7 @@
 /turf/open/floor/ms13/concrete/bricks,
 /area/ms13/underground/underground_town)
 "fkF" = (
-/obj/structure/fluff/ms13/barrel/double/waste,
+/obj/structure/ms13/barrel/double/waste,
 /turf/open/floor/plating/ms13/ground/mountain,
 /area/ms13/underground/mountain)
 "fkY" = (
@@ -13963,7 +13963,7 @@
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "geV" = (
-/obj/structure/fluff/ms13/barrel/single/hazard,
+/obj/structure/ms13/barrel/single/hazard,
 /turf/open/floor/ms13/metal/walkway,
 /area/ms13/town)
 "gfp" = (
@@ -14406,7 +14406,7 @@
 /turf/open/ms13/water/sewer/medium,
 /area/ms13/underground/sewer)
 "hDq" = (
-/obj/structure/fluff/ms13/barrel/quadruple/yellow,
+/obj/structure/ms13/barrel/quadruple/yellow,
 /turf/open/floor/plating/ms13/ground/mountain,
 /area/ms13/underground/mountain)
 "hDw" = (
@@ -14549,7 +14549,7 @@
 /turf/open/floor/ms13/concrete/bricks,
 /area/ms13/underground/underground_town)
 "hVp" = (
-/obj/structure/fluff/ms13/barrel/quadruple/red/two,
+/obj/structure/ms13/barrel/quadruple/red/two,
 /turf/open/floor/plating/ms13/ground/mountain,
 /area/ms13/underground/mountain)
 "hVK" = (
@@ -14560,7 +14560,7 @@
 /turf/open/floor/ms13/metal,
 /area/ms13/underground/enclave_base)
 "hWg" = (
-/obj/structure/fluff/ms13/barrel/single/toxic/four,
+/obj/structure/ms13/barrel/single/toxic/four,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/underground/underground_town)
 "hWG" = (
@@ -14590,7 +14590,7 @@
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/underground/underground_town)
 "hZR" = (
-/obj/structure/fluff/ms13/barrel/single/toxic,
+/obj/structure/ms13/barrel/single/toxic,
 /turf/open/floor/plating/ms13/ground/mountain,
 /area/ms13/underground/mountain)
 "iaQ" = (
@@ -14827,7 +14827,7 @@
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/underground/army_bunker)
 "iMG" = (
-/obj/structure/fluff/ms13/trash/papers,
+/obj/structure/ms13/trash/papers,
 /turf/open/floor/ms13/tile/long,
 /area/ms13/town)
 "iNW" = (
@@ -14952,14 +14952,14 @@
 /turf/open/floor/ms13/metal/grate,
 /area/ms13/town)
 "jen" = (
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 1
 	},
 /turf/open/floor/ms13/concrete,
 /area/ms13/town)
 "jfx" = (
 /obj/structure/ms13/foundation/wide/variantthree,
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 9
 	},
 /obj/item/clothing/head/helmet/ms13/sailor,
@@ -15059,7 +15059,7 @@
 /turf/open/floor/ms13/concrete,
 /area/ms13/underground/underground_town)
 "jDq" = (
-/obj/structure/fluff/ms13/barrel/single/label,
+/obj/structure/ms13/barrel/single/label,
 /turf/open/floor/ms13/tile/full/green,
 /area/ms13/underground/army_bunker)
 "jEb" = (
@@ -15413,7 +15413,7 @@
 /turf/open/floor/ms13/concrete,
 /area/ms13/underground/underground_town)
 "kNS" = (
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 8
 	},
 /turf/open/floor/ms13/concrete,
@@ -15518,7 +15518,7 @@
 /turf/closed/wall/ms13/concrete,
 /area/ms13/underground/mountain)
 "kYP" = (
-/obj/structure/fluff/ms13/barrel/quadruple/yellow/one,
+/obj/structure/ms13/barrel/quadruple/yellow/one,
 /turf/open/floor/ms13/tile/full/green,
 /area/ms13/underground/army_bunker)
 "kZg" = (
@@ -15569,7 +15569,7 @@
 /turf/open/floor/plating/ms13/ground/mountain,
 /area/ms13/underground/mountain)
 "ldS" = (
-/obj/structure/fluff/ms13/barrel/triple/yellow/two,
+/obj/structure/ms13/barrel/triple/yellow/two,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "lel" = (
@@ -15689,7 +15689,7 @@
 /turf/open/floor/ms13/concrete,
 /area/ms13/underground/underground_town)
 "lzM" = (
-/obj/structure/fluff/ms13/barrel/single/waste,
+/obj/structure/ms13/barrel/single/waste,
 /turf/open/floor/plating/ms13/ground/mountain,
 /area/ms13/underground/mountain)
 "lAE" = (
@@ -15763,7 +15763,7 @@
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/underground/underground_town)
 "lOR" = (
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 10
 	},
 /turf/open/floor/ms13/concrete/industrial,
@@ -15929,7 +15929,7 @@
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/underground/underground_town)
 "miz" = (
-/obj/structure/fluff/ms13/trash/papers,
+/obj/structure/ms13/trash/papers,
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 9
 	},
@@ -16698,7 +16698,7 @@
 /area/ms13/underground/underground_town)
 "oFe" = (
 /obj/structure/ms13/rug/mat/rubber/single,
-/obj/structure/fluff/ms13/barrel/triple/yellow/one,
+/obj/structure/ms13/barrel/triple/yellow/one,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "oHf" = (
@@ -16724,7 +16724,7 @@
 /obj/structure/chair/office/ms13/green{
 	dir = 8
 	},
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 9
 	},
 /turf/open/floor/ms13/tile/long,
@@ -17497,13 +17497,13 @@
 /turf/open/floor/ms13/concrete,
 /area/ms13/underground/subway)
 "qQW" = (
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 4
 	},
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/underground/sewer)
 "qUC" = (
-/obj/structure/fluff/ms13/barrel/single/redalt,
+/obj/structure/ms13/barrel/single/redalt,
 /turf/open/floor/plating/ms13/ground/mountain,
 /area/ms13/underground/mountain)
 "qYs" = (
@@ -17529,7 +17529,7 @@
 /area/ms13/underground/mountain)
 "rfg" = (
 /obj/structure/table/ms13/metal,
-/obj/structure/fluff/ms13/trash/papers,
+/obj/structure/ms13/trash/papers,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/underground/sewer)
 "rfr" = (
@@ -17658,7 +17658,7 @@
 /turf/open/floor/ms13/concrete,
 /area/ms13/underground/underground_town)
 "rDf" = (
-/obj/structure/fluff/ms13/barrel/double/red,
+/obj/structure/ms13/barrel/double/red,
 /turf/open/floor/plating/ms13/ground/mountain,
 /area/ms13/underground/mountain)
 "rDo" = (
@@ -17860,7 +17860,7 @@
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/underground/army_bunker)
 "sdh" = (
-/obj/structure/fluff/ms13/barrel/single/toxic/two,
+/obj/structure/ms13/barrel/single/toxic/two,
 /turf/open/floor/plating/ms13/ground/mountain,
 /area/ms13/underground/mountain)
 "seC" = (
@@ -18081,7 +18081,7 @@
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/underground/army_bunker)
 "sHS" = (
-/obj/structure/fluff/ms13/barrel/double/grey/two,
+/obj/structure/ms13/barrel/double/grey/two,
 /turf/open/floor/ms13/tile/full/green,
 /area/ms13/underground/army_bunker)
 "sIa" = (
@@ -18481,7 +18481,7 @@
 /turf/open/floor/plating/ms13/ground/mountain,
 /area/ms13/underground/mountain)
 "tTp" = (
-/obj/structure/fluff/ms13/barrel/quadruple/waste,
+/obj/structure/ms13/barrel/quadruple/waste,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/underground/underground_town)
 "tTt" = (
@@ -18842,7 +18842,7 @@
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/underground/mountain)
 "uUH" = (
-/obj/structure/fluff/ms13/trash/papers{
+/obj/structure/ms13/trash/papers{
 	dir = 4
 	},
 /turf/open/floor/ms13/concrete,
@@ -19217,7 +19217,7 @@
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/underground/sewer)
 "wjD" = (
-/obj/structure/fluff/ms13/trash/papers,
+/obj/structure/ms13/trash/papers,
 /turf/open/floor/ms13/concrete,
 /area/ms13/town)
 "wkQ" = (
@@ -19291,7 +19291,7 @@
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/underground/underground_town)
 "wDi" = (
-/obj/structure/fluff/ms13/barrel/triple/yellow/two,
+/obj/structure/ms13/barrel/triple/yellow/two,
 /turf/open/floor/plating/ms13/ground/mountain,
 /area/ms13/underground/mountain)
 "wDn" = (
@@ -19319,7 +19319,7 @@
 /turf/open/floor/ms13/tile/large/cream,
 /area/ms13/underground/sewer)
 "wJm" = (
-/obj/structure/fluff/ms13/barrel/single/warning/two,
+/obj/structure/ms13/barrel/single/warning/two,
 /obj/machinery/light/ms13/bulb/industrial,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)

--- a/_maps/map_files/map_purgatory.dmm
+++ b/_maps/map_files/map_purgatory.dmm
@@ -2173,7 +2173,7 @@
 /area/ms13/underground/mountain)
 "Xn" = (
 /obj/structure/ms13/rug/rubber,
-/obj/structure/fluff/ms13/barrel/quadruple/red/one,
+/obj/structure/ms13/barrel/quadruple/red/one,
 /turf/open/floor/plating/ms13/ground/desertalt,
 /area/space)
 "Xq" = (

--- a/_maps/snapshots/Mammoth_2_17_2022/Mammoth_above_snapshot.dmm
+++ b/_maps/snapshots/Mammoth_2_17_2022/Mammoth_above_snapshot.dmm
@@ -4358,7 +4358,7 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
-/obj/structure/fluff/ms13/barrel/single/flammable/three,
+/obj/structure/ms13/barrel/single/flammable/three,
 /turf/open/floor/ms13/metal,
 /area/ms13/town)
 "anS" = (
@@ -12521,7 +12521,7 @@
 /area/ms13/town)
 "aOF" = (
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/mountain,
-/obj/structure/fluff/ms13/barrel/single/hazard/one,
+/obj/structure/ms13/barrel/single/hazard/one,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/underground/tunnel/maintenance)
 "aOG" = (

--- a/_maps/snapshots/Mammoth_2_17_2022/Mammoth_below_snapshot.dmm
+++ b/_maps/snapshots/Mammoth_2_17_2022/Mammoth_below_snapshot.dmm
@@ -3529,7 +3529,7 @@
 /turf/open/floor/wood/ms13/carpet/shaggy,
 /area/ms13/underground/vault_atrium_lower)
 "anj" = (
-/obj/structure/fluff/ms13/barrel/quadruple/red/two,
+/obj/structure/ms13/barrel/quadruple/red/two,
 /turf/open/floor/ms13/tile/full/green,
 /area/ms13/underground/army_bunker)
 "ank" = (
@@ -4643,7 +4643,7 @@
 /turf/open/floor/ms13/sewer,
 /area/ms13/underground/sewer)
 "aro" = (
-/obj/structure/fluff/ms13/barrel/single/toxic/four,
+/obj/structure/ms13/barrel/single/toxic/four,
 /turf/open/floor/ms13/metal,
 /area/ms13/underground/enclave_base)
 "arp" = (
@@ -10282,7 +10282,7 @@
 /turf/open/floor/wood/ms13/common,
 /area/ms13/underground/underground_town)
 "aMp" = (
-/obj/structure/fluff/ms13/barrel/double/red,
+/obj/structure/ms13/barrel/double/red,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/underground/sewer)
 "aMq" = (
@@ -13982,7 +13982,7 @@
 /area/ms13/underground/sewer)
 "bgR" = (
 /obj/machinery/light/ms13,
-/obj/structure/fluff/ms13/barrel/single/toxic/one,
+/obj/structure/ms13/barrel/single/toxic/one,
 /turf/open/floor/ms13/metal,
 /area/ms13/underground/enclave_base)
 "boq" = (
@@ -14213,7 +14213,7 @@
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/underground/underground_town)
 "fkF" = (
-/obj/structure/fluff/ms13/barrel/double/waste,
+/obj/structure/ms13/barrel/double/waste,
 /turf/open/floor/plating/ms13/ground/mountain,
 /area/ms13/underground/mountain)
 "frP" = (
@@ -14281,7 +14281,7 @@
 /turf/open/floor/ms13/concrete,
 /area/ms13/supermarket/basement)
 "geV" = (
-/obj/structure/fluff/ms13/barrel/single/hazard,
+/obj/structure/ms13/barrel/single/hazard,
 /turf/open/floor/ms13/metal/walkway,
 /area/ms13/town)
 "giU" = (
@@ -14386,7 +14386,7 @@
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/underground/underground_town)
 "hZR" = (
-/obj/structure/fluff/ms13/barrel/single/toxic,
+/obj/structure/ms13/barrel/single/toxic,
 /turf/open/floor/plating/ms13/ground/mountain,
 /area/ms13/underground/mountain)
 "iaY" = (
@@ -14452,7 +14452,7 @@
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/underground/vault_atrium_lower)
 "jDq" = (
-/obj/structure/fluff/ms13/barrel/single/label,
+/obj/structure/ms13/barrel/single/label,
 /turf/open/floor/ms13/tile/full/green,
 /area/ms13/underground/army_bunker)
 "jJZ" = (
@@ -14547,7 +14547,7 @@
 /turf/open/floor/ms13/metal/grate/border,
 /area/ms13/underground/vault_atrium_lower)
 "kYP" = (
-/obj/structure/fluff/ms13/barrel/quadruple/yellow/one,
+/obj/structure/ms13/barrel/quadruple/yellow/one,
 /turf/open/floor/ms13/tile/full/green,
 /area/ms13/underground/army_bunker)
 "kZy" = (
@@ -14842,7 +14842,7 @@
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/underground/underground_town)
 "qbY" = (
-/obj/structure/fluff/ms13/barrel/single/hazard,
+/obj/structure/ms13/barrel/single/hazard,
 /turf/open/floor/ms13/metal/plate,
 /area/ms13/town)
 "qoS" = (
@@ -15003,7 +15003,7 @@
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/underground/underground_town)
 "sHS" = (
-/obj/structure/fluff/ms13/barrel/double/grey/two,
+/obj/structure/ms13/barrel/double/grey/two,
 /turf/open/floor/ms13/tile/full/green,
 /area/ms13/underground/army_bunker)
 "sPd" = (

--- a/_maps/snapshots/Mammoth_2_17_2022/Mammoth_snapshot.dmm
+++ b/_maps/snapshots/Mammoth_2_17_2022/Mammoth_snapshot.dmm
@@ -277,7 +277,7 @@
 /turf/open/floor/ms13/tile/navy,
 /area/ms13/town)
 "ahM" = (
-/obj/structure/fluff/ms13/mammoth_sign,
+/obj/structure/ms13/mammoth_sign,
 /turf/open/floor/plating/ms13/ground/snow,
 /area/ms13/snow/lightforest)
 "aib" = (
@@ -3110,7 +3110,7 @@
 /turf/open/floor/ms13/concrete,
 /area/ms13/town)
 "cAC" = (
-/obj/structure/fluff/ms13/barrel/single/red/three,
+/obj/structure/ms13/barrel/single/red/three,
 /turf/open/floor/ms13/concrete,
 /area/ms13/town)
 "cAF" = (
@@ -3650,7 +3650,7 @@
 /turf/open/floor/wood/ms13/common,
 /area/ms13/tribal_abandoned)
 "cYd" = (
-/obj/structure/fluff/ms13/barrel/single/toxic/four,
+/obj/structure/ms13/barrel/single/toxic/four,
 /turf/open/floor/plating/ms13/ground/road,
 /area/ms13/town)
 "cYe" = (
@@ -4277,7 +4277,7 @@
 /obj/machinery/light/ms13{
 	dir = 8
 	},
-/obj/structure/fluff/ms13/barrel/single/grey/two,
+/obj/structure/ms13/barrel/single/grey/two,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "dAo" = (
@@ -4621,7 +4621,7 @@
 /turf/open/floor/ms13/tile/large/white,
 /area/ms13/town)
 "dRD" = (
-/obj/structure/fluff/ms13/barrel/single/toxic/two,
+/obj/structure/ms13/barrel/single/toxic/two,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "dSe" = (
@@ -6832,7 +6832,7 @@
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "foU" = (
-/obj/structure/fluff/ms13/barrel/double/grey/two,
+/obj/structure/ms13/barrel/double/grey/two,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "foX" = (
@@ -12821,7 +12821,7 @@
 /area/ms13/town)
 "jaz" = (
 /obj/effect/decal/cleanable/oil/slippery,
-/obj/structure/fluff/ms13/barrel/single/flammable,
+/obj/structure/ms13/barrel/single/flammable,
 /turf/open/floor/ms13/concrete,
 /area/ms13/town)
 "jaD" = (
@@ -19929,7 +19929,7 @@
 /turf/open/floor/ms13/tile/full/navy,
 /area/ms13/town)
 "nwj" = (
-/obj/structure/fluff/ms13/barrel/single/redalt,
+/obj/structure/ms13/barrel/single/redalt,
 /turf/open/floor/ms13/concrete/small,
 /area/ms13/town)
 "nwv" = (
@@ -20827,7 +20827,7 @@
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "oau" = (
-/obj/structure/fluff/ms13/ncrflag,
+/obj/structure/ms13/ncrflag,
 /turf/open/floor/plating/ms13/ground/snow,
 /area/ms13/snow/lightforest)
 "oaA" = (
@@ -20857,7 +20857,7 @@
 /turf/open/floor/plating/ms13/ground/snow,
 /area/ms13/snow/lightforest)
 "obJ" = (
-/obj/structure/fluff/ms13/mammoth_sign,
+/obj/structure/ms13/mammoth_sign,
 /turf/open/floor/plating/ms13/ground/snow,
 /area/ms13)
 "obM" = (
@@ -24795,7 +24795,7 @@
 /turf/open/floor/plating/ms13/ground/snow,
 /area/ms13)
 "uOV" = (
-/obj/structure/fluff/ms13/barrel/double/red,
+/obj/structure/ms13/barrel/double/red,
 /turf/open/floor/ms13/concrete,
 /area/ms13/town)
 "uOZ" = (
@@ -25087,7 +25087,7 @@
 /turf/open/floor/wood/ms13/mosaic,
 /area/ms13/town)
 "vrf" = (
-/obj/structure/fluff/ms13/barrel/single/toxic/three,
+/obj/structure/ms13/barrel/single/toxic/three,
 /turf/open/floor/plating/ms13/ground/road,
 /area/ms13/town)
 "vrx" = (
@@ -25499,7 +25499,7 @@
 /turf/open/floor/wood/ms13/carpet/shaggy,
 /area/ms13/town)
 "wiz" = (
-/obj/structure/fluff/ms13/largencrbanner,
+/obj/structure/ms13/largencrbanner,
 /turf/open/floor/plating/ms13/ground/snow,
 /area/ms13/snow/lightforest)
 "wiJ" = (
@@ -25533,7 +25533,7 @@
 /turf/open/floor/wood/ms13/common,
 /area/ms13/town)
 "wlS" = (
-/obj/structure/fluff/ms13/barrel/single/toxic/one,
+/obj/structure/ms13/barrel/single/toxic/one,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "wmi" = (

--- a/mojave/structures/decorative.dm
+++ b/mojave/structures/decorative.dm
@@ -37,6 +37,9 @@
 	desc = "CALL A CODER. CALL A CODER. But not for me. :reachforthesky:"
 	icon = 'mojave/icons/structure/64x64_misc.dmi'
 	icon_state = "base_class"
+	density = FALSE
+	anchored = TRUE
+	opacity = FALSE
 
 /obj/structure/ms13/mammoth_sign
 	name = "\improper Mammoth Lakes sign"
@@ -63,8 +66,7 @@
 	name = "cable"
 	icon = 'mojave/icons/objects/cables.dmi'
 	density = FALSE
-	anchored = TRUE
-	opacity = FALSE
+
 /obj/structure/ms13/cable/red
 	icon_state = "cable_red_straight"
 

--- a/mojave/structures/decorative.dm
+++ b/mojave/structures/decorative.dm
@@ -63,7 +63,8 @@
 	name = "cable"
 	icon = 'mojave/icons/objects/cables.dmi'
 	density = FALSE
-
+	anchored = TRUE
+	opacity = FALSE
 /obj/structure/ms13/cable/red
 	icon_state = "cable_red_straight"
 

--- a/mojave/structures/decorative.dm
+++ b/mojave/structures/decorative.dm
@@ -32,25 +32,25 @@
 
 //signs/flags//
 
-/obj/structure/fluff/ms13
+/obj/structure/ms13
 	name = "fluff ms13 basetype"
 	desc = "CALL A CODER. CALL A CODER. But not for me. :reachforthesky:"
 	icon = 'mojave/icons/structure/64x64_misc.dmi'
 	icon_state = "base_class"
 
-/obj/structure/fluff/ms13/mammoth_sign
+/obj/structure/ms13/mammoth_sign
 	name = "\improper Mammoth Lakes sign"
 	desc = "Welcome to Mammoth Lakes: the town where it's always winter!"
 	icon = 'mojave/icons/structure/64x64_misc.dmi'
 	icon_state = "mammoth_sign"
 
-/obj/structure/fluff/ms13/largencrbanner
+/obj/structure/ms13/largencrbanner
 	name = "\improper NCR Banner"
 	desc = "A large banner stretched along a somewhat sturdy metal pole. It bears the insignia of a bear, representative of the New California Republic."
 	icon = 'mojave/icons/objects/flags32x64.dmi'
 	icon_state = "ncrflag"
 
-/obj/structure/fluff/ms13/ncrflag
+/obj/structure/ms13/ncrflag
 	name = "\improper NCR flagpole"
 	desc = "A very tall flag pole, You can almost see the NCR's flag up there!"
 	icon = 'mojave/icons/structure/largeflags.dmi'
@@ -174,7 +174,7 @@
 
 // Barrels //
 
-/obj/structure/fluff/ms13/barrel
+/obj/structure/ms13/barrel
 	name = "barrel"
 	desc = "A sealed canister of mystery, closed to time."
 	icon = 'mojave/icons/structure/barrels.dmi'
@@ -186,349 +186,349 @@
 	var/unique = FALSE //used to set if the icon is randomised or not
 	projectile_passchance = 65
 
-/obj/structure/fluff/ms13/barrel/deconstruct(disassembled = TRUE)
+/obj/structure/ms13/barrel/deconstruct(disassembled = TRUE)
 	if(!(flags_1 & NODECONSTRUCT_1))
 		new /obj/item/stack/sheet/ms13/scrap(loc, 3)
 		new /obj/item/stack/sheet/ms13/scrap_steel(loc, 2)
 	qdel(src)
 
-/obj/structure/fluff/ms13/barrel/Initialize()
+/obj/structure/ms13/barrel/Initialize()
 	. = ..()
 	if(!unique)
 		icon_state = "[icon_type]_[rand(1, amount)]"
 
-/obj/structure/fluff/ms13/barrel/single
+/obj/structure/ms13/barrel/single
 
-/obj/structure/fluff/ms13/barrel/single/grey
+/obj/structure/ms13/barrel/single/grey
 	icon_state = "grey_1"
 	icon_type = "grey"
 
-/obj/structure/fluff/ms13/barrel/single/grey/one
+/obj/structure/ms13/barrel/single/grey/one
 	icon_state = "grey_1"
 	unique = TRUE
 
-/obj/structure/fluff/ms13/barrel/single/grey/two
+/obj/structure/ms13/barrel/single/grey/two
 	icon_state = "grey_2"
 	unique = TRUE
 
-/obj/structure/fluff/ms13/barrel/single/grey/three
+/obj/structure/ms13/barrel/single/grey/three
 	icon_state = "grey_3"
 	unique = TRUE
 
-/obj/structure/fluff/ms13/barrel/single/red
+/obj/structure/ms13/barrel/single/red
 	icon_state = "red_1"
 	icon_type = "red"
 
-/obj/structure/fluff/ms13/barrel/single/red/one
+/obj/structure/ms13/barrel/single/red/one
 	icon_state = "red_1"
 	unique = TRUE
 
-/obj/structure/fluff/ms13/barrel/single/red/two
+/obj/structure/ms13/barrel/single/red/two
 	icon_state = "red_2"
 	unique = TRUE
 
-/obj/structure/fluff/ms13/barrel/single/red/three
+/obj/structure/ms13/barrel/single/red/three
 	icon_state = "red_3"
 	unique = TRUE
 
-/obj/structure/fluff/ms13/barrel/single/yellow
+/obj/structure/ms13/barrel/single/yellow
 	icon_state = "yellow_1"
 	icon_type = "yellow"
 
-/obj/structure/fluff/ms13/barrel/single/yellow/one
+/obj/structure/ms13/barrel/single/yellow/one
 	icon_state = "yellow_1"
 	unique = TRUE
 
-/obj/structure/fluff/ms13/barrel/single/yellow/two
+/obj/structure/ms13/barrel/single/yellow/two
 	icon_state = "yellow_2"
 	unique = TRUE
 
-/obj/structure/fluff/ms13/barrel/single/yellow/three
+/obj/structure/ms13/barrel/single/yellow/three
 	icon_state = "yellow_3"
 	unique = TRUE
 
-/obj/structure/fluff/ms13/barrel/single/label
+/obj/structure/ms13/barrel/single/label
 	icon_state = "label_1"
 	icon_type = "label"
 
-/obj/structure/fluff/ms13/barrel/single/label/one
+/obj/structure/ms13/barrel/single/label/one
 	icon_state = "label_1"
 	unique = TRUE
 
-/obj/structure/fluff/ms13/barrel/single/label/two
+/obj/structure/ms13/barrel/single/label/two
 	icon_state = "label_2"
 	unique = TRUE
 
-/obj/structure/fluff/ms13/barrel/single/label/three
+/obj/structure/ms13/barrel/single/label/three
 	icon_state = "label_3"
 	unique = TRUE
 
-/obj/structure/fluff/ms13/barrel/single/hazard
+/obj/structure/ms13/barrel/single/hazard
 	icon_state = "hazard_1"
 	icon_type = "hazard"
 
-/obj/structure/fluff/ms13/barrel/single/hazard/one
+/obj/structure/ms13/barrel/single/hazard/one
 	icon_state = "hazard_1"
 	unique = TRUE
 
-/obj/structure/fluff/ms13/barrel/single/hazard/two
+/obj/structure/ms13/barrel/single/hazard/two
 	icon_state = "hazard_2"
 	unique = TRUE
 
-/obj/structure/fluff/ms13/barrel/single/hazard/three
+/obj/structure/ms13/barrel/single/hazard/three
 	icon_state = "hazard_3"
 	unique = TRUE
 
-/obj/structure/fluff/ms13/barrel/single/redalt
+/obj/structure/ms13/barrel/single/redalt
 	icon_state = "red_alt_1"
 	icon_type = "red_alt"
 
-/obj/structure/fluff/ms13/barrel/single/redalt/one
+/obj/structure/ms13/barrel/single/redalt/one
 	icon_state = "red_alt_1"
 	unique = TRUE
 
-/obj/structure/fluff/ms13/barrel/single/redalt/two
+/obj/structure/ms13/barrel/single/redalt/two
 	icon_state = "red_alt_2"
 	unique = TRUE
 
-/obj/structure/fluff/ms13/barrel/single/redalt/three
+/obj/structure/ms13/barrel/single/redalt/three
 	icon_state = "red_alt_3"
 	unique = TRUE
 
-/obj/structure/fluff/ms13/barrel/single/toxic
+/obj/structure/ms13/barrel/single/toxic
 	icon_state = "toxic_1"
 	icon_type = "toxic"
 	amount = 4
 
-/obj/structure/fluff/ms13/barrel/single/toxic/Initialize()
+/obj/structure/ms13/barrel/single/toxic/Initialize()
 	. = ..()
 	AddElement(/datum/element/radioactive)
 
-/obj/structure/fluff/ms13/barrel/single/toxic/one
+/obj/structure/ms13/barrel/single/toxic/one
 	icon_state = "toxic_1"
 	unique = TRUE
 
-/obj/structure/fluff/ms13/barrel/single/toxic/two
+/obj/structure/ms13/barrel/single/toxic/two
 	icon_state = "toxic_2"
 	unique = TRUE
 
-/obj/structure/fluff/ms13/barrel/single/toxic/three
+/obj/structure/ms13/barrel/single/toxic/three
 	icon_state = "toxic_3"
 	unique = TRUE
 
-/obj/structure/fluff/ms13/barrel/single/toxic/four
+/obj/structure/ms13/barrel/single/toxic/four
 	icon_state = "toxic_4"
 	unique = TRUE
 
-/obj/structure/fluff/ms13/barrel/single/waste
+/obj/structure/ms13/barrel/single/waste
 	icon_state = "waste_1"
 	icon_type = "waste"
 
-/obj/structure/fluff/ms13/barrel/single/waste/one
+/obj/structure/ms13/barrel/single/waste/one
 	icon_state = "waste_1"
 	unique = TRUE
 
-/obj/structure/fluff/ms13/barrel/single/waste/two
+/obj/structure/ms13/barrel/single/waste/two
 	icon_state = "waste_2"
 	unique = TRUE
 
-/obj/structure/fluff/ms13/barrel/single/waste/three
+/obj/structure/ms13/barrel/single/waste/three
 	icon_state = "waste_3"
 	unique = TRUE
 
-/obj/structure/fluff/ms13/barrel/single/flammable
+/obj/structure/ms13/barrel/single/flammable
 	icon_state = "flammable_1"
 	icon_type = "flammable"
 
-/obj/structure/fluff/ms13/barrel/single/flammable/one
+/obj/structure/ms13/barrel/single/flammable/one
 	icon_state = "flammable_1"
 	unique = TRUE
 
-/obj/structure/fluff/ms13/barrel/single/flammable/two
+/obj/structure/ms13/barrel/single/flammable/two
 	icon_state = "flammable_2"
 	unique = TRUE
 
-/obj/structure/fluff/ms13/barrel/single/flammable/three
+/obj/structure/ms13/barrel/single/flammable/three
 	icon_state = "flammable_3"
 	unique = TRUE
 
-/obj/structure/fluff/ms13/barrel/single/warning
+/obj/structure/ms13/barrel/single/warning
 	icon_state = "warning_1"
 	icon_type = "warning"
 
-/obj/structure/fluff/ms13/barrel/single/warning/one
+/obj/structure/ms13/barrel/single/warning/one
 	icon_state = "warning_1"
 	unique = TRUE
 
-/obj/structure/fluff/ms13/barrel/single/warning/two
+/obj/structure/ms13/barrel/single/warning/two
 	icon_state = "warning_2"
 	unique = TRUE
 
-/obj/structure/fluff/ms13/barrel/single/warning/three
+/obj/structure/ms13/barrel/single/warning/three
 	icon_state = "warning_3"
 	unique = TRUE
 
-/obj/structure/fluff/ms13/barrel/double
+/obj/structure/ms13/barrel/double
 	name = "barrels"
 	desc = "Sealed canisters of mystery, closed to time."
 	amount = 2
 
-/obj/structure/fluff/ms13/barrel/double/grey
+/obj/structure/ms13/barrel/double/grey
 	icon_state = "double_grey_1"
 	icon_type = "double_grey"
 
-/obj/structure/fluff/ms13/barrel/double/grey/one
+/obj/structure/ms13/barrel/double/grey/one
 	icon_state = "double_grey_1"
 	unique = TRUE
 
-/obj/structure/fluff/ms13/barrel/double/grey/two
+/obj/structure/ms13/barrel/double/grey/two
 	icon_state = "double_grey_2"
 	unique = TRUE
 
-/obj/structure/fluff/ms13/barrel/double/red
+/obj/structure/ms13/barrel/double/red
 	icon_state = "double_red_1"
 	icon_type = "double_red"
 
-/obj/structure/fluff/ms13/barrel/double/red/one
+/obj/structure/ms13/barrel/double/red/one
 	icon_state = "double_red_1"
 	unique = TRUE
 
-/obj/structure/fluff/ms13/barrel/double/red/two
+/obj/structure/ms13/barrel/double/red/two
 	icon_state = "double_red_2"
 	unique = TRUE
 
-/obj/structure/fluff/ms13/barrel/double/yellow
+/obj/structure/ms13/barrel/double/yellow
 	icon_state = "double_yellow_1"
 	icon_type = "double_yellow"
 
-/obj/structure/fluff/ms13/barrel/double/yellow/one
+/obj/structure/ms13/barrel/double/yellow/one
 	icon_state = "double_yellow_1"
 	unique = TRUE
 
-/obj/structure/fluff/ms13/barrel/double/yellow/two
+/obj/structure/ms13/barrel/double/yellow/two
 	icon_state = "double_yellow_2"
 	unique = TRUE
 
-/obj/structure/fluff/ms13/barrel/double/waste
+/obj/structure/ms13/barrel/double/waste
 	icon_state = "double_waste_1"
 	icon_type = "double_waste"
 	amount = 1
 
-/obj/structure/fluff/ms13/barrel/triple
+/obj/structure/ms13/barrel/triple
 	name = "barrels"
 	desc = "Sealed canisters of mystery, closed to time."
 
-/obj/structure/fluff/ms13/barrel/triple/grey
+/obj/structure/ms13/barrel/triple/grey
 	icon_state = "triple_grey_1"
 	icon_type = "triple_grey"
 
-/obj/structure/fluff/ms13/barrel/triple/grey/one
+/obj/structure/ms13/barrel/triple/grey/one
 	icon_state = "triple_grey_1"
 	unique = TRUE
 
-/obj/structure/fluff/ms13/barrel/triple/grey/two
+/obj/structure/ms13/barrel/triple/grey/two
 	icon_state = "triple_grey_2"
 	unique = TRUE
 
-/obj/structure/fluff/ms13/barrel/triple/grey/three
+/obj/structure/ms13/barrel/triple/grey/three
 	icon_state = "triple_grey_3"
 	unique = TRUE
 
-/obj/structure/fluff/ms13/barrel/triple/red
+/obj/structure/ms13/barrel/triple/red
 	icon_state = "triple_red_1"
 	icon_type = "triple_red"
 	amount = 2
 
-/obj/structure/fluff/ms13/barrel/triple/red/one
+/obj/structure/ms13/barrel/triple/red/one
 	icon_state = "triple_red_1"
 	unique = TRUE
 
-/obj/structure/fluff/ms13/barrel/triple/red/two
+/obj/structure/ms13/barrel/triple/red/two
 	icon_state = "triple_red_2"
 	unique = TRUE
 
-/obj/structure/fluff/ms13/barrel/triple/yellow
+/obj/structure/ms13/barrel/triple/yellow
 	icon_state = "triple_yellow_1"
 	icon_type = "triple_yellow"
 
-/obj/structure/fluff/ms13/barrel/triple/yellow/one
+/obj/structure/ms13/barrel/triple/yellow/one
 	icon_state = "triple_yellow_1"
 	unique = TRUE
 
-/obj/structure/fluff/ms13/barrel/triple/yellow/two
+/obj/structure/ms13/barrel/triple/yellow/two
 	icon_state = "triple_yellow_2"
 	unique = TRUE
 
-/obj/structure/fluff/ms13/barrel/triple/yellow/three
+/obj/structure/ms13/barrel/triple/yellow/three
 	icon_state = "triple_yellow_3"
 	unique = TRUE
 
-/obj/structure/fluff/ms13/barrel/triple/waste
+/obj/structure/ms13/barrel/triple/waste
 	icon_state = "triple_waste_1"
 	icon_type = "triple_waste"
 	amount = 2
 
-/obj/structure/fluff/ms13/barrel/triple/waste/one
+/obj/structure/ms13/barrel/triple/waste/one
 	icon_state = "triple_waste_1"
 	unique = TRUE
 
-/obj/structure/fluff/ms13/barrel/triple/waste/two
+/obj/structure/ms13/barrel/triple/waste/two
 	icon_state = "triple_waste_2"
 	unique = TRUE
 
-/obj/structure/fluff/ms13/barrel/quadruple
+/obj/structure/ms13/barrel/quadruple
 	name = "barrels"
 	desc = "Sealed canisters of mystery, closed to time."
 	amount = 1
 
-/obj/structure/fluff/ms13/barrel/quadruple/grey
+/obj/structure/ms13/barrel/quadruple/grey
 	icon_state = "quad_grey_1"
 	icon_type = "quad_grey"
 
-/obj/structure/fluff/ms13/barrel/quadruple/grey/one
+/obj/structure/ms13/barrel/quadruple/grey/one
 	icon_state = "quad_grey_1"
 	unique = TRUE
 
-/obj/structure/fluff/ms13/barrel/quadruple/red
+/obj/structure/ms13/barrel/quadruple/red
 	icon_state = "quad_red_1"
 	icon_type = "quad_red"
 	amount = 2
 
-/obj/structure/fluff/ms13/barrel/quadruple/red/one
+/obj/structure/ms13/barrel/quadruple/red/one
 	icon_state = "quad_red_1"
 	unique = TRUE
 
-/obj/structure/fluff/ms13/barrel/quadruple/red/two
+/obj/structure/ms13/barrel/quadruple/red/two
 	icon_state = "quad_red_2"
 	unique = TRUE
 
-/obj/structure/fluff/ms13/barrel/quadruple/yellow
+/obj/structure/ms13/barrel/quadruple/yellow
 	icon_state = "quad_yellow_1"
 	icon_type = "quad_yellow"
 
-/obj/structure/fluff/ms13/barrel/quadruple/yellow/one
+/obj/structure/ms13/barrel/quadruple/yellow/one
 	icon_state = "quad_yellow_1"
 	unique = TRUE
 
-/obj/structure/fluff/ms13/barrel/quadruple/waste
+/obj/structure/ms13/barrel/quadruple/waste
 	icon_state = "quad_waste_1"
 	icon_type = "quad_waste"
 
-/obj/structure/fluff/ms13/barrel/quadruple/waste/one
+/obj/structure/ms13/barrel/quadruple/waste/one
 	icon_state = "quad_waste_1"
 	unique = TRUE
 
-/obj/structure/fluff/ms13/trash
+/obj/structure/ms13/trash
 	name = "Base type MS13 TRASH"
 	desc = "Who the hell littered this here? Call a mapper!"
 	icon = 'mojave/icons/structure/miscellaneous.dmi'
 
-/obj/structure/fluff/ms13/trash/papers
+/obj/structure/ms13/trash/papers
 	name = "scattered papers"
 	desc = "Some scattered papers. They look mostly ruined."
 	icon_state = "scattered_papers"
 
-/obj/structure/fluff/ms13/trash/papers/attack_hand(mob/living/user, list/modifiers)
+/obj/structure/ms13/trash/papers/attack_hand(mob/living/user, list/modifiers)
 	. = ..()
 	if(!user.canUseTopic(src, BE_CLOSE, NO_DEXTERITY))
 		return


### PR DESCRIPTION
I don't know why we bothered using it anyways. Freak it.

The tipping point was fluff code having a specific interaction with wrenches to break down into metal... STUPID...