### PR TITLE
The Pocketening

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -301,10 +301,10 @@
 			how_cool_are_your_threads += "[src]'s storage opens when clicked.\n"
 		else
 			how_cool_are_your_threads += "[src]'s storage opens when dragged to yourself.\n"
-		if (pockets.can_hold?.len) // If pocket type can hold anything, vs only specific items
+		/*if (pockets.can_hold?.len) // If pocket type can hold anything, vs only specific items
 			how_cool_are_your_threads += "[src] can store [pockets.max_items] <a href='?src=[REF(src)];show_valid_pocket_items=1'>item\s</a>.\n"
 		else
-			how_cool_are_your_threads += "[src] can store [pockets.max_items] item\s that are [weight_class_to_text(pockets.max_w_class)] or smaller.\n"
+			how_cool_are_your_threads += "[src] can store [pockets.max_items] item\s that are [weight_class_to_text(pockets.max_w_class)] or smaller.\n"*/ //Mojave Edit - This is dumb, doesn't apply to us, and would be annoying to change on a per suit basis so I'm just disabling it. It's pretty redundant anyways - Hekzder
 		if(pockets.quickdraw)
 			how_cool_are_your_threads += "You can quickly remove an item from [src] using Right-Click.\n"
 		if(pockets.silent)
@@ -386,7 +386,7 @@
 	if (armor_value < 0)
 		. = "-"
 	. += "\Roman[round(abs(armor_value), 10) / 10]"
-	return . */ //MOJAVE EDIT - Comments all of this out because, like with the weapon description proc, it is stupid and we shouldn't have it or should implement it in a better, less gamey way. 
+	return . */ //MOJAVE EDIT - Comments all of this out because, like with the weapon description proc, it is stupid and we shouldn't have it or should implement it in a better, less gamey way.
 
 /obj/item/clothing/atom_break(damage_flag)
 	. = ..()

--- a/mojave/code/modules/storage/tarkov.dm
+++ b/mojave/code/modules/storage/tarkov.dm
@@ -149,7 +149,7 @@
 	attack_hand_interact = TRUE
 	rustle_sound = FALSE
 
-/datum/component/storage/concrete/ms13/suit/small //a 2x1 for minimal suit storage
+/datum/component/storage/concrete/ms13/suit/small //a 1x2 for minimal suit storage
 	screen_max_columns = 1
 	screen_max_rows = 2
 
@@ -157,8 +157,8 @@
 	screen_max_columns = 2
 	screen_max_rows = 2
 
-/datum/component/storage/concrete/ms13/suit/large //a 3x2 meant almost exclusively for non-armor suits
-	screen_max_columns = 3
+/datum/component/storage/concrete/ms13/suit/large //a 4x2 meant almost exclusively for non-armor suits
+	screen_max_columns = 4
 	screen_max_rows = 2
 	screen_start_x = 16
 
@@ -219,7 +219,9 @@
 		/obj/item/gun/ballistic/revolver/ms13/rev556,
 		/obj/item/gun/ballistic/automatic/pistol/ms13/m9mm,
 		/obj/item/gun/ballistic/automatic/pistol/ms13/m10mm,
-		/obj/item/gun/ballistic/automatic/pistol/ms13/pistol45
+		/obj/item/gun/ballistic/automatic/pistol/ms13/pistol45,
+		/obj/item/gun/ballistic/automatic/ms13/full/smg10mm,
+		/obj/item/gun/ballistic/automatic/ms13/full/smg9mm
 		))
 
 /datum/component/storage

--- a/mojave/code/modules/storage/tarkov.dm
+++ b/mojave/code/modules/storage/tarkov.dm
@@ -139,6 +139,89 @@
 		/obj/item/stack/ms13/currency/prewar,
 		/obj/item/stack/ms13/currency/ncr_dollar))
 
+/datum/component/storage/concrete/ms13/suit //base type suit storage to avoid redundant defines
+	screen_max_columns = 1
+	screen_max_rows = 2
+	screen_start_y = 4
+	screen_start_x = 17
+	quickdraw = TRUE
+	silent = TRUE
+	attack_hand_interact = TRUE
+	rustle_sound = FALSE
+
+/datum/component/storage/concrete/ms13/suit/small //a 2x1 for minimal suit storage
+	screen_max_columns = 1
+	screen_max_rows = 2
+
+/datum/component/storage/concrete/ms13/suit/med //a 2x2 for decent suit storage
+	screen_max_columns = 2
+	screen_max_rows = 2
+
+/datum/component/storage/concrete/ms13/suit/large //a 3x2 meant almost exclusively for non-armor suits
+	screen_max_columns = 3
+	screen_max_rows = 2
+	screen_start_x = 16
+
+/datum/component/storage/concrete/ms13/suit/Initialize()
+	. = ..()
+	set_holdable(list(
+		/obj/item/knife,
+		/obj/item/switchblade,
+		/obj/item/pen,
+		/obj/item/scalpel,
+		/obj/item/reagent_containers/syringe,
+		/obj/item/reagent_containers/hypospray/medipen,
+		/obj/item/screwdriver,
+		/obj/item/ms13/lockpick/basic,
+		/obj/item/gun/ballistic/automatic/pistol/ms13/pistol22,
+		/obj/item/gun/ballistic/revolver/ms13/derringer,
+		/obj/item/gun/ballistic/revolver/ms13/rev357/police,
+		/obj/item/stack/ms13/currency,
+		/obj/item/flashlight/ms13,
+		/obj/item/flashlight/flare/ms13,
+		/obj/item/radio/ms13,
+		/obj/item/stack/medical/ms13,
+		/obj/item/food/ms13/prewar/canned,
+		/obj/item/reagent_containers/food/drinks/bottle/ms13/trooper_beer,
+		/obj/item/reagent_containers/food/drinks/bottle/ms13/caligary_beer,
+		/obj/item/stack/sheet/ms13/nugget,
+		/obj/item/stack/sheet/ms13/scrap_parts,
+		/obj/item/stack/sheet/ms13/rubber,
+		/obj/item/stack/sheet/ms13/plastic,
+		/obj/item/stack/sheet/ms13/ceramic,
+		/obj/item/stack/sheet/ms13/glass,
+		/obj/item/stack/sheet/ms13/scrap_electronics,
+		/obj/item/stack/sheet/ms13/circuits,
+		/obj/item/ms13/component,
+		/obj/item/reagent_containers/food/drinks/soda_cans/ms13,
+		/obj/item/ammo_box/magazine/ms13,
+		/obj/item/wirecutters/ms13,
+		/obj/item/wrench/ms13,
+		/obj/item/ms13/hammer,
+		/obj/item/restraints/handcuffs/ms13,
+		/obj/item/ms13/knuckles,
+		/obj/item/stock_parts/cell/ms13,
+		/obj/item/ammo_box/magazine/ammo_stack ,
+		/obj/item/clothing/glasses/ms13,
+		/obj/item/clothing/mask/ms13/bandana,
+		/obj/item/stack/medical/suture/ms13,
+		/obj/item/stack/medical/ointment/ms13,
+		/obj/item/stack/medical/gauze/ms13,
+		/obj/item/stack/sheet/ms13/cloth,
+		/obj/item/stack/sheet/ms13/leather,
+		/obj/item/stack/sheet/ms13/mil_fiber,
+		/obj/item/stack/sheet/ms13/thread,
+		/obj/item/card/id/ms13,
+		/obj/item/gun/ballistic/revolver/ms13/caravan/sawed,
+		/obj/item/gun/ballistic/revolver/ms13/rev44,
+		/obj/item/gun/ballistic/revolver/ms13/rev357,
+		/obj/item/gun/ballistic/revolver/ms13/rev10mm,
+		/obj/item/gun/ballistic/revolver/ms13/rev556,
+		/obj/item/gun/ballistic/automatic/pistol/ms13/m9mm,
+		/obj/item/gun/ballistic/automatic/pistol/ms13/m10mm,
+		/obj/item/gun/ballistic/automatic/pistol/ms13/pistol45
+		))
+
 /datum/component/storage
 	screen_max_columns = 8
 	screen_max_rows = 3

--- a/mojave/items/clothing/suits/armor.dm
+++ b/mojave/items/clothing/suits/armor.dm
@@ -223,6 +223,7 @@
                 FIRE = CLASS2_FIRE)
 	equip_delay_self = 2.5 SECONDS
 	equip_delay_other = 4 SECONDS
+	pocket_storage_component_path = /datum/component/storage/concrete/ms13/suit/med
 
 /obj/item/clothing/suit/armor/ms13/vest/civilian
 	name = "civilian kevlar vest"
@@ -237,6 +238,7 @@
                 LASER = 0, \
                 ENERGY = 0, \
                 FIRE = CLASS1_FIRE)
+	pocket_storage_component_path = /datum/component/storage/concrete/ms13/suit/small
 
 /obj/item/clothing/suit/armor/ms13/vest/military
 	name = "military kevlar vest"
@@ -296,6 +298,7 @@
                 FIRE = 0)
 	equip_delay_self = 1.5 SECONDS
 	equip_delay_other = 3 SECONDS
+	pocket_storage_component_path = /datum/component/storage/concrete/ms13/suit/med
 
 /obj/item/clothing/suit/ms13/raider
 	name = "raider reinforced jacket"
@@ -316,6 +319,7 @@
                 FIRE = CLASS2_FIRE)
 	equip_delay_self = 2.5 SECONDS
 	equip_delay_other = 4 SECONDS
+	pocket_storage_component_path = /datum/component/storage/concrete/ms13/suit/small
 
 /obj/item/clothing/suit/ms13/raider/plated
 	name = "raider plated jacket"
@@ -552,6 +556,7 @@
                 FIRE = CLASS2_FIRE)
 	equip_delay_self = 2.5 SECONDS
 	equip_delay_other = 4 SECONDS
+	pocket_storage_component_path = /datum/component/storage/concrete/ms13/suit/small
 
 /obj/item/clothing/suit/armor/ms13/ncr/reinforced
 	name = "\improper NCR reinforced infantry vest"
@@ -751,6 +756,7 @@
                 FIRE = 0)
 	equip_delay_self = 1.5 SECONDS
 	equip_delay_other = 3 SECONDS
+	pocket_storage_component_path = /datum/component/storage/concrete/ms13/suit/med
 
 /obj/item/clothing/suit/armor/ms13/scribe/head
 	name = "\improper Brotherhood head scribe's robe"
@@ -775,6 +781,7 @@
                 FIRE = 0)
 	equip_delay_self = 1.5 SECONDS
 	equip_delay_other = 3 SECONDS
+	pocket_storage_component_path = /datum/component/storage/concrete/ms13/suit/med
 
 /obj/item/clothing/suit/armor/ms13/vest/bos
 	name = "\improper Brotherhood kevlar vest"
@@ -793,6 +800,7 @@
                 FIRE = CLASS2_FIRE)
 	equip_delay_self = 2.5 SECONDS
 	equip_delay_other = 4 SECONDS
+	pocket_storage_component_path = /datum/component/storage/concrete/ms13/suit/small
 
 /obj/item/clothing/suit/armor/ms13/combat/bos
 	name = "\improper Brotherhood combat armor"
@@ -832,6 +840,7 @@
                 FIRE = CLASS3_FIRE)
 	equip_delay_self = 2.5 SECONDS
 	equip_delay_other = 4 SECONDS
+	pocket_storage_component_path = /datum/component/storage/concrete/ms13/suit/small
 
 /obj/item/clothing/suit/armor/ms13/eliteriot/ranger
 	name = "\improper Elite Desert Ranger armor"

--- a/mojave/items/clothing/suits/suit.dm
+++ b/mojave/items/clothing/suits/suit.dm
@@ -59,6 +59,7 @@
                 LASER = 0, \
                 ENERGY = 0, \
                 FIRE = 0)
+	pocket_storage_component_path = /datum/component/storage/concrete/ms13/suit/large
 
 /obj/item/clothing/suit/ms13/vest/brown
 	name = "brown vest"
@@ -105,6 +106,7 @@
                 LASER = CLASS1_LASER, \
                 ENERGY = 0, \
                 FIRE = 0)
+	pocket_storage_component_path = /datum/component/storage/concrete/ms13/suit/large
 
 /obj/item/clothing/suit/ms13/veteran_coat
 	name = "merc veteran coat"
@@ -121,6 +123,7 @@
                 LASER = 0, \
                 ENERGY = 0, \
                 FIRE = 0)
+	pocket_storage_component_path = /datum/component/storage/concrete/ms13/suit/large
 
 /obj/item/clothing/suit/ms13/veteran_coat/black
 	name = "black veteran coat"
@@ -144,6 +147,7 @@
                 FIRE = CLASS2_FIRE)
 	equip_delay_self = 2.5 SECONDS
 	equip_delay_other = 4 SECONDS
+	pocket_storage_component_path = /datum/component/storage/concrete/ms13/suit/med
 
 /obj/item/clothing/suit/ms13/ljacket/reinforced
 	name = "reinforced leather jacket"
@@ -163,6 +167,7 @@
                 FIRE = CLASS2_FIRE)
 	equip_delay_self = 2.5 SECONDS
 	equip_delay_other = 4 SECONDS
+	pocket_storage_component_path = /datum/component/storage/concrete/ms13/suit/med
 
 // winter jackets //
 
@@ -180,6 +185,7 @@
                 LASER = CLASS1_LASER, \
                 ENERGY = 0, \
                 FIRE = 0)
+	pocket_storage_component_path = /datum/component/storage/concrete/ms13/suit/large
 
 /obj/item/clothing/suit/toggle/ms13/wjacket/orange
 	name = "orange winter jacket"
@@ -202,6 +208,7 @@
                 FIRE = CLASS2_FIRE)
 	equip_delay_self = 2.5 SECONDS
 	equip_delay_other = 4 SECONDS
+	pocket_storage_component_path = /datum/component/storage/concrete/ms13/suit/med
 
 /obj/item/clothing/suit/toggle/ms13/wjacket/orange/armored
 	name = "armored orange winter jacket"
@@ -219,6 +226,7 @@
                 FIRE = CLASS3_FIRE)
 	equip_delay_self = 3.5 SECONDS
 	equip_delay_other = 5 SECONDS
+	pocket_storage_component_path = null
 
 /obj/item/clothing/suit/toggle/ms13/wjacket/brown
 	name = "brown winter jacket"
@@ -241,6 +249,7 @@
                 FIRE = CLASS2_FIRE)
 	equip_delay_self = 2.5 SECONDS
 	equip_delay_other = 4 SECONDS
+	pocket_storage_component_path = /datum/component/storage/concrete/ms13/suit/med
 
 /obj/item/clothing/suit/toggle/ms13/wjacket/brown/armored
 	name = "armored brown jacket"
@@ -258,6 +267,7 @@
                 FIRE = CLASS3_FIRE)
 	equip_delay_self = 3.5 SECONDS
 	equip_delay_other = 5 SECONDS
+	pocket_storage_component_path = null
 
 /obj/item/clothing/suit/toggle/ms13/wjacket/blue
 	name = "blue winter jacket"
@@ -280,6 +290,7 @@
                 FIRE = CLASS2_FIRE)
 	equip_delay_self = 2.5 SECONDS
 	equip_delay_other = 4 SECONDS
+	pocket_storage_component_path = /datum/component/storage/concrete/ms13/suit/med
 
 /obj/item/clothing/suit/toggle/ms13/wjacket/blue/armored
 	name = "armored blue winter jacket"
@@ -297,6 +308,7 @@
                 FIRE = CLASS3_FIRE)
 	equip_delay_self = 3.5 SECONDS
 	equip_delay_other = 5 SECONDS
+	pocket_storage_component_path = null
 
 /obj/item/clothing/suit/toggle/ms13/wjacket/black
 	name = "black winter jacket"
@@ -319,6 +331,7 @@
                 FIRE = CLASS2_FIRE)
 	equip_delay_self = 2.5 SECONDS
 	equip_delay_other = 4 SECONDS
+	pocket_storage_component_path = /datum/component/storage/concrete/ms13/suit/med
 
 /obj/item/clothing/suit/toggle/ms13/wjacket/black/armored
 	name = "armored black winter jacket"
@@ -336,6 +349,7 @@
                 FIRE = CLASS3_FIRE)
 	equip_delay_self = 3.5 SECONDS
 	equip_delay_other = 5 SECONDS
+	pocket_storage_component_path = null
 
 // jackets //
 
@@ -402,6 +416,7 @@
                 LASER = 0, \
                 ENERGY = 0, \
                 FIRE = 0)
+	pocket_storage_component_path = /datum/component/storage/concrete/ms13/suit/med
 
 /obj/item/clothing/suit/ms13/ljacket/biker
 	name = "biker jacket"
@@ -467,6 +482,7 @@
                 LASER = CLASS1_LASER, \
                 ENERGY = 0, \
                 FIRE = 0)
+	pocket_storage_component_path = /datum/component/storage/concrete/ms13/suit/large
 
 /obj/item/clothing/suit/ms13/trench/detective
 	name = "detective's trenchcoat"
@@ -560,6 +576,7 @@
                 FIRE = CLASS2_FIRE)
 	equip_delay_self = 3.5 SECONDS
 	equip_delay_other = 5 SECONDS
+	pocket_storage_component_path = null
 
 /obj/item/clothing/suit/ms13/trench/black/armored
 	name = "armored black trenchcoat"
@@ -578,6 +595,7 @@
                 FIRE = CLASS3_FIRE)
 	equip_delay_self = 4 SECONDS
 	equip_delay_other = 6 SECONDS
+	pocket_storage_component_path = null
 
 // dusters //
 
@@ -596,6 +614,7 @@
                 LASER = 0, \
                 ENERGY = 0, \
                 FIRE = 0)
+	pocket_storage_component_path = /datum/component/storage/concrete/ms13/suit/large
 
 /obj/item/clothing/suit/ms13/duster/reinforced
 	name = "reinforced duster"
@@ -613,6 +632,7 @@
                 FIRE = CLASS2_FIRE)
 	equip_delay_self = 2.5 SECONDS
 	equip_delay_other = 4 SECONDS
+	pocket_storage_component_path = /datum/component/storage/concrete/ms13/suit/med
 
 /obj/item/clothing/suit/ms13/duster/ranger
 	name = "\improper Desert Ranger duster"
@@ -628,6 +648,7 @@
                 LASER = CLASS1_LASER, \
                 ENERGY = 0, \
                 FIRE = 0)
+	pocket_storage_component_path = /datum/component/storage/concrete/ms13/suit/med
 
 // labcoats //
 
@@ -695,6 +716,7 @@
                 LASER = 0, \
                 ENERGY = 0, \
                 FIRE = 0)
+	pocket_storage_component_path = /datum/component/storage/concrete/ms13/suit/large
 
 /obj/item/clothing/suit/ms13/drylander/hunter
 	name = "\improper Drylander hunter padded robes"
@@ -710,6 +732,7 @@
                 LASER = 0, \
                 ENERGY = 0, \
                 FIRE = 0)
+	pocket_storage_component_path = /datum/component/storage/concrete/ms13/suit/med
 
 /obj/item/clothing/suit/ms13/drylander/headtaker
 	name = "\improper Drylander Headtaker padded robes"
@@ -726,6 +749,7 @@
                 LASER = CLASS2_LASER, \
                 ENERGY = 0, \
                 FIRE = CLASS2_FIRE)
+	pocket_storage_component_path = /datum/component/storage/concrete/ms13/suit/med
 
 /obj/item/clothing/suit/ms13/drylander/simple
 	name = "\improper Drylander simple robes"

--- a/mojave/structures/ores.dm
+++ b/mojave/structures/ores.dm
@@ -95,6 +95,16 @@
 
 //Nuggets
 
+/obj/item/stack/sheet/ms13/nugget
+	name = "base type nugget"
+	desc = "Full of BUGS! You shouldn't be seeing this."
+	icon = 'mojave/icons/objects/crafting/materials_inventory.dmi'
+	w_class = WEIGHT_CLASS_TINY
+	grid_height = 32
+	grid_width = 32
+	amount = 1
+	max_amount = 8
+
 /obj/item/stack/sheet/ms13/nugget/Initialize()
 	. = ..()
 	AddElement(/datum/element/item_scaling, 0.45, 1)
@@ -103,11 +113,8 @@
 	name = "zinc nuggets"
 	desc = "A hard lump of zinc, Useless now."
 	singular_name = "zinc nugget"
-	icon = 'mojave/icons/objects/crafting/materials_inventory.dmi'
 	icon_state = "brass"
 	merge_type = /obj/item/stack/sheet/ms13/nugget/nugget_zinc
-	amount = 1
-	max_amount = 16
 
 /obj/item/stack/sheet/ms13/nugget/nugget_zinc/two
 	amount = 2
@@ -116,11 +123,8 @@
 	name = "iron ore nuggets"
 	desc = "A hard lump of iron, Useless now."
 	singular_name = "iron ore nugget"
-	icon = 'mojave/icons/objects/crafting/materials_inventory.dmi'
 	icon_state = "iron"
 	merge_type = /obj/item/stack/sheet/ms13/nugget/nugget_iron
-	amount = 1
-	max_amount = 16
 
 /obj/item/stack/sheet/ms13/nugget/nugget_iron/two
 	amount = 2
@@ -129,11 +133,8 @@
 	name = "pitchblende nuggets"
 	desc = "A hard lump of uranium, Useless now."
 	singular_name = "pitchblende nugget"
-	icon = 'mojave/icons/objects/crafting/materials_inventory.dmi'
 	icon_state = "uranium"
 	merge_type = /obj/item/stack/sheet/ms13/nugget/nugget_uranium
-	amount = 1
-	max_amount = 16
 
 /obj/item/stack/sheet/ms13/nugget/nugget_uranium/two
 	amount = 2
@@ -142,11 +143,8 @@
 	name = "coal chunks"
 	desc = "A hard lump of coal, careful with any flames."
 	singular_name = "coal chunk"
-	icon = 'mojave/icons/objects/crafting/materials_inventory.dmi'
 	icon_state = "coal"
 	merge_type = /obj/item/stack/sheet/ms13/nugget/nugget_coal
-	amount = 1
-	max_amount = 16
 
 /obj/item/stack/sheet/ms13/nugget/nugget_coal/two
 	amount = 2
@@ -155,11 +153,8 @@
 	name = "copper ore nuggets"
 	desc = "Full of potential copper. Useless now."
 	singular_name = "copper ore nugget"
-	icon = 'mojave/icons/objects/crafting/materials_inventory.dmi'
 	icon_state = "copper"
 	merge_type = /obj/item/stack/sheet/ms13/nugget/nugget_copper
-	amount = 1
-	max_amount = 16
 
 /obj/item/stack/sheet/ms13/nugget/nugget_copper/two
 	amount = 2
@@ -168,11 +163,8 @@
 	name = "lead ore nuggets"
 	desc = "Full of potential lead. Useless now."
 	singular_name = "lead ore nugget"
-	icon = 'mojave/icons/objects/crafting/materials_inventory.dmi'
 	icon_state = "lead"
 	merge_type = /obj/item/stack/sheet/ms13/nugget/nugget_lead
-	amount = 1
-	max_amount = 16
 
 /obj/item/stack/sheet/ms13/nugget/nugget_lead/two
 	amount = 2
@@ -181,11 +173,8 @@
 	name = "aluminium ore nuggets"
 	desc = "Full of potential aluminium. Useless now."
 	singular_name = "aluminium ore nugget"
-	icon = 'mojave/icons/objects/crafting/materials_inventory.dmi'
 	icon_state = "aluminium"
 	merge_type = /obj/item/stack/sheet/ms13/nugget/nugget_alu
-	amount = 1
-	max_amount = 16
 
 /obj/item/stack/sheet/ms13/nugget/nugget_alu/two
 	amount = 2
@@ -194,11 +183,8 @@
 	name = "silver ore nuggets"
 	desc = "Full of potential silver. Useless now."
 	singular_name = "silver ore nugget"
-	icon = 'mojave/icons/objects/crafting/materials_inventory.dmi'
 	icon_state = "silver"
 	merge_type = /obj/item/stack/sheet/ms13/nugget/nugget_silver
-	amount = 1
-	max_amount = 16
 
 /obj/item/stack/sheet/ms13/nugget/nugget_silver/two
 	amount = 2
@@ -207,11 +193,8 @@
 	name = "gold ore nuggets"
 	desc = "Full of potential gold. Useless now."
 	singular_name = "gold ore nugget"
-	icon = 'mojave/icons/objects/crafting/materials_inventory.dmi'
 	icon_state = "gold"
 	merge_type = /obj/item/stack/sheet/ms13/nugget/nugget_gold
-	amount = 1
-	max_amount = 16
 
 /obj/item/stack/sheet/ms13/nugget/nugget_gold/two
 	amount = 2


### PR DESCRIPTION
## About The Pull Request

Adds pockets to suits, with varying sizes based on the suit. 

The smallest, a 1x2, is used for some armored vests.
The medium size, a 2x2, is used for padded jackets and other armored vests
The largest, a 4x2, is used for basically all unarmored suit items save for including some exceptions like the Drylander Chieftain robes. 

You can put a lot of things in the suits as long as you can fit them in. If I missed anything please let me know because I have to manually define the items to avoid allowing child items inside that I wouldn't want in there. 

Also has a slight change to nugget storage and stack sizes because they weren't adjusted before and it was an oversight on my part. 

## Why It's Good For The Game

Slightly more storage is cool. 