### PR TITLE
Drought Lootening

### DIFF
--- a/_maps/map_files/Drought/Drought.dmm
+++ b/_maps/map_files/Drought/Drought.dmm
@@ -70,6 +70,7 @@
 	dir = 4
 	},
 /obj/structure/table/ms13/metal/grate,
+/obj/effect/spawner/random/ms13/smokeable/general,
 /turf/open/floor/ms13/tile/full/green,
 /area/ms13/town)
 "aew" = (
@@ -381,8 +382,16 @@
 /obj/structure/ms13/cave_decor/boards/drought/northsouth,
 /turf/open/floor/plating/ms13/ground/desert,
 /area/ms13/water_baron)
+"auv" = (
+/obj/machinery/door/unpowered/ms13/metal/red{
+	dir = 1
+	},
+/obj/effect/spawner/random/ms13/locked/random/lowchance,
+/turf/open/floor/ms13/tile/brown/big,
+/area/ms13/town)
 "auz" = (
 /obj/structure/table/ms13/metal/constructed,
+/obj/effect/spawner/random/ms13/medical/bloodbag,
 /turf/open/floor/ms13/tile/large/cream,
 /area/ms13/town)
 "auB" = (
@@ -564,6 +573,7 @@
 /area/ms13/water_baron/interior)
 "aIT" = (
 /obj/structure/closet/crate/ms13/woodcrate/uncrowbarrable,
+/obj/effect/spawner/random/ms13/crafting/refined,
 /turf/open/floor/plating/ms13/ground/desertalt,
 /area/ms13/desert)
 "aJd" = (
@@ -651,6 +661,11 @@
 	dir = 1
 	},
 /turf/open/floor/ms13/tile/large/cream,
+/area/ms13/town)
+"aOc" = (
+/obj/machinery/door/unpowered/ms13/wood,
+/obj/effect/spawner/random/ms13/locked/random/medchance,
+/turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "aOe" = (
 /obj/structure/filingcabinet/ms13,
@@ -995,6 +1010,7 @@
 "bgm" = (
 /obj/structure/table/ms13/no_smooth/metal,
 /obj/item/ms13/fluff/ashtray,
+/obj/effect/spawner/random/ms13/smokeable/lowrandom,
 /turf/open/floor/ms13/ceramic,
 /area/ms13/desert)
 "bho" = (
@@ -1223,6 +1239,7 @@
 /obj/structure/ms13/trash/papers{
 	dir = 1
 	},
+/obj/effect/spawner/random/ms13/drugs/prewar,
 /turf/open/floor/ms13/tile/full/green,
 /area/ms13/town)
 "bxt" = (
@@ -1884,8 +1901,10 @@
 /obj/structure/closet/crate/ms13/footlocker{
 	dir = 4
 	},
-/obj/effect/spawner/random/ms13/melee/tier1,
 /obj/effect/spawner/random/ms13/food/packaged,
+/obj/effect/spawner/random/ms13/food/packaged,
+/obj/effect/spawner/random/ms13/melee/lowrandom,
+/obj/effect/spawner/random/ms13/currency/drought/highrandom,
 /turf/open/floor/plating/ms13/ground/desertalt,
 /area/ms13/desert)
 "ceS" = (
@@ -1894,6 +1913,10 @@
 	},
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
+"cfe" = (
+/obj/effect/landmark/start/ms13/nomad,
+/turf/open/floor/plating/ms13/ground/desertalt,
+/area/ms13/desert)
 "cfM" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/ms13/tile/large/cream,
@@ -2111,7 +2134,7 @@
 /obj/item/ms13/fluff/ashtray{
 	pixel_y = -12
 	},
-/obj/effect/spawner/random/ms13/tools/radio,
+/obj/effect/spawner/random/ms13/smokeable/general,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "cqc" = (
@@ -2151,6 +2174,11 @@
 	dir = 1
 	},
 /turf/open/floor/ms13/concrete/industrial,
+/area/ms13/town)
+"ctc" = (
+/obj/machinery/door/unpowered/ms13/wood/blue,
+/obj/effect/spawner/random/ms13/locked/random/lowchance,
+/turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "ctd" = (
 /obj/effect/decal/cleanable/glass,
@@ -2303,6 +2331,11 @@
 	},
 /turf/open/floor/plating/ms13/ground/road,
 /area/ms13/town)
+"cDt" = (
+/obj/structure/table/ms13/wood/constructed,
+/obj/effect/spawner/random/ms13/smokeable/general,
+/turf/open/floor/ms13/concrete,
+/area/ms13/water_baron/interior)
 "cDX" = (
 /obj/structure/ms13/rug/rubber{
 	dir = 4
@@ -2348,6 +2381,7 @@
 /area/ms13/town)
 "cIk" = (
 /obj/structure/table/ms13/wood/constructed,
+/obj/effect/spawner/random/ms13/smokeable/general,
 /turf/open/floor/wood/ms13/common,
 /area/ms13/water_baron/interior)
 "cIx" = (
@@ -2459,6 +2493,12 @@
 	},
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/factory)
+"cOl" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 6
+	},
+/turf/open/floor/plating/ms13/ground/desert,
+/area/ms13/desert)
 "cPC" = (
 /obj/effect/turf_decal/ms13/covering/paint/white,
 /turf/closed/wall/ms13/siding/blue,
@@ -2730,7 +2770,7 @@
 /area/ms13/factory)
 "dhx" = (
 /obj/structure/table/ms13/wood/constructed,
-/obj/effect/spawner/random/ms13/medical/lowrandom,
+/obj/effect/spawner/random/ms13/smokeable/lowrandom,
 /turf/open/floor/plating/ms13/ground/desertalt,
 /area/ms13/desert)
 "dib" = (
@@ -3083,6 +3123,7 @@
 /obj/structure/ms13/rug/rubber{
 	dir = 4
 	},
+/obj/effect/spawner/random/ms13/drink/alcohol,
 /turf/open/floor/plating/ms13/ground/desertalt,
 /area/ms13/town)
 "dxk" = (
@@ -3207,6 +3248,11 @@
 	},
 /turf/open/floor/ms13/concrete,
 /area/ms13/rangeroutpost/building)
+"dIQ" = (
+/obj/structure/table/ms13/wood/bar,
+/obj/effect/spawner/random/ms13/smokeable/general,
+/turf/open/floor/wood/ms13/carpet/shaggy,
+/area/ms13/town)
 "dJN" = (
 /obj/machinery/light/ms13/bulb,
 /turf/open/floor/wood/ms13/common,
@@ -3302,7 +3348,7 @@
 /obj/machinery/door/unpowered/ms13/seethrough/grate{
 	dir = 1
 	},
-/obj/effect/spawner/random/ms13/locked/random/highchance,
+/obj/effect/spawner/random/ms13/locked/guaranteed/random,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "dQt" = (
@@ -3483,6 +3529,11 @@
 /obj/structure/ms13/rug/mat/rubber,
 /turf/open/floor/ms13/tile/long,
 /area/ms13/town)
+"eej" = (
+/obj/structure/bed/ms13/sleepingbag/green,
+/obj/effect/landmark/start/ms13/nomad,
+/turf/open/floor/plating/ms13/ground/desert,
+/area/ms13/desert)
 "eeM" = (
 /obj/structure/ms13/sandbag,
 /turf/open/floor/plating/ms13/ground/road,
@@ -3695,6 +3746,8 @@
 /obj/machinery/light/ms13{
 	dir = 8
 	},
+/obj/effect/spawner/random/ms13/melee/lowrandom,
+/obj/effect/spawner/random/ms13/tools/tool,
 /turf/open/floor/ms13/concrete/small,
 /area/ms13/water_baron/interior)
 "ern" = (
@@ -3989,6 +4042,7 @@
 /obj/structure/table/ms13/no_smooth/large/wood/square{
 	dir = 4
 	},
+/obj/effect/spawner/random/ms13/smokeable/lowrandom,
 /turf/open/floor/wood/ms13/common,
 /area/ms13/town)
 "eKQ" = (
@@ -4216,6 +4270,7 @@
 /obj/structure/table/ms13/no_smooth/counter/wood{
 	dir = 4
 	},
+/obj/effect/spawner/random/ms13/food/packaged,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "eVK" = (
@@ -4270,6 +4325,11 @@
 "faV" = (
 /obj/structure/table/ms13/wood/constructed,
 /obj/effect/spawner/random/ms13/tools/hardware,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/town)
+"fbe" = (
+/obj/effect/mob_spawn/corpse/human/ms13/nomad,
+/obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "fbW" = (
@@ -5200,6 +5260,7 @@
 /area/ms13/town)
 "gfc" = (
 /obj/structure/table/ms13/no_smooth/metal,
+/obj/effect/spawner/random/ms13/food/trash,
 /turf/open/floor/ms13/tile/large/cafeteria,
 /area/ms13/town)
 "gfA" = (
@@ -5552,6 +5613,10 @@
 /obj/structure/ms13/storage/large/shelf,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
+"gxO" = (
+/obj/effect/mob_spawn/corpse/human/ms13/nomad,
+/turf/open/floor/plating/ms13/ground/road,
+/area/ms13/desert)
 "gyS" = (
 /obj/machinery/door/poddoor/shutters/ms13/horizontal/indestructible/red/right{
 	id = "apparatus_bay1"
@@ -5646,8 +5711,8 @@
 /turf/open/floor/plating/ms13/ground/road,
 /area/ms13/desert)
 "gEf" = (
-/obj/structure/ms13/fruit_empty,
 /obj/structure/ms13/wall_decor/clock,
+/obj/machinery/vending/ms13/sarsaparilla,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "gEp" = (
@@ -5733,6 +5798,13 @@
 /obj/effect/spawner/random/ms13/tools/hardware,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/drylanders/building)
+"gLf" = (
+/obj/structure/table/ms13/no_smooth/counter/wood{
+	dir = 1
+	},
+/obj/effect/spawner/random/ms13/drink/soda,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/town)
 "gLF" = (
 /obj/effect/spawner/random/ms13/guaranteed/food/junkfood_canned,
 /turf/open/floor/ms13/tile/brown/big,
@@ -5741,6 +5813,7 @@
 /obj/structure/table/ms13/no_smooth/counter/wood{
 	dir = 4
 	},
+/obj/effect/spawner/random/ms13/smokeable/general,
 /turf/open/floor/wood/ms13/carpet/shaggy/blue,
 /area/ms13/town)
 "gMI" = (
@@ -5774,6 +5847,13 @@
 /obj/structure/ms13/wall_decor/calendar,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
+"gNU" = (
+/obj/effect/spawner/random/ms13/food/trash,
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/turf/open/floor/plating/ms13/ground/desert,
+/area/ms13/desert)
 "gOn" = (
 /obj/machinery/door/unpowered/ms13/metal{
 	dir = 1
@@ -6651,6 +6731,8 @@
 /area/ms13/town)
 "hRi" = (
 /obj/structure/closet/crate/ms13/woodcrate/compact,
+/obj/effect/spawner/random/ms13/food/packaged,
+/obj/effect/spawner/random/ms13/food/packaged,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "hRw" = (
@@ -7169,6 +7251,11 @@
 /obj/machinery/door/unpowered/ms13/seethrough/mirrored/grate,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
+"iws" = (
+/obj/structure/table/ms13/metal/grate,
+/obj/effect/spawner/random/ms13/smokeable/general,
+/turf/open/floor/ms13/tile/large/cafeteria,
+/area/ms13/rangeroutpost/building)
 "iwH" = (
 /obj/machinery/ms13/terminal/wasteland,
 /turf/open/floor/ms13/concrete/industrial,
@@ -7177,6 +7264,7 @@
 /obj/structure/chair/ms13/wood/padded{
 	dir = 4
 	},
+/obj/effect/spawner/random/ms13/smokeable/general,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "iyG" = (
@@ -7272,6 +7360,8 @@
 /area/ms13/town)
 "iDP" = (
 /obj/structure/closet/crate/ms13/woodcrate,
+/obj/effect/spawner/random/ms13/crafting/lowrandom,
+/obj/effect/spawner/random/ms13/crafting/lowrandom,
 /turf/open/floor/ms13/metal/grate/border,
 /area/ms13/water_baron/interior)
 "iEn" = (
@@ -7578,6 +7668,7 @@
 /obj/machinery/light/ms13{
 	dir = 1
 	},
+/obj/effect/spawner/random/ms13/smokeable/general,
 /turf/open/floor/ms13/concrete,
 /area/ms13/town)
 "iVK" = (
@@ -7596,6 +7687,11 @@
 "iWz" = (
 /obj/structure/ms13/storage/shelf/wood/alt,
 /turf/open/floor/wood/ms13/carpet/shaggy,
+/area/ms13/town)
+"iWM" = (
+/obj/machinery/door/unpowered/ms13/metal,
+/obj/effect/spawner/random/ms13/locked/random/lowchance,
+/turf/open/floor/ms13/concrete,
 /area/ms13/town)
 "iWZ" = (
 /turf/open/floor/plating/ms13/ground/road,
@@ -7633,6 +7729,7 @@
 /obj/structure/ms13/storage/shelf{
 	dir = 4
 	},
+/obj/effect/spawner/random/ms13/crafting/household,
 /turf/open/floor/ms13/ceramic,
 /area/ms13/desert)
 "jae" = (
@@ -7668,6 +7765,7 @@
 /area/ms13/town)
 "jck" = (
 /obj/machinery/door/unpowered/ms13/metal/mirrored/red,
+/obj/effect/spawner/random/ms13/locked/random/lowchance,
 /turf/open/floor/plating/ms13/ground/desertalt,
 /area/ms13/town)
 "jcY" = (
@@ -7710,6 +7808,11 @@
 "jeX" = (
 /obj/effect/spawner/random/ms13/food/trash,
 /turf/open/floor/wood/ms13/carpet/shaggy/green,
+/area/ms13/town)
+"jfN" = (
+/obj/structure/table/ms13/wood,
+/obj/effect/spawner/random/ms13/smokeable/general,
+/turf/open/floor/wood/ms13/carpet/shaggy,
 /area/ms13/town)
 "jgb" = (
 /obj/item/reagent_containers/food/drinks/mug/ms13{
@@ -8073,6 +8176,7 @@
 /area/ms13/town)
 "jCv" = (
 /obj/structure/ms13/storage/shelf/wood/alt,
+/obj/effect/spawner/random/ms13/tools/lights,
 /turf/open/floor/ms13/metal/pipe,
 /area/ms13/water_baron/interior)
 "jCS" = (
@@ -8430,6 +8534,7 @@
 "jYi" = (
 /obj/structure/bed/ms13/bedframe/wood,
 /obj/structure/bed/ms13/mattress/dirty,
+/obj/effect/landmark/start/ms13/nomad,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "jYv" = (
@@ -8829,6 +8934,13 @@
 /obj/structure/ms13/skeleton,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
+"kzS" = (
+/obj/structure/table/ms13/no_smooth/counter/wood/crafted{
+	dir = 1
+	},
+/obj/effect/spawner/random/ms13/drink/alcohol,
+/turf/open/floor/ms13/metal/grate/border/warning,
+/area/ms13/water_baron/interior)
 "kAc" = (
 /obj/machinery/ms13/terminal/wall{
 	dir = 4;
@@ -8924,6 +9036,13 @@
 	},
 /turf/open/floor/plating/ms13/ground/mountain/drought,
 /area/ms13/town)
+"kDl" = (
+/obj/structure/ms13/storage/large/shelf{
+	dir = 4
+	},
+/obj/effect/spawner/random/ms13/medical/lowrandom,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/town)
 "kDm" = (
 /obj/structure/railing/ms13/solo/industrial{
 	dir = 8
@@ -8996,6 +9115,7 @@
 "kGS" = (
 /obj/structure/table/ms13/no_smooth/wood/low,
 /obj/item/ms13/fluff/ashtray,
+/obj/effect/spawner/random/ms13/smokeable/general,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "kHU" = (
@@ -9128,6 +9248,7 @@
 /obj/structure/ms13/bars/slot/rusty{
 	dir = 4
 	},
+/obj/effect/spawner/random/ms13/smokeable/general,
 /turf/open/floor/ms13/concrete,
 /area/ms13/rangeroutpost/building)
 "kOs" = (
@@ -9177,6 +9298,7 @@
 /obj/structure/ms13/storage/shelf{
 	dir = 1
 	},
+/obj/effect/spawner/random/ms13/crafting/electrical,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "kPT" = (
@@ -9240,10 +9362,10 @@
 /turf/open/floor/ms13/tile/large/cream,
 /area/ms13/town)
 "kTl" = (
-/obj/machinery/door/unpowered/ms13/seethrough/grate{
+/obj/effect/spawner/random/ms13/locked/random/lowchance,
+/obj/machinery/door/unpowered/ms13/metal/red{
 	dir = 8
 	},
-/obj/effect/spawner/random/ms13/locked/random/lowchance,
 /turf/open/floor/ms13/concrete,
 /area/ms13/town)
 "kTn" = (
@@ -9560,6 +9682,7 @@
 "lku" = (
 /obj/item/ms13/fluff/ruined_book,
 /obj/structure/table/ms13/wood,
+/obj/effect/spawner/random/ms13/currency/drought/lowrandom,
 /turf/open/floor/wood/ms13/carpet/shaggy,
 /area/ms13/town)
 "lkx" = (
@@ -9594,7 +9717,7 @@
 /obj/item/ms13/fluff/ashtray{
 	pixel_y = 5
 	},
-/obj/effect/spawner/random/ms13/drink/soda,
+/obj/effect/spawner/random/ms13/smokeable/general,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "lmF" = (
@@ -10288,6 +10411,13 @@
 /obj/structure/ms13/wall_decor/clock,
 /turf/open/floor/wood/ms13/carpet/shaggy,
 /area/ms13/town)
+"lZe" = (
+/obj/structure/table/ms13/no_smooth/counter/wood{
+	dir = 8
+	},
+/obj/effect/spawner/random/ms13/food/packaged,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/town)
 "lZH" = (
 /obj/structure/table/ms13/metal/grate,
 /obj/machinery/light/ms13{
@@ -10419,6 +10549,7 @@
 /obj/machinery/door/unpowered/ms13/wood/blue{
 	dir = 8
 	},
+/obj/effect/spawner/random/ms13/locked/random/medchance,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "mhq" = (
@@ -10490,6 +10621,7 @@
 /obj/structure/closet/crate/ms13/woodcrate/compact/army,
 /obj/effect/spawner/random/ms13/guaranteed/gun/lowrandom,
 /obj/effect/spawner/random/ms13/guaranteed/ammo/lowrandom,
+/obj/effect/spawner/random/ms13/power_armor/parts,
 /turf/open/floor/ms13/tile/brown/big,
 /area/ms13/town)
 "mlJ" = (
@@ -10528,6 +10660,11 @@
 	},
 /turf/open/floor/plating/ms13/ground/desert,
 /area/ms13/desert)
+"moK" = (
+/obj/machinery/light/ms13/bulb,
+/mob/living/basic/ms13/hostile_animal/mantis,
+/turf/open/floor/ms13/tile,
+/area/ms13/town)
 "moV" = (
 /obj/structure/table/ms13/no_smooth/counter/metal/bend{
 	dir = 8
@@ -11046,6 +11183,7 @@
 	pixel_x = -10;
 	pixel_y = 3
 	},
+/obj/effect/spawner/random/ms13/smokeable/general,
 /turf/open/floor/plating/ms13/ground/desertalt,
 /area/ms13/town)
 "mXK" = (
@@ -11214,6 +11352,8 @@
 "nhA" = (
 /obj/structure/ms13/fence/wire,
 /obj/structure/closet/crate/ms13/woodcrate,
+/obj/effect/spawner/random/ms13/tools/tool,
+/obj/effect/spawner/random/ms13/tools/hardware,
 /turf/open/floor/plating/ms13/ground/desertalt,
 /area/ms13/desert)
 "nhB" = (
@@ -11415,10 +11555,17 @@
 	},
 /turf/open/floor/ms13/tile/large/cream,
 /area/ms13/factory)
+"nta" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/turf/open/floor/plating/ms13/ground/desert,
+/area/ms13/desert)
 "ntK" = (
 /obj/machinery/door/unpowered/ms13/metal{
 	dir = 4
 	},
+/obj/effect/spawner/random/ms13/locked/random/lowchance,
 /turf/open/floor/ms13/tile/full/green,
 /area/ms13/town)
 "ntX" = (
@@ -11426,6 +11573,13 @@
 	dir = 8
 	},
 /turf/open/floor/ms13/tile/large/cream,
+/area/ms13/town)
+"nua" = (
+/obj/machinery/door/unpowered/ms13/metal{
+	dir = 4
+	},
+/obj/effect/spawner/random/ms13/locked/random/highchance,
+/turf/open/floor/ms13/concrete,
 /area/ms13/town)
 "nux" = (
 /obj/machinery/light/ms13/bulb{
@@ -11449,6 +11603,11 @@
 /area/ms13/town)
 "nvU" = (
 /turf/open/floor/ms13/tile/large/black,
+/area/ms13/town)
+"nwa" = (
+/obj/machinery/door/unpowered/ms13/metal,
+/obj/effect/spawner/random/ms13/locked/random/medchance,
+/turf/open/floor/ms13/concrete,
 /area/ms13/town)
 "nwC" = (
 /obj/structure/ms13/storage/bookshelf,
@@ -11480,6 +11639,7 @@
 "nzL" = (
 /obj/structure/table/ms13/wood/bar,
 /obj/machinery/light/ms13,
+/obj/effect/spawner/random/ms13/smokeable/general,
 /turf/open/floor/wood/ms13/carpet/shaggy,
 /area/ms13/town)
 "nzQ" = (
@@ -11621,7 +11781,7 @@
 /obj/structure/table/ms13/no_smooth/counter/wood/crafted{
 	dir = 8
 	},
-/obj/effect/spawner/random/ms13/crafting/electrical,
+/obj/effect/spawner/random/ms13/crafting/lowrandom,
 /turf/open/floor/plating/ms13/ground/desertalt,
 /area/ms13/town)
 "nHo" = (
@@ -11660,6 +11820,7 @@
 /obj/machinery/door/unpowered/ms13/seethrough/metal{
 	dir = 1
 	},
+/obj/effect/spawner/random/ms13/locked/random/lowchance,
 /turf/open/floor/wood/ms13/mosaic,
 /area/ms13/town)
 "nIz" = (
@@ -11772,6 +11933,11 @@
 	dir = 4
 	},
 /turf/open/floor/wood/ms13/carpet/shaggy/green,
+/area/ms13/town)
+"nOT" = (
+/obj/structure/table/ms13/no_smooth/wood/low,
+/obj/effect/spawner/random/ms13/crafting/household,
+/turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "nPq" = (
 /obj/structure/chair/ms13/metal/red/broken{
@@ -12016,6 +12182,13 @@
 	},
 /turf/open/floor/plating/ms13/ground/desert,
 /area/ms13/desert)
+"oeK" = (
+/obj/machinery/door/unpowered/ms13/metal{
+	dir = 1
+	},
+/obj/effect/spawner/random/ms13/locked/random/medchance,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/town)
 "ofP" = (
 /mob/living/basic/ms13/hostile_animal/gecko,
 /turf/open/floor/plating/ms13/ground/desertalt,
@@ -12051,6 +12224,13 @@
 /obj/item/shovel/ms13,
 /turf/open/floor/plating/ms13/ground/desertalt,
 /area/ms13/desert)
+"ohy" = (
+/obj/machinery/door/unpowered/ms13/metal{
+	dir = 4
+	},
+/obj/effect/spawner/random/ms13/locked/random/medchance,
+/turf/open/floor/ms13/concrete/industrial,
+/area/ms13/town)
 "oiX" = (
 /obj/structure/table/ms13/low_wall/concrete,
 /turf/open/floor/ms13/concrete/industrial,
@@ -12156,6 +12336,10 @@
 /obj/structure/ms13/storage/vent,
 /turf/open/floor/ms13/metal/grate,
 /area/ms13/water_baron/interior)
+"oqo" = (
+/obj/effect/mob_spawn/corpse/human/ms13/nomad,
+/turf/open/floor/ms13/concrete/industrial,
+/area/ms13/town)
 "oqM" = (
 /obj/effect/spawner/random/ms13/drugs/lowrandom,
 /turf/open/floor/plating/ms13/ground/desertalt,
@@ -12717,6 +12901,7 @@
 /area/ms13/water_baron)
 "oTs" = (
 /obj/structure/chair/ms13/wood,
+/obj/effect/landmark/start/ms13/nomad,
 /turf/open/floor/plating/ms13/ground/sidewalk,
 /area/ms13/town)
 "oTD" = (
@@ -12768,6 +12953,10 @@
 	},
 /turf/open/floor/plating/ms13/ground/desert,
 /area/ms13/legioncamp)
+"oWj" = (
+/obj/effect/spawner/random/ms13/crafting/lowrandom,
+/turf/open/floor/plating/ms13/ground/mountain/drought,
+/area/ms13/town)
 "oWl" = (
 /obj/structure/closet/crate/ms13/woodcrate,
 /obj/effect/spawner/random/ms13/medical/herbal,
@@ -12862,6 +13051,7 @@
 /area/ms13/town)
 "pad" = (
 /obj/machinery/door/unpowered/ms13/metal/alt,
+/obj/effect/spawner/random/ms13/locked/random/medchance,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "pba" = (
@@ -12978,6 +13168,10 @@
 /obj/structure/ms13/pay_phone,
 /turf/open/floor/plating/ms13/ground/sidewalk,
 /area/ms13/town)
+"pgb" = (
+/obj/effect/mob_spawn/corpse/human/ms13/nomad,
+/turf/open/floor/plating/ms13/ground/desert,
+/area/ms13/desert)
 "phq" = (
 /obj/structure/table/ms13/low_wall/scrap/blue,
 /obj/structure/window/fulltile/ms13/glass,
@@ -13087,6 +13281,10 @@
 "pqg" = (
 /turf/open/floor/ms13/concrete,
 /area/ms13/water_baron)
+"pqn" = (
+/obj/effect/spawner/random/ms13/crafting/electrical,
+/turf/open/floor/plating/ms13/ground/mountain/drought,
+/area/ms13/town)
 "pqx" = (
 /obj/structure/ms13/pot/plant,
 /turf/open/floor/wood/ms13/carpet/shaggy/blue,
@@ -13338,6 +13536,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/ms13/showerdrains/small,
+/mob/living/basic/ms13/hostile_animal/radroach,
 /turf/open/floor/ms13/tile/blue/long,
 /area/ms13/town)
 "pCn" = (
@@ -13678,6 +13877,17 @@
 /obj/structure/ms13/departure,
 /turf/open/floor/plating/ms13/ground/desert,
 /area/ms13/desert)
+"qba" = (
+/obj/structure/table/ms13/wood,
+/obj/effect/spawner/random/ms13/smokeable/general,
+/turf/open/floor/wood/ms13/common,
+/area/ms13/town)
+"qbV" = (
+/obj/structure/closet/crate/ms13/woodcrate/compact,
+/obj/effect/spawner/random/ms13/crafting/household,
+/obj/effect/spawner/random/ms13/crafting/household,
+/turf/open/floor/ms13/concrete/industrial,
+/area/ms13/town)
 "qdu" = (
 /obj/structure/table/ms13/no_smooth/wood,
 /obj/structure/ms13/wall_decor/calendar,
@@ -13689,6 +13899,7 @@
 	pixel_x = -10;
 	pixel_y = -4
 	},
+/obj/effect/spawner/random/ms13/smokeable/general,
 /turf/open/floor/wood/ms13/carpet/shaggy/blue,
 /area/ms13/town)
 "qdA" = (
@@ -13696,6 +13907,7 @@
 /obj/machinery/light/ms13{
 	dir = 8
 	},
+/obj/machinery/vending/ms13/nuka,
 /turf/open/floor/ms13/tile/large/cream,
 /area/ms13/town)
 "qeu" = (
@@ -13948,6 +14160,7 @@
 /obj/structure/closet/crate/ms13/woodcrate/compact,
 /obj/effect/spawner/random/ms13/crafting/lowrandom,
 /obj/effect/spawner/random/ms13/crafting/lowrandom,
+/obj/effect/spawner/random/ms13/power_armor/parts,
 /turf/open/floor/plating/ms13/ground/desert,
 /area/ms13/desert)
 "qpP" = (
@@ -14324,6 +14537,7 @@
 /obj/structure/closet/crate/ms13/red,
 /obj/effect/spawner/random/ms13/armor/lowrandom,
 /obj/effect/spawner/random/ms13/tools/lights,
+/obj/effect/spawner/random/ms13/medical/lowrandom,
 /turf/open/floor/plating/ms13/ground/desertalt,
 /area/ms13/desert)
 "qFU" = (
@@ -14399,6 +14613,11 @@
 	},
 /turf/open/floor/ms13/metal/grate,
 /area/ms13/water_baron/interior)
+"qMb" = (
+/obj/structure/ms13/storage/shelf/wood/alt,
+/obj/effect/spawner/random/ms13/tools/tool,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/town)
 "qMq" = (
 /obj/structure/closet/crate/ms13/footlocker{
 	dir = 4
@@ -14500,6 +14719,7 @@
 	pixel_x = 7;
 	pixel_y = -3
 	},
+/obj/effect/spawner/random/ms13/smokeable/general,
 /turf/open/floor/plating/ms13/ground/desert,
 /area/ms13/desert)
 "qQL" = (
@@ -14552,6 +14772,7 @@
 /area/ms13/town)
 "qSx" = (
 /obj/structure/ms13/wall_decor/exit,
+/obj/effect/spawner/random/ms13/food/trash,
 /turf/open/floor/plating/ms13/ground/sidewalk,
 /area/ms13/desert)
 "qSN" = (
@@ -15385,6 +15606,9 @@
 "rRy" = (
 /obj/structure/ms13/fence/wire,
 /obj/structure/closet/crate/ms13/woodcrate/compact,
+/obj/effect/spawner/random/ms13/smokeable/highrandom,
+/obj/effect/spawner/random/ms13/smokeable/highrandom,
+/obj/effect/spawner/random/ms13/smokeable/general,
 /turf/open/floor/plating/ms13/ground/desert,
 /area/ms13/desert)
 "rRz" = (
@@ -15697,6 +15921,7 @@
 "skl" = (
 /obj/structure/table/ms13/metal/small,
 /obj/item/ms13/fluff/ashtray,
+/obj/effect/spawner/random/ms13/smokeable/general,
 /turf/open/floor/ms13/tile/large/cream,
 /area/ms13/town)
 "skF" = (
@@ -15765,6 +15990,7 @@
 "soP" = (
 /obj/structure/table/ms13/metal/heavy,
 /obj/effect/spawner/random/ms13/tools/radio,
+/obj/effect/spawner/random/ms13/crafting/electrical,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "sqy" = (
@@ -15954,6 +16180,10 @@
 /area/ms13/town)
 "syV" = (
 /turf/closed/wall/ms13/adobe,
+/area/ms13/desert)
+"syY" = (
+/obj/effect/spawner/random/ms13/tools/tool,
+/turf/open/floor/plating/ms13/ground/desertalt,
 /area/ms13/desert)
 "sze" = (
 /obj/effect/decal/cleanable/blood/drip{
@@ -16213,6 +16443,7 @@
 /area/ms13/town)
 "sRh" = (
 /obj/structure/closet/crate/ms13/woodcrate/compact/boom,
+/obj/effect/spawner/random/ms13/ammo/highrandom,
 /turf/open/floor/plating/ms13/ground/desertalt,
 /area/ms13/desert)
 "sRn" = (
@@ -16734,6 +16965,11 @@
 "tuR" = (
 /turf/open/floor/plating/ms13/ground/sidewalk,
 /area/ms13/water_baron/interior)
+"tvf" = (
+/obj/structure/ms13/storage/large/shelf/wood,
+/obj/effect/spawner/random/ms13/crafting/household,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/town)
 "tvj" = (
 /obj/structure/ms13/storage/bookshelf,
 /turf/open/floor/wood/ms13/wide,
@@ -16984,6 +17220,11 @@
 /obj/structure/ms13/rug/red,
 /turf/open/floor/plating/ms13/ground/desertalt,
 /area/ms13/town)
+"tGL" = (
+/obj/machinery/door/unpowered/ms13/wood,
+/obj/effect/spawner/random/ms13/locked/random/lowchance,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/town)
 "tHq" = (
 /obj/effect/decal/cleanable/glass{
 	dir = 8
@@ -17062,6 +17303,13 @@
 "tLH" = (
 /mob/living/basic/ms13/hostile_animal/radroach,
 /turf/open/floor/ms13/tile/large/cream,
+/area/ms13/town)
+"tMc" = (
+/obj/structure/table/ms13/no_smooth/counter/wood{
+	dir = 8
+	},
+/obj/effect/spawner/random/ms13/drink/alcohol,
+/turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "tMm" = (
 /mob/living/basic/ms13/hostile_animal/gecko,
@@ -17438,6 +17686,7 @@
 /obj/structure/ms13/trash/papers{
 	dir = 1
 	},
+/obj/effect/spawner/random/ms13/smokeable/highrandom,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "uhg" = (
@@ -17491,6 +17740,13 @@
 	dir = 4
 	},
 /obj/effect/spawner/random/ms13/locked/random/medchance,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/town)
+"uls" = (
+/obj/machinery/light/ms13,
+/obj/machinery/vending/ms13/cigarettes{
+	dir = 1
+	},
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "ulA" = (
@@ -18226,6 +18482,7 @@
 /obj/structure/ms13/storage/large/shelf{
 	dir = 4
 	},
+/obj/effect/spawner/random/ms13/tools/hardware,
 /turf/open/floor/ms13/tile/large/cafeteria,
 /area/ms13/town)
 "vcp" = (
@@ -18272,6 +18529,7 @@
 /obj/structure/table/ms13/metal/small,
 /obj/item/ms13/fluff/ashtray,
 /obj/structure/noticeboard/ms13/cork,
+/obj/effect/spawner/random/ms13/smokeable/general,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "vdY" = (
@@ -18454,6 +18712,7 @@
 /area/ms13/underground/mountain)
 "vnQ" = (
 /obj/structure/table/ms13/no_smooth/wood/square,
+/obj/effect/spawner/random/ms13/smokeable/lowrandom,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "vnS" = (
@@ -18550,6 +18809,12 @@
 /obj/structure/chair/ms13/metal,
 /turf/open/floor/ms13/concrete,
 /area/ms13/town)
+"vrO" = (
+/obj/structure/bed/ms13/bedframe/wire,
+/obj/structure/bed/ms13/mattress/dirty,
+/obj/effect/landmark/start/ms13/denizen,
+/turf/open/floor/wood/ms13/common,
+/area/ms13/water_baron/interior)
 "vuj" = (
 /obj/structure/bed/ms13/sleepingbag/red,
 /obj/structure/ms13/rug/rubber{
@@ -18635,6 +18900,7 @@
 "vxS" = (
 /obj/structure/table/ms13/metal/grate,
 /obj/machinery/light/ms13,
+/obj/effect/spawner/random/ms13/tools/tool,
 /obj/effect/spawner/random/ms13/tools/tool,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
@@ -18802,6 +19068,7 @@
 /obj/machinery/light/ms13/bulb/industrial{
 	dir = 8
 	},
+/obj/effect/spawner/random/ms13/smokeable/general,
 /turf/open/floor/ms13/concrete/small,
 /area/ms13/water_baron/interior)
 "vJN" = (
@@ -18864,6 +19131,10 @@
 /obj/effect/spawner/random/ms13/drugs/lowrandom,
 /turf/open/floor/ms13/concrete/small,
 /area/ms13/water_baron/interior)
+"vPT" = (
+/obj/effect/spawner/random/ms13/drugs/lowrandom,
+/turf/open/floor/ms13/tile/blue/long,
+/area/ms13/town)
 "vQf" = (
 /obj/structure/ms13/storage/shelf/wood/alt,
 /turf/open/floor/ms13/concrete,
@@ -18934,6 +19205,7 @@
 "vTg" = (
 /obj/structure/table/ms13/metal/heavy,
 /obj/structure/ms13/rug/rubber,
+/obj/effect/spawner/random/ms13/smokeable/general,
 /turf/open/floor/ms13/concrete,
 /area/ms13/water_baron/interior)
 "vTi" = (
@@ -19043,6 +19315,7 @@
 /obj/structure/table/ms13/no_smooth/counter/metal{
 	dir = 1
 	},
+/obj/effect/spawner/random/ms13/food/packaged,
 /turf/open/floor/ms13/tile/long,
 /area/ms13/town)
 "vZl" = (
@@ -19231,6 +19504,7 @@
 /obj/structure/table/ms13/metal/small,
 /obj/item/ms13/fluff/ashtray,
 /obj/structure/noticeboard/ms13/cork,
+/obj/effect/spawner/random/ms13/smokeable/lowrandom,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "wrX" = (
@@ -19253,6 +19527,13 @@
 	},
 /obj/effect/spawner/random/ms13/armor/lowrandom,
 /turf/open/floor/ms13/tile/large/cream,
+/area/ms13/town)
+"wsD" = (
+/obj/machinery/door/unpowered/ms13/wood{
+	dir = 1
+	},
+/obj/effect/spawner/random/ms13/locked/random/lowchance,
+/turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "wtK" = (
 /obj/structure/ms13/street_sign/speed,
@@ -19661,6 +19942,13 @@
 /obj/effect/spawner/random/ms13/currency/drought/lowrandom,
 /turf/open/floor/ms13/concrete,
 /area/ms13/desert)
+"wSb" = (
+/obj/machinery/door/unpowered/ms13/metal{
+	dir = 8
+	},
+/obj/effect/spawner/random/ms13/locked/random/highchance,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/town)
 "wTp" = (
 /turf/open/floor/ms13/tile,
 /area/ms13/town)
@@ -19743,6 +20031,13 @@
 "wWE" = (
 /obj/structure/bed/ms13/bedframe/wire,
 /obj/structure/bed/ms13/mattress/old,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/town)
+"wWY" = (
+/obj/structure/table/ms13/no_smooth/counter/wood{
+	dir = 8
+	},
+/obj/effect/spawner/random/ms13/medical/lowrandom,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "wWZ" = (
@@ -20143,13 +20438,6 @@
 /obj/structure/ms13/pipes/vertical/east/valve,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
-"xxs" = (
-/obj/structure/ms13/storage/store{
-	dir = 8
-	},
-/obj/effect/spawner/random/ms13/drink/alcohol,
-/turf/open/floor/wood/ms13/carpet/shaggy,
-/area/ms13/town)
 "xxC" = (
 /obj/structure/ms13/toilet{
 	dir = 8
@@ -20210,7 +20498,7 @@
 /obj/machinery/light/ms13{
 	dir = 1
 	},
-/obj/structure/ms13/barrel/double/grey,
+/obj/machinery/vending/ms13/nuka,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "xCf" = (
@@ -20475,6 +20763,13 @@
 /obj/effect/spawner/random/ms13/armor/lowrandom,
 /turf/open/floor/ms13/concrete,
 /area/ms13/town)
+"xTU" = (
+/obj/machinery/door/unpowered/ms13/wood{
+	dir = 8
+	},
+/obj/effect/spawner/random/ms13/locked/random/medchance,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/town)
 "xUB" = (
 /obj/structure/stairs/north,
 /turf/open/floor/ms13/concrete,
@@ -20492,6 +20787,11 @@
 /obj/effect/spawner/random/ms13/crafting/lowrandom,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
+"xVZ" = (
+/obj/structure/ms13/storage/shelf/wood/alt,
+/obj/effect/spawner/random/ms13/tools/hardware,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/town)
 "xWH" = (
 /obj/structure/chair/sofa/corner{
 	dir = 8
@@ -20500,6 +20800,7 @@
 /area/ms13/town)
 "xWX" = (
 /obj/machinery/door/unpowered/ms13/metal/alt,
+/obj/effect/spawner/random/ms13/locked/random/medchance,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "xWZ" = (
@@ -20507,6 +20808,14 @@
 /obj/item/shovel/ms13/spade,
 /turf/open/floor/plating/ms13/ground/desert,
 /area/ms13/water_baron)
+"xXz" = (
+/obj/structure/ms13/storage/large/shelf{
+	dir = 8
+	},
+/obj/effect/spawner/random/ms13/tools/hardware,
+/obj/effect/spawner/random/ms13/tools/hardware,
+/turf/open/floor/ms13/concrete,
+/area/ms13/town)
 "xXA" = (
 /obj/structure/chair/pew/right{
 	dir = 1
@@ -20545,6 +20854,13 @@
 	dir = 1
 	},
 /turf/open/floor/ms13/tile/full/green,
+/area/ms13/town)
+"xZC" = (
+/obj/machinery/door/unpowered/ms13/wood/mirrored{
+	dir = 1
+	},
+/obj/effect/spawner/random/ms13/locked/random/lowchance,
+/turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "xZV" = (
 /obj/structure/table/ms13/no_smooth/counter/metal{
@@ -23312,7 +23628,7 @@ oSs
 oSs
 ryh
 eQU
-bCJ
+lZe
 hHL
 oMe
 uoI
@@ -23683,7 +23999,7 @@ oSs
 oSs
 cvP
 fgc
-oSs
+wDd
 tFD
 cvP
 oSs
@@ -23859,7 +24175,7 @@ oSs
 oSs
 oSs
 oSs
-wgj
+oSs
 oSs
 oSs
 oSs
@@ -24682,7 +24998,7 @@ oNf
 oNf
 oNf
 jJD
-jJD
+vpO
 jJD
 jJD
 jJD
@@ -24835,7 +25151,7 @@ oSs
 oSs
 oSs
 oSs
-oSs
+wDd
 oSs
 oSs
 oSs
@@ -25441,7 +25757,7 @@ oSs
 oSs
 hgp
 rFN
-pRZ
+jfN
 eSY
 pRZ
 rFN
@@ -25884,7 +26200,7 @@ hgp
 hgp
 hgp
 hgp
-lJX
+wsD
 crx
 crx
 nVx
@@ -26136,7 +26452,7 @@ hQa
 hQa
 oSs
 rnj
-mJN
+tvf
 crx
 crx
 crx
@@ -26654,7 +26970,7 @@ hgp
 hgp
 rFN
 qnp
-wkU
+moK
 rFN
 rFN
 okW
@@ -26897,7 +27213,7 @@ aCk
 crx
 crx
 crx
-ewu
+gLf
 rFN
 oSs
 hQa
@@ -27079,7 +27395,7 @@ oSs
 oSs
 oSs
 oSs
-oSs
+wDd
 ajY
 cvP
 oSs
@@ -27998,7 +28314,7 @@ hNV
 hNV
 hNV
 iek
-mCc
+iws
 grI
 uet
 oPv
@@ -28740,7 +29056,7 @@ kOY
 nRg
 jJD
 hQa
-hQa
+gxO
 hQa
 hQa
 hQa
@@ -34587,7 +34903,7 @@ gqg
 ylS
 ylS
 ylS
-rJN
+iWM
 jJD
 jJD
 rnd
@@ -35006,7 +35322,7 @@ wIP
 wIP
 wIP
 wIP
-aPX
+ohy
 wIP
 wIP
 wIP
@@ -36369,7 +36685,7 @@ cor
 cor
 cor
 cor
-cor
+tNu
 ify
 aKJ
 aKJ
@@ -36537,7 +36853,7 @@ vYq
 dHD
 cor
 fTI
-whY
+kzS
 rmn
 cor
 cor
@@ -36602,7 +36918,7 @@ hQa
 jJD
 jJD
 wIP
-ouh
+dcc
 gcr
 plr
 ylS
@@ -37669,7 +37985,7 @@ hgp
 qxW
 afB
 dVZ
-bCJ
+tMc
 mQg
 uYc
 iyl
@@ -37747,7 +38063,7 @@ dbU
 pqg
 vYq
 ril
-tJC
+cDt
 nAg
 gDd
 sIV
@@ -37952,7 +38268,7 @@ jWG
 atj
 nAg
 oRI
-tJC
+cDt
 fRw
 aKJ
 kME
@@ -38070,7 +38386,7 @@ ewu
 qTW
 hgp
 hgp
-vfN
+oeK
 crx
 crx
 crx
@@ -38481,7 +38797,7 @@ oRc
 oRc
 iNr
 jgx
-vQP
+vPT
 iNr
 oSs
 oSs
@@ -39207,7 +39523,7 @@ oSs
 oSs
 oSs
 oSs
-jJD
+hMs
 jJD
 oSs
 oSs
@@ -39238,7 +39554,7 @@ jJD
 jJD
 jJD
 jJD
-jJD
+hMs
 jJD
 jJD
 jJD
@@ -40185,7 +40501,7 @@ fmt
 cep
 myZ
 fXv
-ewR
+vrO
 vYq
 yhI
 yhI
@@ -40434,7 +40750,7 @@ cXR
 jJD
 jJD
 jJD
-jJD
+hMs
 jJD
 jJD
 jJD
@@ -42234,7 +42550,7 @@ oSs
 oSs
 oSs
 oSs
-jJD
+hMs
 hQa
 hQa
 hQa
@@ -44647,7 +44963,7 @@ blm
 aIT
 hgp
 hgp
-hgp
+pyv
 sRh
 cXR
 mTp
@@ -46076,7 +46392,7 @@ jJD
 hQa
 wHx
 hQa
-jJD
+hMs
 oSs
 oSs
 vXM
@@ -46171,7 +46487,7 @@ blm
 blm
 blm
 blm
-oSs
+wDd
 oSs
 cXR
 cXR
@@ -46990,7 +47306,7 @@ cXR
 rsI
 rHi
 lXA
-ifR
+qba
 rHi
 mbj
 tfd
@@ -47786,7 +48102,7 @@ blm
 blm
 blm
 blm
-hgp
+syY
 ryA
 hgp
 cXR
@@ -47798,7 +48114,7 @@ rHi
 rHi
 nTW
 lXA
-ifR
+qba
 rHi
 rHi
 kdL
@@ -48090,7 +48406,7 @@ crx
 crx
 crx
 crx
-drT
+aOc
 jJD
 jJD
 hQa
@@ -48393,7 +48709,7 @@ blm
 blm
 blm
 oSs
-hgp
+fBT
 hgp
 jJD
 uoQ
@@ -48415,7 +48731,7 @@ jJD
 hQa
 hQa
 hQa
-jJD
+hMs
 hgp
 hgp
 hgp
@@ -48595,7 +48911,7 @@ blm
 blm
 blm
 oSs
-oSs
+pgb
 hgp
 jJD
 jJD
@@ -49083,7 +49399,7 @@ dOI
 xRA
 hPH
 oSs
-cuI
+eej
 hgp
 nhA
 oSs
@@ -49304,7 +49620,7 @@ euF
 oSs
 oSs
 oSs
-jJD
+hMs
 hQa
 wHx
 hQa
@@ -49430,7 +49746,7 @@ oSs
 bEh
 xdx
 koi
-xxs
+koi
 sJd
 vyK
 crx
@@ -49892,7 +50208,7 @@ kPR
 crx
 cSR
 crx
-bOa
+uZV
 cXR
 oSs
 hgp
@@ -50646,7 +50962,7 @@ tPj
 kMb
 crx
 iOX
-lQg
+dIQ
 sZC
 kMb
 eHk
@@ -50761,7 +51077,7 @@ fYk
 qRS
 ylS
 ylS
-erN
+xXz
 fYk
 wvp
 fYk
@@ -50854,7 +51170,7 @@ kMb
 eHk
 eHk
 tPj
-vpO
+jJD
 hQa
 hQa
 hQa
@@ -50930,7 +51246,7 @@ cXR
 iIY
 crx
 crx
-drT
+tGL
 crx
 crx
 crx
@@ -51166,7 +51482,7 @@ fYk
 vry
 ylS
 ylS
-rJN
+nwa
 cKM
 cKM
 cKM
@@ -51458,7 +51774,7 @@ oSs
 oSs
 oSs
 hgp
-hgp
+cfe
 hgp
 jJD
 hQa
@@ -51568,7 +51884,7 @@ oSs
 oSs
 cXR
 cXR
-hSP
+nua
 cXR
 cXR
 cXR
@@ -51629,7 +51945,7 @@ oSs
 oSs
 jJD
 jJD
-jJD
+hMs
 hQa
 hQa
 jJD
@@ -53515,7 +53831,7 @@ uhO
 aQh
 tmC
 rjS
-hRi
+qbV
 cXR
 jJD
 hQa
@@ -53541,7 +53857,7 @@ ruN
 crx
 crx
 crx
-ePG
+uls
 cXR
 jJD
 hQa
@@ -53965,7 +54281,7 @@ crx
 bUO
 crx
 crx
-crx
+fbe
 prt
 crx
 ogS
@@ -54751,7 +55067,7 @@ cXR
 cXR
 cXR
 jVU
-fio
+wSb
 cXR
 cXR
 cXR
@@ -54759,7 +55075,7 @@ pcm
 jLw
 hQa
 hQa
-jJD
+hMs
 fYk
 jFW
 lls
@@ -54955,7 +55271,7 @@ dmz
 crx
 crx
 crx
-kvN
+qMb
 oem
 jJD
 hQa
@@ -55157,7 +55473,7 @@ dmz
 wxq
 crx
 crx
-kvN
+xVZ
 cXR
 jJD
 hQa
@@ -56456,7 +56772,7 @@ cvP
 oSs
 oSs
 oSs
-oSs
+byK
 oSs
 oSs
 oSs
@@ -56641,7 +56957,7 @@ hgp
 oSs
 oSs
 hgp
-hgp
+syY
 mxc
 hgp
 oSs
@@ -56958,7 +57274,7 @@ hQa
 jJD
 jeR
 tmC
-tmC
+oqo
 tmC
 kPD
 qJJ
@@ -57065,7 +57381,7 @@ crx
 crx
 crx
 crx
-kvN
+cjC
 rFN
 oSs
 oSs
@@ -57469,7 +57785,7 @@ rFN
 rFN
 crx
 crx
-uui
+fvm
 rFN
 oSs
 oSs
@@ -57653,7 +57969,7 @@ cXR
 oDY
 vyy
 crx
-jqR
+kDl
 aXf
 tzu
 cmZ
@@ -59034,7 +59350,7 @@ tFH
 tRW
 iAo
 crx
-sYk
+xZC
 hgp
 hgp
 oSs
@@ -59876,13 +60192,13 @@ bEz
 jvs
 jvs
 jvs
-eoi
+ctc
 crx
 crx
 crx
 crx
 crx
-eoi
+ctc
 hgp
 hgp
 hgp
@@ -60688,7 +61004,7 @@ oSs
 oSs
 oSs
 oSs
-oSs
+wDd
 oSs
 syV
 iIg
@@ -60830,7 +61146,7 @@ dVW
 lXA
 oPV
 dVZ
-bCJ
+wWY
 cXR
 hgp
 hgp
@@ -61194,7 +61510,7 @@ lJX
 crx
 crx
 crx
-oAK
+auv
 gLF
 hNJ
 aFF
@@ -61505,7 +61821,7 @@ oSs
 oSs
 oSs
 oSs
-oSs
+wDd
 oSs
 oSs
 oSs
@@ -61637,7 +61953,7 @@ vHH
 dVW
 cXR
 lXA
-cwb
+ukN
 cXR
 cXR
 hgp
@@ -61800,7 +62116,7 @@ hqN
 hqN
 hqN
 nBf
-hqN
+ihN
 hqN
 hqN
 mIB
@@ -62446,7 +62762,7 @@ crx
 lXA
 crx
 qJE
-bzA
+nOT
 cXR
 hgp
 hgp
@@ -63515,7 +63831,7 @@ crx
 cXR
 cXR
 cXR
-wRs
+xTU
 cXR
 cXR
 cXR
@@ -63922,7 +64238,7 @@ crx
 crx
 crx
 crx
-drT
+tGL
 hgp
 hgp
 hgp
@@ -64676,14 +64992,14 @@ hgp
 hgp
 hgp
 hgp
-oSs
+wDd
 oSs
 iNR
 oSs
 oSs
 oSs
 oSs
-oSs
+wDd
 oSs
 oSs
 oSs
@@ -64700,8 +65016,8 @@ hgp
 hgp
 hgp
 vBv
-mTp
-mTp
+oWj
+pqn
 mTp
 mTp
 mTp
@@ -65100,7 +65416,7 @@ uKO
 iNr
 vBv
 oSs
-oSs
+nta
 oSs
 oSs
 oSs
@@ -65302,7 +65618,7 @@ vBv
 vBv
 oSs
 oSs
-oSs
+gNU
 oSs
 oSs
 oSs
@@ -65497,14 +65813,14 @@ oSs
 oSs
 oSs
 oSs
+sgj
 oSs
-oSs
-oSs
-oSs
-oSs
-oSs
-oSs
-oSs
+pgb
+lhi
+lhi
+lhi
+lhi
+cOl
 oSs
 oSs
 oSs

--- a/_maps/map_files/Drought/Drought_above.dmm
+++ b/_maps/map_files/Drought/Drought_above.dmm
@@ -224,6 +224,7 @@
 	},
 /obj/structure/ms13/wall_decor/clock,
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
+/obj/effect/spawner/random/ms13/drink/alcohol,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "aR" = (
@@ -366,6 +367,12 @@
 /turf/open/floor/ms13/concrete/cable{
 	dir = 1
 	},
+/area/ms13/town)
+"bs" = (
+/obj/structure/table/ms13/metal/grate,
+/obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
+/obj/effect/spawner/random/ms13/crafting/electrical,
+/turf/open/floor/ms13/concrete,
 /area/ms13/town)
 "bt" = (
 /obj/structure/chair/comfy/ms13/ergo,
@@ -557,6 +564,7 @@
 	pixel_x = -4;
 	pixel_y = 5
 	},
+/obj/effect/spawner/random/ms13/currency/drought/prewar/lowrandom,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "bW" = (
@@ -572,6 +580,7 @@
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /obj/structure/table/ms13/metal,
 /obj/effect/spawner/random/ms13/gun/lowrandom,
+/obj/effect/spawner/random/ms13/tools/radio,
 /turf/open/floor/ms13/concrete,
 /area/ms13/town)
 "bZ" = (
@@ -823,6 +832,7 @@
 	dir = 1
 	},
 /obj/structure/table/ms13/wood/constructed,
+/obj/effect/spawner/random/ms13/drink/soda,
 /turf/open/openspace/ms13,
 /area/ms13/desert)
 "cT" = (
@@ -1388,11 +1398,6 @@
 /obj/effect/turf_decal/ms13/covering/paint/white,
 /turf/closed/wall/ms13/brick/gray,
 /area/ms13/town)
-"eP" = (
-/obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
-/obj/structure/ms13/storage/large/shelf,
-/turf/open/floor/ms13/concrete/cable/box,
-/area/ms13/town)
 "eQ" = (
 /obj/structure/table/ms13/no_smooth/counter/wood{
 	dir = 8
@@ -1479,8 +1484,6 @@
 /area/ms13/town)
 "fh" = (
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
-/obj/effect/spawner/random/ms13/ammo/lowrandom,
-/obj/effect/spawner/random/ms13/ammo/lowrandom,
 /obj/structure/closet/crate/ms13/footlocker{
 	dir = 4
 	},
@@ -1489,6 +1492,7 @@
 /obj/effect/spawner/random/ms13/currency/drought/lowrandom,
 /obj/effect/spawner/random/ms13/currency/drought/lowrandom,
 /obj/effect/spawner/random/ms13/ammo/highrandom,
+/obj/effect/spawner/random/ms13/drink/alcohol_uncommon,
 /turf/open/floor/ms13/concrete,
 /area/ms13/water_baron)
 "fi" = (
@@ -1581,6 +1585,7 @@
 	dir = 1
 	},
 /obj/machinery/light/ms13/bulb,
+/obj/effect/spawner/random/ms13/ammo/lowrandom,
 /obj/effect/spawner/random/ms13/ammo/lowrandom,
 /turf/open/floor/wood/ms13/carpet/shaggy/blue,
 /area/ms13/town)
@@ -1860,6 +1865,7 @@
 	pixel_y = 9
 	},
 /obj/structure/table/ms13/no_smooth/dice,
+/obj/effect/spawner/random/ms13/smokeable/general,
 /turf/open/floor/plating/ms13/roof,
 /area/ms13/water_baron)
 "gw" = (
@@ -1876,6 +1882,7 @@
 	pixel_y = 7
 	},
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
+/obj/effect/spawner/random/ms13/smokeable/general,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "gB" = (
@@ -2051,6 +2058,13 @@
 	dir = 4
 	},
 /area/ms13/town)
+"hb" = (
+/obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
+/obj/structure/table/ms13/metal/grate,
+/obj/effect/spawner/random/ms13/crafting/electrical,
+/obj/effect/spawner/random/ms13/crafting/electrical,
+/turf/open/floor/ms13/concrete,
+/area/ms13/town)
 "hc" = (
 /obj/effect/turf_decal/ms13/graffiti/moyai,
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
@@ -2166,6 +2180,7 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
+/obj/effect/spawner/random/ms13/power_armor/parts,
 /turf/open/floor/ms13/tile/brown/big,
 /area/ms13/town)
 "hv" = (
@@ -2402,6 +2417,13 @@
 "ii" = (
 /turf/open/floor/plating/ms13/roof/wood,
 /area/ms13/drylanders)
+"ij" = (
+/obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
+/mob/living/basic/ms13/ghoul/radioactive,
+/turf/open/floor/ms13/concrete/cable{
+	dir = 1
+	},
+/area/ms13/town)
 "ik" = (
 /obj/structure/bed/ms13/bedframe/cot,
 /obj/structure/bed/ms13/mattress/stale,
@@ -3395,8 +3417,8 @@
 	pixel_x = 5;
 	pixel_y = 7
 	},
-/obj/effect/spawner/random/ms13/drink/alcohol,
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
+/obj/effect/spawner/random/ms13/smokeable/general,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "lE" = (
@@ -3498,6 +3520,14 @@
 /obj/structure/ms13/foundation/variantfour,
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /turf/open/openspace/ms13,
+/area/ms13/town)
+"lZ" = (
+/obj/machinery/door/unpowered/ms13/wood{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
+/obj/effect/spawner/random/ms13/locked/random/lowchance,
+/turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "ma" = (
 /obj/effect/turf_decal/ms13/covering/paint/green,
@@ -3775,6 +3805,7 @@
 /obj/machinery/door/unpowered/ms13/wood{
 	dir = 8
 	},
+/obj/effect/spawner/random/ms13/locked/random/medchance,
 /turf/open/floor/wood/ms13/carpet/shaggy/blue,
 /area/ms13/town)
 "nb" = (
@@ -4206,6 +4237,12 @@
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /turf/open/floor/wood/ms13/carpet/shaggy/green,
 /area/ms13/town)
+"os" = (
+/obj/structure/table/ms13/wood,
+/obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
+/obj/effect/spawner/random/ms13/smokeable/highrandom,
+/turf/open/floor/wood/ms13/carpet,
+/area/ms13/town)
 "ot" = (
 /obj/structure/closet/ms13/metal,
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
@@ -4428,6 +4465,7 @@
 	pixel_y = 9
 	},
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
+/obj/item/lighter/ms13/zippo,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "pi" = (
@@ -4453,6 +4491,14 @@
 	},
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /turf/open/floor/ms13/concrete/industrial,
+/area/ms13/town)
+"pl" = (
+/obj/machinery/door/unpowered/ms13/wood{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
+/obj/effect/spawner/random/ms13/locked/random/medchance,
+/turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "pm" = (
 /obj/structure/chair/comfy/ms13/ergo,
@@ -4590,6 +4636,7 @@
 	},
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
+/obj/effect/spawner/random/ms13/smokeable/highrandom,
 /turf/open/floor/wood/ms13/carpet,
 /area/ms13/town)
 "pO" = (
@@ -4911,6 +4958,12 @@
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /turf/open/floor/ms13/concrete,
 /area/ms13/water_baron/interior)
+"ra" = (
+/obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
+/obj/structure/ms13/storage/large/shelf,
+/obj/effect/spawner/random/ms13/tools/lights,
+/turf/open/floor/ms13/concrete,
+/area/ms13/town)
 "rb" = (
 /obj/effect/turf_decal/ms13/covering/wallpaper/red,
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
@@ -4952,10 +5005,10 @@
 "rj" = (
 /obj/structure/ms13/wall_decor/flag/arizona,
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
-/obj/effect/spawner/random/ms13/drink/soda,
 /obj/machinery/ms13/terminal/wasteland{
 	dir = 4
 	},
+/obj/effect/spawner/random/ms13/drink/soda_uncommon,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "rk" = (
@@ -5312,6 +5365,8 @@
 	dir = 8
 	},
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
+/obj/effect/spawner/random/ms13/crafting/lowrandom,
+/obj/effect/spawner/random/ms13/crafting/household,
 /turf/open/floor/plating/ms13/roof/metal,
 /area/ms13/town)
 "sB" = (
@@ -5444,6 +5499,11 @@
 	},
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /turf/open/openspace/ms13,
+/area/ms13/town)
+"sT" = (
+/obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
+/obj/effect/spawner/random/ms13/drugs/lowrandom,
+/turf/open/floor/ms13/tile/brown/big,
 /area/ms13/town)
 "sV" = (
 /obj/structure/chair/comfy/ms13/armchair,
@@ -5765,6 +5825,15 @@
 	},
 /obj/effect/turf_decal/ms13/showerdrains/small,
 /turf/open/floor/ms13/tile,
+/area/ms13/town)
+"ue" = (
+/obj/structure/ms13/barricade{
+	dir = 8
+	},
+/obj/structure/table/ms13/wood/constructed,
+/obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
+/obj/effect/spawner/random/ms13/drink/alcohol,
+/turf/open/floor/plating/ms13/roof/metal,
 /area/ms13/town)
 "uf" = (
 /obj/structure/bed/roller/ms13,
@@ -6093,6 +6162,8 @@
 "vh" = (
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /obj/structure/ms13/storage/large/shelf,
+/obj/effect/spawner/random/ms13/crafting/lowrandom,
+/obj/effect/spawner/random/ms13/crafting/lowrandom,
 /turf/open/floor/ms13/concrete,
 /area/ms13/town)
 "vi" = (
@@ -6233,6 +6304,7 @@
 	dir = 8
 	},
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
+/obj/effect/spawner/random/ms13/ammo/lowrandom,
 /turf/open/floor/plating/ms13/roof/metal,
 /area/ms13/town)
 "vG" = (
@@ -6488,8 +6560,7 @@
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "wx" = (
-/obj/effect/spawner/random/ms13/tools/lights,
-/obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
+/obj/effect/spawner/random/ms13/power_armor/parts,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "wy" = (
@@ -6538,6 +6609,7 @@
 /obj/structure/lattice/catwalk/ms13,
 /obj/structure/ms13/storage/shelf,
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
+/obj/effect/spawner/random/ms13/tools/hardware,
 /turf/open/openspace/ms13,
 /area/ms13/town)
 "wF" = (
@@ -6626,6 +6698,7 @@
 	pixel_y = 7
 	},
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
+/obj/effect/spawner/random/ms13/smokeable/highrandom,
 /turf/open/floor/wood/ms13/carpet,
 /area/ms13/town)
 "wU" = (
@@ -6731,10 +6804,10 @@
 /area/ms13/town)
 "xp" = (
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
-/obj/effect/spawner/random/ms13/locked/random/lowchance,
 /obj/machinery/door/unpowered/ms13/metal/red{
 	dir = 8
 	},
+/obj/effect/spawner/random/ms13/locked/random/medchance,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "xq" = (
@@ -6867,7 +6940,7 @@
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /obj/structure/ms13/wall_decor/cross,
 /obj/effect/spawner/random/ms13/armor/lowrandom,
-/obj/effect/spawner/random/ms13/armor/highrandom,
+/obj/effect/spawner/random/ms13/armor/headgear,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "xS" = (
@@ -7414,14 +7487,10 @@
 	dir = 1
 	},
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
-/obj/effect/spawner/random/ms13/crafting/household,
+/obj/effect/spawner/random/ms13/currency/drought/prewar/lowrandom,
+/obj/effect/spawner/random/ms13/currency/drought/prewar/lowrandom,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
-"zR" = (
-/obj/structure/ms13/sandbag,
-/obj/effect/spawner/random/ms13/drink/soda,
-/turf/open/floor/plating/ms13/roof/metal,
-/area/ms13/desert)
 "zS" = (
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /obj/effect/spawner/random/ms13/currency/drought/lowrandom,
@@ -7665,6 +7734,7 @@
 	pixel_x = 11;
 	pixel_y = 6
 	},
+/obj/effect/spawner/random/ms13/drink/alcohol,
 /turf/open/floor/wood/ms13/carpet,
 /area/ms13/town)
 "AN" = (
@@ -7945,7 +8015,7 @@
 "BL" = (
 /obj/structure/table/ms13/metal/constructed,
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
-/obj/effect/spawner/random/ms13/gun/lowrandom,
+/obj/effect/spawner/random/ms13/power_armor/parts,
 /turf/open/floor/plating/ms13/roof/wood,
 /area/ms13/desert)
 "BN" = (
@@ -7966,6 +8036,7 @@
 /obj/structure/ms13/lamp{
 	pixel_y = 12
 	},
+/obj/effect/spawner/random/ms13/smokeable/highrandom,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "BP" = (
@@ -7974,6 +8045,11 @@
 	},
 /turf/open/floor/ms13/concrete,
 /area/ms13/desert)
+"BQ" = (
+/obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
+/mob/living/basic/ms13/robot/handy,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/town)
 "BR" = (
 /obj/structure/table/ms13/no_smooth/counter/metal/bend{
 	dir = 1
@@ -8541,6 +8617,15 @@
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /turf/open/floor/ms13/tile/large/cream,
 /area/ms13/town)
+"Ef" = (
+/obj/structure/ms13/barricade{
+	dir = 8
+	},
+/obj/structure/table/ms13/wood/constructed,
+/obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
+/obj/effect/spawner/random/ms13/smokeable/general,
+/turf/open/floor/plating/ms13/roof/metal,
+/area/ms13/town)
 "Eg" = (
 /obj/structure/chair/sofa/corp/left{
 	dir = 8
@@ -8593,6 +8678,7 @@
 "En" = (
 /obj/structure/table/ms13/no_smooth/wood/low,
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
+/obj/effect/spawner/random/ms13/smokeable/general,
 /turf/open/floor/ms13/tile/large/checkered,
 /area/ms13/town)
 "Eo" = (
@@ -8904,6 +8990,14 @@
 /obj/structure/ms13/pipes/vertical/west/corner/down,
 /turf/open/floor/ms13/concrete/small,
 /area/ms13/water_baron/interior)
+"Fq" = (
+/obj/machinery/light/ms13/bulb{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
+/obj/effect/spawner/random/ms13/drugs/lowrandom,
+/turf/open/floor/ms13/tile/brown/big,
+/area/ms13/town)
 "Fr" = (
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /obj/machinery/light/ms13{
@@ -9094,6 +9188,7 @@
 "Gb" = (
 /obj/structure/ms13/skeleton,
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
+/obj/effect/spawner/random/ms13/gun/lowrandom,
 /turf/open/floor/wood/ms13/carpet,
 /area/ms13/town)
 "Gd" = (
@@ -9450,6 +9545,7 @@
 /obj/structure/chair/ms13/metal{
 	dir = 1
 	},
+/obj/effect/spawner/random/ms13/smokeable/general,
 /turf/open/floor/wood/ms13/carpet/shaggy/blue,
 /area/ms13/town)
 "Hj" = (
@@ -9498,6 +9594,7 @@
 /obj/structure/table/ms13/metal/constructed,
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /obj/effect/spawner/random/ms13/ammo/lowrandom,
+/obj/effect/spawner/random/ms13/gun/lowrandom,
 /turf/open/floor/plating/ms13/roof/wood,
 /area/ms13/desert)
 "Ht" = (
@@ -9880,6 +9977,7 @@
 	dir = 1
 	},
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
+/obj/effect/spawner/random/ms13/smokeable/general,
 /turf/open/floor/wood/ms13/mosaic,
 /area/ms13/rangeroutpost/building)
 "ID" = (
@@ -10046,6 +10144,11 @@
 /obj/structure/ms13/wall_decor/clock,
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /turf/open/floor/wood/ms13/wide,
+/area/ms13/town)
+"Jh" = (
+/obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
+/mob/living/basic/ms13/ghoul/brown,
+/turf/open/floor/plating/ms13/roof/metal,
 /area/ms13/town)
 "Ji" = (
 /obj/structure/closet/crate/ms13/woodcrate/compact,
@@ -10304,6 +10407,7 @@
 	},
 /obj/structure/table/ms13/wood/constructed,
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
+/obj/effect/spawner/random/ms13/crafting/lowrandom,
 /turf/open/floor/plating/ms13/roof/metal/rusty,
 /area/ms13/town)
 "JY" = (
@@ -10334,6 +10438,14 @@
 	},
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
+"Kd" = (
+/obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
+/obj/machinery/door/unpowered/ms13/metal/red{
+	dir = 8
+	},
+/obj/effect/spawner/random/ms13/locked/random/medchance,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/town)
 "Ke" = (
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /obj/structure/table/ms13/metal/grate,
@@ -10341,6 +10453,7 @@
 	dir = 9
 	},
 /obj/machinery/light/ms13,
+/obj/effect/spawner/random/ms13/tools/radio/high,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "Kf" = (
@@ -10611,6 +10724,7 @@
 	pixel_x = -6;
 	pixel_y = 6
 	},
+/obj/effect/spawner/random/ms13/currency/drought/prewar/lowrandom,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "KZ" = (
@@ -10993,6 +11107,12 @@
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /turf/open/floor/wood/ms13/common,
 /area/ms13/drylanders/building)
+"Mq" = (
+/obj/machinery/door/unpowered/ms13/wood,
+/obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
+/obj/effect/spawner/random/ms13/locked/random/lowchance,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/town)
 "Mr" = (
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /obj/structure/lattice/catwalk/ms13,
@@ -11138,6 +11258,10 @@
 /obj/effect/spawner/random/ms13/clothing/gloves,
 /turf/open/floor/ms13/concrete,
 /area/ms13/town)
+"MV" = (
+/obj/effect/spawner/random/ms13/smokeable/highrandom,
+/turf/open/floor/plating/ms13/ground/desert,
+/area/ms13/water_baron)
 "MW" = (
 /obj/structure/lattice/catwalk/ms13,
 /obj/structure/ms13/storage/large/shelf{
@@ -11221,6 +11345,14 @@
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
+"Nj" = (
+/obj/machinery/door/unpowered/ms13/wood{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
+/obj/effect/spawner/random/ms13/locked/random/lowchance,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/town)
 "Nk" = (
 /obj/structure/ladder/ms13,
 /obj/structure/lattice/catwalk/ms13,
@@ -11250,11 +11382,13 @@
 	dir = 8
 	},
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
+/obj/effect/spawner/random/ms13/drink/alcohol,
 /turf/open/floor/ms13/concrete,
 /area/ms13/water_baron)
 "No" = (
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /obj/machinery/door/unpowered/ms13/wood,
+/obj/effect/spawner/random/ms13/locked/random/lowchance,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "Np" = (
@@ -11841,6 +11975,7 @@
 "Pn" = (
 /obj/structure/table/ms13/wood,
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
+/obj/effect/spawner/random/ms13/currency/drought/prewar/highrandom,
 /turf/open/floor/wood/ms13/carpet,
 /area/ms13/town)
 "Po" = (
@@ -11947,6 +12082,12 @@
 	},
 /turf/open/floor/wood/ms13/mosaic,
 /area/ms13/town)
+"PH" = (
+/obj/machinery/door/unpowered/ms13/wood,
+/obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
+/obj/effect/spawner/random/ms13/locked/random/medchance,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/town)
 "PJ" = (
 /obj/structure/ms13/lamp/mining_lamp,
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
@@ -12007,7 +12148,7 @@
 /obj/structure/closet/crate/ms13/woodcrate/compact,
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /obj/effect/spawner/random/ms13/drugs/lowrandom,
-/obj/effect/spawner/random/ms13/drugs/lowrandom,
+/obj/effect/spawner/random/ms13/drugs/highrandom,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "PU" = (
@@ -12397,6 +12538,7 @@
 /obj/structure/table/ms13/no_smooth/large/metal/desk,
 /obj/structure/ms13/wall_decor/clock,
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
+/obj/effect/spawner/random/ms13/smokeable/general,
 /turf/open/floor/ms13/concrete,
 /area/ms13/town)
 "Ri" = (
@@ -12479,11 +12621,6 @@
 /obj/structure/ms13/sandbag,
 /turf/open/floor/plating/ms13/roof,
 /area/ms13/desert)
-"Rx" = (
-/obj/structure/ms13/storage/shelf/wood/alt,
-/obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
-/turf/open/floor/wood/ms13/wide,
-/area/ms13/town)
 "Rz" = (
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /obj/machinery/ms13/terminal{
@@ -12647,6 +12784,15 @@
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /turf/open/openspace/ms13,
 /area/ms13/water_baron)
+"Se" = (
+/obj/machinery/shower{
+	dir = 8
+	},
+/obj/effect/turf_decal/ms13/showerdrains/small,
+/obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
+/obj/effect/spawner/random/ms13/drugs/lowrandom,
+/turf/open/floor/ms13/tile/brown/big,
+/area/ms13/town)
 "Sf" = (
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /obj/structure/chair/ms13/metal/blue{
@@ -12852,8 +12998,8 @@
 	pixel_x = 10;
 	pixel_y = 10
 	},
-/obj/effect/spawner/random/ms13/drink/soda,
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
+/obj/effect/spawner/random/ms13/smokeable/general,
 /turf/open/floor/ms13/tile/large/cream,
 /area/ms13/town)
 "SU" = (
@@ -12987,15 +13133,6 @@
 /obj/effect/spawner/random/ms13/melee/lowrandom,
 /turf/open/floor/ms13/tile/large/cream,
 /area/ms13/town)
-"Tp" = (
-/obj/structure/closet/ms13/fridge,
-/obj/structure/ms13/storage/vent,
-/obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
-/obj/effect/spawner/random/ms13/food/random,
-/obj/effect/spawner/random/ms13/food/random,
-/obj/effect/spawner/random/ms13/food/random,
-/turf/open/floor/ms13/tile/large/cream,
-/area/ms13/town)
 "Tq" = (
 /obj/structure/ms13/barricade{
 	dir = 8
@@ -13021,6 +13158,12 @@
 "Tu" = (
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /turf/closed/wall/ms13/metal,
+/area/ms13/town)
+"Tv" = (
+/obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
+/obj/machinery/door/unpowered/ms13/wood,
+/obj/effect/spawner/random/ms13/locked/random/medchance,
+/turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "Tw" = (
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
@@ -13161,6 +13304,15 @@
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /obj/effect/turf_decal/ms13/graffiti/stop,
 /turf/closed/wall/ms13/brick/gray,
+/area/ms13/town)
+"TU" = (
+/obj/structure/table/ms13/wood,
+/obj/structure/ms13/trash/papers{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
+/obj/effect/spawner/random/ms13/smokeable/highrandom,
+/turf/open/floor/wood/ms13/carpet,
 /area/ms13/town)
 "TV" = (
 /obj/structure/table/ms13/no_smooth/counter/metal{
@@ -13405,6 +13557,7 @@
 	dir = 1
 	},
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
+/obj/effect/spawner/random/ms13/crafting/lowrandom,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "UM" = (
@@ -13915,6 +14068,14 @@
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /turf/open/floor/wood/ms13/common,
 /area/ms13/water_baron/interior)
+"Wz" = (
+/obj/structure/table/ms13/no_smooth/counter/wood{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
+/obj/effect/spawner/random/ms13/currency/drought/prewar/lowrandom,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/town)
 "WA" = (
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /obj/effect/spawner/random/ms13/crafting/household,
@@ -14162,6 +14323,11 @@
 /obj/effect/spawner/random/ms13/gun/lowrandom,
 /turf/open/floor/plating/ms13/roof/metal,
 /area/ms13/desert)
+"Xx" = (
+/obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
+/obj/effect/spawner/random/ms13/tools/lights,
+/turf/open/floor/ms13/concrete/industrial,
+/area/ms13/town)
 "Xy" = (
 /obj/structure/table/ms13/metal/grate,
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
@@ -14236,6 +14402,7 @@
 	pixel_x = 10
 	},
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
+/obj/effect/spawner/random/ms13/smokeable/general,
 /turf/open/floor/wood/ms13/mosaic,
 /area/ms13/town)
 "XL" = (
@@ -14269,6 +14436,7 @@
 /obj/effect/spawner/random/ms13/drugs/prewar,
 /obj/effect/spawner/random/ms13/currency/drought/prewar/highrandom,
 /obj/effect/spawner/random/ms13/ammo/highrandom,
+/obj/effect/spawner/random/ms13/currency/drought/prewar/highrandom,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "XP" = (
@@ -14647,6 +14815,15 @@
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
+"Zq" = (
+/obj/structure/lattice/catwalk/ms13,
+/obj/structure/ms13/storage/shelf{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
+/obj/effect/spawner/random/ms13/tools/hardware,
+/turf/open/openspace/ms13,
+/area/ms13/town)
 "Zr" = (
 /obj/structure/filingcabinet/ms13,
 /obj/structure/ms13/storage/vent,
@@ -14697,7 +14874,7 @@
 	pixel_x = -10;
 	pixel_y = 9
 	},
-/obj/effect/spawner/random/ms13/currency/drought/prewar/lowrandom,
+/obj/effect/spawner/random/ms13/smokeable/general,
 /turf/open/floor/wood/ms13/mosaic,
 /area/ms13/town)
 "ZB" = (
@@ -14725,6 +14902,7 @@
 	dir = 8
 	},
 /obj/item/trash/ms13/candle,
+/obj/item/lighter/ms13/zippo,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "ZE" = (
@@ -20325,8 +20503,8 @@ qi
 cF
 cF
 aR
-ZY
-ZY
+ue
+Ef
 Ho
 gl
 MG
@@ -20729,7 +20907,7 @@ qi
 cF
 cF
 OY
-OY
+Jh
 OY
 OY
 ym
@@ -21702,7 +21880,7 @@ ZF
 Or
 wx
 rR
-Or
+Xx
 Tj
 wM
 qi
@@ -22899,7 +23077,7 @@ wM
 SQ
 SC
 nT
-WD
+TU
 gn
 Gb
 wf
@@ -23299,7 +23477,7 @@ SC
 zM
 zM
 zM
-vU
+PH
 SC
 SC
 zM
@@ -25327,7 +25505,7 @@ XF
 Xq
 hM
 MO
-Cc
+Wz
 Xq
 XF
 qi
@@ -25739,7 +25917,7 @@ Xe
 xd
 XF
 Fo
-SC
+BQ
 SC
 SC
 pm
@@ -26134,7 +26312,7 @@ qi
 XF
 Fg
 Hq
-Pn
+os
 gn
 cP
 XF
@@ -31029,7 +31207,7 @@ qi
 qi
 qi
 qi
-zR
+mB
 mB
 cF
 cF
@@ -31175,7 +31353,7 @@ us
 Kp
 Kp
 ha
-vh
+nU
 tl
 TE
 vh
@@ -31671,7 +31849,7 @@ Rh
 nU
 nh
 aS
-CG
+bs
 Kk
 CG
 wM
@@ -31779,12 +31957,12 @@ ip
 wM
 nU
 Hl
-Kp
+ij
 fy
 Jq
 nU
 nU
-Ea
+hb
 wM
 qi
 qi
@@ -31983,10 +32161,10 @@ Ue
 Cq
 nU
 nU
-eP
+Ri
 nU
 vP
-vh
+ra
 wM
 qi
 qi
@@ -32277,7 +32455,7 @@ wM
 aS
 oX
 aS
-oX
+bh
 wM
 wM
 wM
@@ -35528,7 +35706,7 @@ MG
 yW
 bm
 bT
-hI
+MV
 hj
 hI
 hI
@@ -43631,7 +43809,7 @@ rD
 ZB
 zM
 zM
-No
+Tv
 SC
 XZ
 XF
@@ -44086,7 +44264,7 @@ qi
 qi
 qi
 as
-Jt
+Fq
 Fx
 Ol
 SC
@@ -44217,7 +44395,7 @@ qi
 qi
 Yc
 kF
-fP
+Kd
 Yc
 Yc
 Yc
@@ -44697,7 +44875,7 @@ zk
 es
 Lk
 kA
-Tp
+bO
 Fu
 ze
 XF
@@ -45432,7 +45610,7 @@ On
 zM
 LG
 SC
-Rx
+Yr
 Yc
 ip
 ip
@@ -55355,7 +55533,7 @@ qi
 dy
 nU
 tc
-vk
+pl
 SC
 PC
 SC
@@ -55562,7 +55740,7 @@ PT
 EM
 oT
 Xz
-Fx
+sT
 ZP
 Qa
 qi
@@ -56966,7 +57144,7 @@ Qa
 nc
 Qa
 Qa
-nc
+Nj
 Qa
 Qa
 nc
@@ -57163,7 +57341,7 @@ JP
 SC
 yz
 SC
-vU
+Mq
 Pq
 SC
 Mx
@@ -57359,7 +57537,7 @@ qi
 qi
 qi
 nw
-Re
+Se
 QL
 Mx
 QT
@@ -57981,7 +58159,7 @@ eT
 Mx
 Ox
 SA
-vk
+lZ
 SC
 SC
 hU
@@ -58853,7 +59031,7 @@ qi
 qi
 qi
 dD
-vQ
+Zq
 JU
 iE
 Lx

--- a/_maps/map_files/Drought/Drought_below.dmm
+++ b/_maps/map_files/Drought/Drought_below.dmm
@@ -25,10 +25,14 @@
 "ah" = (
 /obj/structure/table/ms13/no_smooth/counter/wood,
 /obj/structure/ms13/wall_decor/calendar,
+/obj/effect/spawner/random/ms13/crafting/household,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "al" = (
 /obj/structure/closet/ms13/metal,
+/obj/effect/spawner/random/ms13/tools/lights,
+/obj/effect/spawner/random/ms13/clothing/under,
+/obj/effect/spawner/random/ms13/clothing/gloves,
 /turf/open/floor/ms13/concrete,
 /area/ms13/town)
 "ao" = (
@@ -107,6 +111,11 @@
 /obj/effect/spawner/random/ms13/gun/lowrandom,
 /turf/open/floor/plating/ms13/ground/mountain/drought,
 /area/ms13/underground/mountain)
+"aO" = (
+/obj/machinery/door/unpowered/ms13/wood,
+/obj/effect/spawner/random/ms13/locked/random/lowchance,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/town)
 "aP" = (
 /obj/structure/table/ms13/metal/heavy,
 /obj/effect/spawner/random/ms13/power_armor/parts,
@@ -151,10 +160,18 @@
 /obj/structure/ladder/ms13,
 /turf/open/floor/plating/ms13/ground/sidewalk,
 /area/ms13/underground/mountain)
+"bj" = (
+/obj/machinery/door/unpowered/ms13/seethrough/grate{
+	dir = 4
+	},
+/obj/effect/spawner/random/ms13/locked/random/lowchance,
+/turf/open/floor/plating/ms13/ground/desertalt,
+/area/ms13/town)
 "bk" = (
 /obj/structure/table/ms13/metal/grate,
 /obj/effect/spawner/random/ms13/medical/lowrandom,
 /obj/effect/spawner/random/ms13/medical/lowrandom,
+/obj/effect/spawner/random/ms13/medical/medkit,
 /turf/open/floor/ms13/tile/blue,
 /area/ms13/underground/mountain_bunker)
 "bn" = (
@@ -208,6 +225,7 @@
 /obj/structure/closet/ms13/metal,
 /obj/effect/spawner/random/ms13/clothing/under,
 /obj/effect/spawner/random/ms13/clothing/mask,
+/obj/effect/spawner/random/ms13/clothing/shoe,
 /turf/open/floor/plating/ms13/ground/desertalt,
 /area/ms13/town)
 "bZ" = (
@@ -242,6 +260,7 @@
 	},
 /obj/structure/table/ms13/wood/constructed/cobbled,
 /obj/effect/spawner/random/ms13/crafting/electrical,
+/obj/effect/spawner/random/ms13/crafting/highrandom,
 /turf/open/floor/plating/ms13/ground/desertalt,
 /area/ms13/town)
 "cn" = (
@@ -309,12 +328,20 @@
 	},
 /turf/open/floor/ms13/metal/pipe/corner,
 /area/ms13/underground/mountain_bunker)
+"cE" = (
+/obj/machinery/door/unpowered/ms13/wood{
+	dir = 4
+	},
+/obj/effect/spawner/random/ms13/locked/random/highchance,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/town)
 "cH" = (
 /obj/structure/noticeboard/ms13/cork,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "cI" = (
 /obj/structure/table/ms13/no_smooth/counter/metal,
+/obj/effect/spawner/random/ms13/smokeable/general,
 /turf/open/floor/ms13/concrete,
 /area/ms13/town)
 "cL" = (
@@ -378,6 +405,13 @@
 /obj/effect/spawner/random/ms13/tools/hardware,
 /turf/open/floor/plating/ms13/ground/desertalt,
 /area/ms13/town)
+"do" = (
+/obj/machinery/light/ms13/bulb{
+	dir = 8
+	},
+/mob/living/basic/ms13/hostile_animal/radroach,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/town)
 "dp" = (
 /obj/machinery/button/ms13{
 	dir = 4;
@@ -409,8 +443,7 @@
 /obj/structure/ms13/storage/shelf{
 	dir = 1
 	},
-/obj/effect/spawner/random/ms13/crafting/lowrandom,
-/obj/effect/spawner/random/ms13/crafting/lowrandom,
+/obj/effect/spawner/random/ms13/power_armor/parts,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "dA" = (
@@ -439,6 +472,7 @@
 /area/ms13/underground/mountain)
 "dG" = (
 /obj/structure/ms13/cave_decor/boards/mammoth/northsouth,
+/mob/living/basic/ms13/hostile_animal/molerat,
 /turf/open/floor/plating/ms13/ground/desertalt,
 /area/ms13/town)
 "dH" = (
@@ -503,6 +537,7 @@
 /obj/machinery/door/unpowered/ms13/metal/mirrored/red{
 	dir = 1
 	},
+/obj/effect/spawner/random/ms13/locked/random/highchance,
 /turf/open/floor/plating/ms13/ground/desertalt,
 /area/ms13/town)
 "ea" = (
@@ -602,6 +637,12 @@
 	},
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
+"eI" = (
+/obj/structure/ms13/turfdecor/drought,
+/obj/structure/ms13/skeleton,
+/obj/effect/spawner/random/ms13/power_armor/parts,
+/turf/open/floor/plating/ms13/ground/desertalt,
+/area/ms13/town)
 "eK" = (
 /obj/effect/spawner/random/ms13/armor/headgear,
 /turf/open/floor/plating/ms13/ground/mountain/drought,
@@ -610,6 +651,13 @@
 /obj/structure/table/ms13/wood/constructed/cobbled,
 /obj/effect/spawner/random/ms13/tools/tool,
 /turf/open/floor/plating/ms13/ground/desertalt,
+/area/ms13/town)
+"eP" = (
+/obj/structure/ms13/storage/large/shelf{
+	dir = 8
+	},
+/obj/effect/spawner/random/ms13/tools/radio,
+/turf/open/floor/ms13/concrete,
 /area/ms13/town)
 "eR" = (
 /obj/structure/table/ms13/metal/alt,
@@ -818,6 +866,8 @@
 /area/ms13/town)
 "fZ" = (
 /obj/structure/closet/crate/ms13/woodcrate/compact/boom,
+/obj/item/grenade/ms13/molotov,
+/obj/item/grenade/ms13/molotov,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "gb" = (
@@ -906,7 +956,15 @@
 	dir = 1
 	},
 /obj/effect/spawner/random/ms13/tools/tool,
+/obj/effect/spawner/random/ms13/tools/hardware,
 /turf/open/floor/ms13/concrete/bricks,
+/area/ms13/town)
+"gC" = (
+/obj/structure/ms13/storage/shelf/wood/alt{
+	dir = 1
+	},
+/obj/effect/spawner/random/ms13/power_armor/parts,
+/turf/open/floor/plating/ms13/ground/desertalt,
 /area/ms13/town)
 "gF" = (
 /obj/structure/ms13/turfdecor/drought,
@@ -940,6 +998,7 @@
 	},
 /obj/structure/bed/ms13/bedframe/metal,
 /obj/structure/bed/ms13/mattress/old,
+/obj/effect/spawner/random/ms13/food/packaged,
 /turf/open/floor/plating/ms13/ground/desertalt,
 /area/ms13/town)
 "gQ" = (
@@ -962,6 +1021,12 @@
 /obj/effect/spawner/random/ms13/food/trash,
 /turf/open/floor/plating/ms13/ground/desert,
 /area/ms13/desert)
+"gZ" = (
+/obj/structure/table/ms13/wood/constructed/cobbled,
+/obj/effect/spawner/random/ms13/tools/tool,
+/obj/effect/spawner/random/ms13/tools/lights,
+/turf/open/floor/plating/ms13/ground/desertalt,
+/area/ms13/town)
 "hb" = (
 /obj/structure/ms13/barrel/single/redalt/two,
 /turf/open/floor/plating/ms13/ground/desertalt,
@@ -1110,6 +1175,8 @@
 /area/ms13/town)
 "hV" = (
 /obj/structure/closet/crate/ms13/woodcrate,
+/obj/effect/spawner/random/ms13/tools/tool,
+/obj/effect/spawner/random/ms13/tools/tool,
 /turf/open/floor/ms13/concrete,
 /area/ms13/underground/mountain)
 "hW" = (
@@ -1173,6 +1240,7 @@
 	pixel_x = -6;
 	pixel_y = 1
 	},
+/obj/effect/spawner/random/ms13/smokeable/highrandom,
 /turf/open/floor/plating/ms13/ground/mountain/drought,
 /area/ms13/underground/mountain)
 "iA" = (
@@ -1256,6 +1324,7 @@
 /obj/effect/spawner/random/ms13/food/junkfood_boxed,
 /obj/effect/spawner/random/ms13/food/junkfood_boxed,
 /obj/effect/spawner/random/ms13/medical/bloodbag,
+/obj/effect/spawner/random/ms13/food/random,
 /turf/open/floor/plating/ms13/ground/desertalt,
 /area/ms13/town)
 "jj" = (
@@ -1283,6 +1352,13 @@
 /obj/structure/ms13/bonepile,
 /turf/open/floor/plating/ms13/ground/mountain/drought,
 /area/ms13/underground/mountain)
+"jr" = (
+/obj/machinery/door/unpowered/ms13/seethrough/grate{
+	dir = 4
+	},
+/obj/effect/spawner/random/ms13/locked/random/medchance,
+/turf/open/floor/plating/ms13/ground/desertalt,
+/area/ms13/town)
 "jv" = (
 /obj/effect/turf_decal/trimline/yellow/line,
 /turf/open/floor/ms13/metal/grate,
@@ -1606,6 +1682,7 @@
 "lP" = (
 /obj/structure/closet/ms13/metal,
 /obj/effect/spawner/random/ms13/tools/tool,
+/obj/effect/spawner/random/ms13/tools/lights,
 /turf/open/floor/ms13/concrete,
 /area/ms13/town)
 "lQ" = (
@@ -1700,6 +1777,11 @@
 /obj/effect/spawner/random/ms13/crafting/electrical,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
+"mD" = (
+/obj/structure/closet/crate/ms13/woodcrate,
+/obj/effect/spawner/random/ms13/crafting/precious,
+/turf/open/floor/ms13/concrete,
+/area/ms13/underground/mountain)
 "mE" = (
 /obj/structure/ms13/storage/large/shelf{
 	dir = 8
@@ -1754,6 +1836,7 @@
 /obj/machinery/door/unpowered/ms13/metal/mirrored/alt{
 	dir = 4
 	},
+/obj/effect/spawner/random/ms13/locked/random/medchance,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "mW" = (
@@ -1841,7 +1924,7 @@
 "nw" = (
 /obj/structure/ms13/skeleton,
 /obj/effect/decal/cleanable/blood/old,
-/obj/effect/spawner/random/ms13/gun/tier1,
+/obj/effect/spawner/random/ms13/gun/lowrandom,
 /turf/open/floor/plating/ms13/ground/mountain/drought,
 /area/ms13/underground/mountain)
 "nB" = (
@@ -1864,7 +1947,7 @@
 /obj/structure/ms13/storage/large/shelf/wood{
 	dir = 4
 	},
-/obj/effect/spawner/random/ms13/melee/lowrandom,
+/obj/effect/spawner/random/ms13/melee/unique,
 /turf/open/floor/plating/ms13/ground/desertalt,
 /area/ms13/town)
 "nG" = (
@@ -1893,6 +1976,7 @@
 /obj/structure/closet/crate/ms13/woodcrate/compact,
 /obj/effect/spawner/random/ms13/medical/lowrandom,
 /obj/effect/spawner/random/ms13/drink/alcohol,
+/obj/effect/spawner/random/ms13/drugs/lowrandom,
 /turf/open/floor/plating/ms13/ground/desertalt,
 /area/ms13/town)
 "nU" = (
@@ -1909,9 +1993,15 @@
 /obj/effect/spawner/random/ms13/crafting/electrical,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
+"nX" = (
+/obj/machinery/door/unpowered/ms13/wood,
+/obj/effect/spawner/random/ms13/locked/guaranteed/random,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/town)
 "nY" = (
 /obj/structure/ms13/cave_decor/support/beams,
 /obj/structure/closet/crate/ms13/medical,
+/obj/effect/spawner/random/ms13/medical/bloodbag,
 /obj/effect/spawner/random/ms13/medical/bloodbag,
 /obj/effect/spawner/random/ms13/medical/bloodbag,
 /turf/open/floor/plating/ms13/ground/desertalt,
@@ -2130,6 +2220,10 @@
 "pw" = (
 /turf/open/floor/ms13/metal,
 /area/ms13/underground/mountain_bunker)
+"px" = (
+/mob/living/basic/ms13/ghoul/radioactive,
+/turf/open/floor/plating/ms13/ground/desertalt,
+/area/ms13/town)
 "py" = (
 /obj/structure/table/ms13/no_smooth/counter/metal{
 	dir = 1
@@ -2232,6 +2326,7 @@
 /obj/effect/spawner/random/ms13/food/junkfood_canned,
 /obj/effect/spawner/random/ms13/food/random,
 /obj/effect/spawner/random/ms13/medical/bloodbag,
+/obj/effect/spawner/random/ms13/food/random,
 /turf/open/floor/plating/ms13/ground/desertalt,
 /area/ms13/town)
 "ql" = (
@@ -2286,6 +2381,11 @@
 /obj/machinery/door/unpowered/ms13/wood,
 /turf/open/floor/plating/ms13/ground/mountain/drought,
 /area/ms13/underground/mountain)
+"qF" = (
+/obj/machinery/door/unpowered/ms13/seethrough/grate,
+/obj/effect/spawner/random/ms13/locked/random/lowchance,
+/turf/open/floor/plating/ms13/ground/desertalt,
+/area/ms13/town)
 "qG" = (
 /obj/machinery/ms13/plant_machinery/broken,
 /turf/open/floor/ms13/metal/grate,
@@ -2304,6 +2404,7 @@
 /obj/structure/chair/ms13/metal/broken{
 	dir = 4
 	},
+/mob/living/basic/ms13/hostile_animal/radroach,
 /turf/open/floor/ms13/concrete,
 /area/ms13/town)
 "qL" = (
@@ -2341,6 +2442,7 @@
 	},
 /obj/effect/spawner/random/ms13/tools/hardware,
 /obj/effect/spawner/random/ms13/tools/hardware,
+/obj/effect/spawner/random/ms13/crafting/lowrandom,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "qV" = (
@@ -2369,6 +2471,13 @@
 /obj/effect/spawner/random/ms13/tools/tool,
 /turf/open/floor/ms13/concrete,
 /area/ms13/underground/mountain_bunker)
+"rp" = (
+/obj/machinery/door/unpowered/ms13/wood{
+	dir = 8
+	},
+/obj/effect/spawner/random/ms13/locked/random/medchance,
+/turf/open/floor/plating/ms13/ground/mountain/drought,
+/area/ms13/underground/mountain)
 "rq" = (
 /obj/structure/chair/ms13/metal/broken,
 /obj/machinery/light/ms13{
@@ -2481,6 +2590,8 @@
 /area/ms13/town)
 "rR" = (
 /obj/structure/closet/crate/ms13/woodcrate/compact/boom,
+/obj/item/grenade/ms13/molotov,
+/obj/item/grenade/ms13/molotov,
 /turf/open/floor/plating/ms13/ground/desertalt,
 /area/ms13/town)
 "rS" = (
@@ -2518,7 +2629,7 @@
 /area/ms13/town)
 "se" = (
 /obj/structure/table/ms13/metal/grate,
-/obj/effect/spawner/random/ms13/medical/medkit,
+/obj/effect/spawner/random/ms13/clothing/backpack/high,
 /turf/open/floor/ms13/concrete,
 /area/ms13/underground/mountain_bunker)
 "sf" = (
@@ -2530,6 +2641,7 @@
 "sh" = (
 /obj/structure/bed/ms13/bedframe/wood,
 /obj/structure/bed/ms13/sleepingbag/green,
+/obj/effect/spawner/random/ms13/smokeable/general,
 /turf/open/floor/plating/ms13/ground/desertalt,
 /area/ms13/town)
 "sk" = (
@@ -2539,6 +2651,7 @@
 /area/ms13/underground/mountain_bunker)
 "sl" = (
 /obj/structure/bed/ms13/sleepingbag/red,
+/obj/effect/spawner/random/ms13/smokeable/general,
 /turf/open/floor/plating/ms13/ground/desertalt,
 /area/ms13/town)
 "sm" = (
@@ -2564,6 +2677,7 @@
 /obj/structure/closet/crate/ms13/woodcrate/compact/army,
 /obj/effect/spawner/random/ms13/ammo/lowrandom,
 /obj/effect/spawner/random/ms13/ammo/highrandom,
+/obj/effect/spawner/random/ms13/power_armor/parts,
 /turf/open/floor/plating/ms13/ground/desertalt,
 /area/ms13/town)
 "sy" = (
@@ -2573,13 +2687,14 @@
 	pixel_x = 8;
 	pixel_y = 10
 	},
+/obj/effect/spawner/random/ms13/smokeable/highrandom,
 /turf/open/floor/plating/ms13/ground/desertalt,
 /area/ms13/town)
 "sz" = (
 /obj/machinery/door/unpowered/ms13/metal/alt{
 	dir = 8
 	},
-/obj/effect/spawner/random/ms13/locked/random/lowchance,
+/obj/effect/spawner/random/ms13/locked/random/medchance,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "sC" = (
@@ -2759,6 +2874,7 @@
 /obj/structure/ms13/lamp/mining_lamp{
 	pixel_y = 30
 	},
+/obj/effect/spawner/random/ms13/drink/soda_uncommon,
 /turf/open/floor/plating/ms13/ground/desertalt,
 /area/ms13/town)
 "tH" = (
@@ -2842,6 +2958,7 @@
 	pixel_x = 8;
 	pixel_y = 8
 	},
+/obj/item/lighter/ms13/zippo,
 /turf/open/floor/plating/ms13/ground/desertalt,
 /area/ms13/town)
 "uj" = (
@@ -2931,6 +3048,10 @@
 /obj/effect/spawner/random/ms13/crafting/lowrandom,
 /turf/open/floor/plating/ms13/ground/desertalt,
 /area/ms13/town)
+"uQ" = (
+/obj/effect/spawner/random/ms13/ammo/lowrandom,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/town)
 "uS" = (
 /obj/structure/closet/crate/ms13/red,
 /obj/effect/spawner/random/ms13/tools/hardware,
@@ -2989,6 +3110,11 @@
 /obj/effect/spawner/random/ms13/melee/lowrandom,
 /turf/open/floor/plating/ms13/ground/desertalt,
 /area/ms13/town)
+"vs" = (
+/obj/structure/ms13/storage/shelf/wood/alt,
+/obj/effect/spawner/random/ms13/ammo/lowrandom,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/town)
 "vt" = (
 /obj/structure/table/ms13/metal/small,
 /obj/item/ms13/fluff/alarmclock{
@@ -3034,6 +3160,11 @@
 /obj/structure/ms13/rug/red,
 /turf/open/floor/plating/ms13/ground/desertalt,
 /area/ms13/town)
+"vF" = (
+/obj/machinery/door/unpowered/ms13/metal/mirrored/red,
+/obj/effect/spawner/random/ms13/locked/random/medchance,
+/turf/open/floor/plating/ms13/ground/desertalt,
+/area/ms13/town)
 "vG" = (
 /obj/structure/ms13/lamp/makeshift{
 	pixel_y = 4
@@ -3060,6 +3191,11 @@
 	},
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
+"vN" = (
+/obj/structure/ms13/skeleton,
+/obj/effect/spawner/random/ms13/power_armor/parts,
+/turf/open/floor/plating/ms13/ground/desert,
+/area/ms13/desert)
 "vO" = (
 /obj/structure/ms13/barrel/single/flammable/one,
 /obj/structure/ms13/storage/vent,
@@ -3139,6 +3275,7 @@
 	pixel_y = 6
 	},
 /obj/structure/table/ms13/no_smooth/cable_reel,
+/obj/effect/spawner/random/ms13/smokeable/general,
 /turf/open/floor/plating/ms13/ground/desertalt,
 /area/ms13/town)
 "wn" = (
@@ -3156,6 +3293,7 @@
 /obj/machinery/light/ms13{
 	dir = 1
 	},
+/obj/effect/spawner/random/ms13/tools/hardware,
 /turf/open/floor/ms13/concrete,
 /area/ms13/town)
 "wr" = (
@@ -3224,10 +3362,9 @@
 	pixel_y = 30
 	},
 /obj/structure/closet/crate/ms13/woodcrate/compact/army,
-/obj/effect/spawner/random/ms13/gun/lowrandom,
-/obj/effect/spawner/random/ms13/ammo/lowrandom,
-/obj/effect/spawner/random/ms13/ammo/lowrandom,
-/obj/effect/spawner/random/ms13/ammo/lowrandom,
+/obj/effect/spawner/random/ms13/gun/highrandom,
+/obj/effect/spawner/random/ms13/ammo/highrandom,
+/obj/effect/spawner/random/ms13/ammo/highrandom,
 /turf/open/floor/plating/ms13/ground/desertalt,
 /area/ms13/town)
 "wK" = (
@@ -3264,7 +3401,7 @@
 /obj/machinery/door/unpowered/ms13/metal/red{
 	dir = 8
 	},
-/obj/effect/spawner/random/ms13/locked/random/highchance,
+/obj/effect/spawner/random/ms13/locked/guaranteed/random,
 /turf/open/floor/ms13/tile/large/cream,
 /area/ms13/town)
 "wX" = (
@@ -3324,6 +3461,7 @@
 /obj/structure/ms13/lamp/mining_lamp{
 	pixel_y = 30
 	},
+/obj/structure/ms13/skeleton,
 /turf/open/floor/plating/ms13/ground/desertalt,
 /area/ms13/town)
 "xA" = (
@@ -3350,7 +3488,7 @@
 /obj/structure/closet/crate/ms13/woodcrate,
 /obj/effect/spawner/random/ms13/crafting/precious,
 /obj/effect/spawner/random/ms13/crafting/precious,
-/obj/effect/spawner/random/ms13/crafting/precious,
+/obj/effect/spawner/random/ms13/crafting/refined,
 /turf/open/floor/plating/ms13/ground/desertalt,
 /area/ms13/town)
 "xK" = (
@@ -3394,7 +3532,6 @@
 /obj/structure/ms13/storage/shelf/wood/alt{
 	dir = 1
 	},
-/obj/effect/spawner/random/ms13/ammo/lowrandom,
 /obj/effect/spawner/random/ms13/ammo/lowrandom,
 /obj/effect/spawner/random/ms13/ammo/lowrandom,
 /turf/open/floor/wood/ms13/wide,
@@ -3510,6 +3647,12 @@
 /obj/structure/bed/ms13/mattress/old,
 /turf/open/floor/plating/ms13/ground/desertalt,
 /area/ms13/town)
+"yV" = (
+/obj/structure/closet/crate/ms13/woodcrate,
+/obj/effect/spawner/random/ms13/armor/lowrandom,
+/obj/effect/spawner/random/ms13/armor/headgear,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/town)
 "yW" = (
 /obj/structure/chair/comfy/ms13/ergo{
 	dir = 1
@@ -3540,7 +3683,7 @@
 /obj/machinery/door/unpowered/ms13/metal{
 	dir = 8
 	},
-/obj/effect/spawner/random/ms13/locked/random/lowchance,
+/obj/effect/spawner/random/ms13/locked/guaranteed/random,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "zf" = (
@@ -3617,6 +3760,13 @@
 	},
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
+"zH" = (
+/obj/structure/table/ms13/wood/constructed/cobbled,
+/obj/effect/spawner/random/ms13/crafting/lowrandom,
+/obj/effect/spawner/random/ms13/crafting/lowrandom,
+/obj/effect/spawner/random/ms13/crafting/lowrandom,
+/turf/open/floor/plating/ms13/ground/desertalt,
+/area/ms13/town)
 "zJ" = (
 /mob/living/basic/ms13/hostile_animal/giantant,
 /turf/open/floor/plating/ms13/ground/mountain/drought,
@@ -3667,6 +3817,8 @@
 /area/ms13/underground/mountain_bunker)
 "Ai" = (
 /obj/structure/table/rolling/ms13,
+/obj/effect/spawner/random/ms13/medical/surgical,
+/obj/effect/spawner/random/ms13/medical/surgical,
 /turf/open/floor/ms13/tile/large/cream,
 /area/ms13/town)
 "Aj" = (
@@ -3843,6 +3995,11 @@
 	},
 /turf/open/floor/plating/ms13/ground/desertalt,
 /area/ms13/town)
+"Bx" = (
+/obj/structure/closet/crate/ms13/woodcrate,
+/obj/effect/spawner/random/ms13/clothing/backpack/high,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/town)
 "Bz" = (
 /obj/structure/bed/ms13/mattress/dirty,
 /obj/structure/ms13/skeleton,
@@ -3856,7 +4013,8 @@
 /area/ms13/town)
 "BE" = (
 /obj/structure/ms13/storage/shelf/wood/alt,
-/obj/effect/spawner/random/ms13/clothing/glasses,
+/obj/effect/spawner/random/ms13/drink/alcohol,
+/obj/effect/spawner/random/ms13/drink/alcohol,
 /turf/open/floor/plating/ms13/ground/desertalt,
 /area/ms13/town)
 "BG" = (
@@ -3910,16 +4068,21 @@
 /obj/effect/spawner/random/ms13/food/trash,
 /turf/open/floor/plating/ms13/ground/sidewalk,
 /area/ms13/underground/mountain)
+"Ce" = (
+/obj/machinery/door/unpowered/ms13/seethrough/grate,
+/obj/effect/spawner/random/ms13/locked/guaranteed/random,
+/turf/open/floor/plating/ms13/ground/desertalt,
+/area/ms13/town)
 "Ch" = (
 /obj/machinery/light/ms13,
 /turf/open/floor/ms13/tile/blue/long,
 /area/ms13/town)
 "Ci" = (
-/obj/structure/closet/crate/ms13/woodcrate/compact,
-/obj/effect/spawner/random/ms13/crafting/refined,
 /obj/structure/ms13/lamp/mining_lamp{
 	pixel_y = 30
 	},
+/obj/structure/ms13/pa_jack,
+/obj/effect/spawner/random/ms13/power_armor/lowrandom,
 /turf/open/floor/plating/ms13/ground/desertalt,
 /area/ms13/town)
 "Cj" = (
@@ -3945,7 +4108,8 @@
 	dir = 4
 	},
 /obj/effect/spawner/random/ms13/drink/alcohol,
-/obj/effect/spawner/random/ms13/melee/lowrandom,
+/obj/effect/spawner/random/ms13/drink/alcohol,
+/obj/effect/spawner/random/ms13/medical/herbal,
 /turf/open/floor/plating/ms13/ground/desertalt,
 /area/ms13/town)
 "Cr" = (
@@ -4031,6 +4195,7 @@
 	pixel_y = 6
 	},
 /obj/structure/table/ms13/no_smooth/cable_reel,
+/obj/effect/spawner/random/ms13/smokeable/highrandom,
 /turf/open/floor/plating/ms13/ground/desertalt,
 /area/ms13/town)
 "CW" = (
@@ -4064,6 +4229,7 @@
 /obj/structure/table/ms13/no_smooth/counter/wood/crafted{
 	dir = 8
 	},
+/obj/effect/spawner/random/ms13/drugs/prewar,
 /turf/open/floor/plating/ms13/ground/desertalt,
 /area/ms13/town)
 "Dk" = (
@@ -4502,6 +4668,11 @@
 /obj/effect/spawner/random/ms13/drink/soda,
 /turf/open/floor/plating/ms13/ground/desertalt,
 /area/ms13/town)
+"Go" = (
+/obj/machinery/door/unpowered/ms13/seethrough/grate,
+/obj/effect/spawner/random/ms13/locked/random/medchance,
+/turf/open/floor/plating/ms13/ground/desertalt,
+/area/ms13/town)
 "Gr" = (
 /obj/structure/ms13/storage/large/shelf{
 	dir = 8
@@ -4580,6 +4751,7 @@
 	pixel_x = -9;
 	pixel_y = 5
 	},
+/obj/effect/spawner/random/ms13/drink/alcohol,
 /turf/open/floor/plating/ms13/ground/desertalt,
 /area/ms13/town)
 "Hd" = (
@@ -4788,6 +4960,11 @@
 	},
 /turf/open/floor/plating/ms13/ground/mountain/drought,
 /area/ms13/underground/mountain)
+"Ix" = (
+/obj/structure/table/ms13/wood,
+/obj/effect/spawner/random/ms13/ammo/highrandom,
+/turf/open/floor/wood/ms13/wide,
+/area/ms13/town)
 "Iy" = (
 /obj/structure/closet/crate/ms13/woodcrate,
 /obj/effect/spawner/random/ms13/guaranteed/crafting/electrical,
@@ -5007,7 +5184,7 @@
 /obj/machinery/door/unpowered/ms13/seethrough/grate{
 	dir = 4
 	},
-/obj/effect/spawner/random/ms13/locked/beginner/lowchance,
+/obj/effect/spawner/random/ms13/locked/random/highchance,
 /turf/open/floor/plating/ms13/ground/desertalt,
 /area/ms13/town)
 "JY" = (
@@ -5085,6 +5262,8 @@
 "KP" = (
 /obj/structure/closet/crate/ms13/woodcrate/compact/sarsaparilla,
 /obj/effect/spawner/random/ms13/drink/alcohol,
+/obj/effect/spawner/random/ms13/drink/alcohol,
+/obj/effect/spawner/random/ms13/drink/alcohol_uncommon,
 /turf/open/floor/plating/ms13/ground/desertalt,
 /area/ms13/town)
 "KQ" = (
@@ -5107,6 +5286,7 @@
 /obj/structure/table/ms13/no_smooth/counter/wood/crafted{
 	dir = 8
 	},
+/obj/effect/spawner/random/ms13/power_armor/parts,
 /turf/open/floor/plating/ms13/ground/desertalt,
 /area/ms13/town)
 "KZ" = (
@@ -5201,6 +5381,14 @@
 /obj/effect/spawner/random/ms13/guaranteed/crafting/precious,
 /turf/open/floor/plating/ms13/ground/desertalt,
 /area/ms13/underground/mountain)
+"LC" = (
+/obj/structure/closet/ms13/metal,
+/obj/effect/spawner/random/ms13/clothing/under,
+/obj/effect/spawner/random/ms13/clothing/gloves,
+/obj/effect/spawner/random/ms13/clothing/shoe,
+/obj/effect/spawner/random/ms13/clothing/hat,
+/turf/open/floor/ms13/concrete,
+/area/ms13/town)
 "LE" = (
 /obj/machinery/door/unpowered/ms13/seethrough/grate{
 	dir = 8
@@ -5263,7 +5451,7 @@
 /area/ms13/town)
 "LU" = (
 /obj/structure/table/ms13/no_smooth/counter/wood/crafted/bend,
-/obj/effect/spawner/random/ms13/gun/lowrandom,
+/obj/effect/spawner/random/ms13/gun/lowunique,
 /turf/open/floor/plating/ms13/ground/desertalt,
 /area/ms13/town)
 "LY" = (
@@ -5718,10 +5906,6 @@
 	},
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
-"Pf" = (
-/mob/living/basic/ms13/hostile_animal/pigrat,
-/turf/open/floor/plating/ms13/ground/desertalt,
-/area/ms13/town)
 "Pg" = (
 /obj/structure/table/ms13/metal/heavy,
 /obj/effect/spawner/random/ms13/crafting/electrical,
@@ -5788,6 +5972,7 @@
 /obj/structure/ms13/storage/shelf{
 	dir = 1
 	},
+/obj/effect/spawner/random/ms13/power_armor/parts,
 /turf/open/floor/ms13/concrete,
 /area/ms13/underground/mountain_bunker)
 "PC" = (
@@ -5824,6 +6009,11 @@
 "PK" = (
 /mob/living/basic/ms13/hostile_animal/giantant,
 /turf/open/floor/ms13/concrete,
+/area/ms13/town)
+"PL" = (
+/obj/machinery/door/unpowered/ms13/metal/mirrored/red,
+/obj/effect/spawner/random/ms13/locked/random/lowchance,
+/turf/open/floor/plating/ms13/ground/desertalt,
 /area/ms13/town)
 "PN" = (
 /obj/effect/turf_decal/trimline/yellow/line{
@@ -5916,6 +6106,13 @@
 	},
 /turf/open/floor/ms13/concrete,
 /area/ms13/town)
+"Qy" = (
+/obj/machinery/door/unpowered/ms13/metal/mirrored/red{
+	dir = 4
+	},
+/obj/effect/spawner/random/ms13/locked/random/lowchance,
+/turf/open/floor/plating/ms13/ground/desertalt,
+/area/ms13/town)
 "QB" = (
 /obj/structure/ms13/storage/shelf/wood/alt{
 	dir = 1
@@ -5943,6 +6140,7 @@
 /obj/item/candle/ms13{
 	pixel_x = 6
 	},
+/obj/item/lighter/ms13/zippo,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "QI" = (
@@ -5956,6 +6154,7 @@
 /obj/machinery/door/unpowered/ms13/metal/red{
 	dir = 8
 	},
+/obj/effect/spawner/random/ms13/locked/random/highchance,
 /turf/open/floor/plating/ms13/ground/desertalt,
 /area/ms13/town)
 "QL" = (
@@ -5966,7 +6165,8 @@
 /obj/structure/ms13/storage/shelf/wood/alt{
 	dir = 8
 	},
-/obj/effect/spawner/random/ms13/ammo/tier1,
+/obj/effect/spawner/random/ms13/ammo/lowrandom,
+/obj/effect/spawner/random/ms13/ammo/lowrandom,
 /turf/open/floor/plating/ms13/ground/desertalt,
 /area/ms13/town)
 "QO" = (
@@ -6060,6 +6260,7 @@
 /obj/structure/ms13/cave_decor/support/beams,
 /obj/structure/closet/ms13/wall/firstaid,
 /obj/effect/spawner/random/ms13/medical/herbal,
+/obj/effect/spawner/random/ms13/medical/lowrandom,
 /turf/open/floor/plating/ms13/ground/desertalt,
 /area/ms13/town)
 "Rv" = (
@@ -6087,6 +6288,11 @@
 /mob/living/basic/ms13/hostile_animal/molerat/young,
 /turf/open/floor/plating/ms13/ground/desertalt,
 /area/ms13/town)
+"RP" = (
+/obj/structure/table/ms13/wood/constructed/cobbled,
+/obj/effect/spawner/random/ms13/melee/tier3,
+/turf/open/floor/plating/ms13/ground/desertalt,
+/area/ms13/town)
 "RQ" = (
 /obj/structure/table/ms13/no_smooth/counter/metal{
 	dir = 8
@@ -6105,8 +6311,8 @@
 /area/ms13/town)
 "RW" = (
 /obj/structure/closet/crate/ms13/red,
-/obj/effect/spawner/random/ms13/melee/tier2,
-/obj/effect/spawner/random/ms13/clothing/under,
+/obj/effect/spawner/random/ms13/power_armor/parts,
+/obj/effect/spawner/random/ms13/power_armor/parts,
 /turf/open/floor/plating/ms13/ground/desertalt,
 /area/ms13/town)
 "RY" = (
@@ -6119,6 +6325,7 @@
 /obj/machinery/door/unpowered/ms13/metal/red{
 	dir = 8
 	},
+/obj/effect/spawner/random/ms13/locked/random/lowchance,
 /turf/open/floor/ms13/tile/large/cream,
 /area/ms13/town)
 "Sa" = (
@@ -6174,11 +6381,24 @@
 /mob/living/basic/ms13/ghoul/brown,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
+"Su" = (
+/obj/structure/ms13/storage/shelf/wood/alt{
+	dir = 1
+	},
+/obj/effect/spawner/random/ms13/crafting/household,
+/obj/effect/spawner/random/ms13/tools/lights,
+/turf/open/floor/plating/ms13/ground/desertalt,
+/area/ms13/town)
+"Sw" = (
+/mob/living/basic/ms13/ghoul/brown,
+/turf/open/floor/ms13/concrete,
+/area/ms13/underground/mountain)
 "Sx" = (
 /obj/structure/chair/ms13/metal{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/blood,
+/obj/item/restraints/handcuffs/ms13/rope,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "Sy" = (
@@ -6295,6 +6515,7 @@
 /obj/structure/table/ms13/metal/small,
 /obj/item/ms13/fluff/ashtray,
 /obj/structure/ms13/storage/vent,
+/obj/effect/spawner/random/ms13/smokeable/general,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "Ti" = (
@@ -6325,7 +6546,7 @@
 	dir = 4
 	},
 /obj/structure/table/ms13/wood/constructed/cobbled,
-/obj/effect/spawner/random/ms13/crafting/highrandom,
+/obj/effect/spawner/random/ms13/drugs/lowrandom,
 /turf/open/floor/plating/ms13/ground/desertalt,
 /area/ms13/town)
 "Ts" = (
@@ -6345,6 +6566,7 @@
 /obj/structure/ms13/storage/shelf/wood/alt{
 	dir = 8
 	},
+/obj/effect/spawner/random/ms13/tools/tool,
 /turf/open/floor/plating/ms13/ground/desertalt,
 /area/ms13/town)
 "TB" = (
@@ -6422,6 +6644,11 @@
 /obj/machinery/light/ms13,
 /turf/open/floor/ms13/metal/grate,
 /area/ms13/town)
+"Ub" = (
+/obj/structure/ms13/skeleton,
+/obj/effect/spawner/random/ms13/tools/tool,
+/turf/open/floor/plating/ms13/ground/desert,
+/area/ms13/desert)
 "Uc" = (
 /obj/structure/closet/ms13/wall/firstaid,
 /obj/effect/spawner/random/ms13/medical/herbal,
@@ -6467,6 +6694,11 @@
 "Up" = (
 /turf/open/floor/plating/ms13/ground/desert,
 /area/ms13/underground/mountain)
+"Uu" = (
+/obj/structure/ms13/turfdecor/drought,
+/mob/living/basic/ms13/ghoul/radioactive,
+/turf/open/floor/plating/ms13/ground/desertalt,
+/area/ms13/town)
 "Uv" = (
 /obj/structure/closet/crate/ms13/woodcrate/compact,
 /obj/effect/spawner/random/ms13/food/junkfood_canned,
@@ -6765,6 +6997,7 @@
 /obj/effect/spawner/random/ms13/medical/herbal,
 /obj/effect/spawner/random/ms13/clothing/under,
 /obj/effect/spawner/random/ms13/clothing/shoe,
+/obj/effect/spawner/random/ms13/clothing/glasses,
 /turf/open/floor/plating/ms13/ground/desertalt,
 /area/ms13/town)
 "WG" = (
@@ -6790,6 +7023,7 @@
 /obj/effect/spawner/random/ms13/drink/alcohol,
 /obj/effect/spawner/random/ms13/drink/alcohol,
 /obj/effect/spawner/random/ms13/drink/alcohol,
+/obj/effect/spawner/random/ms13/drink/alcohol_uncommon,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "WS" = (
@@ -7009,6 +7243,7 @@
 /area/ms13/underground/mountain)
 "YG" = (
 /obj/machinery/door/unpowered/ms13/seethrough/fence/wire,
+/obj/effect/spawner/random/ms13/locked/random/lowchance,
 /turf/open/floor/ms13/concrete/bricks,
 /area/ms13/town)
 "YI" = (
@@ -7033,11 +7268,8 @@
 /area/ms13/underground/mountain)
 "YP" = (
 /obj/structure/closet/crate/ms13/army,
-/obj/effect/spawner/random/ms13/locked/guaranteed/random,
-/obj/effect/spawner/random/ms13/armor/lowrandom,
-/obj/effect/spawner/random/ms13/armor/lowrandom,
 /obj/effect/spawner/random/ms13/armor/headgear,
-/obj/effect/spawner/random/ms13/armor/headgear,
+/obj/effect/spawner/random/ms13/armor/highrandom,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "YT" = (
@@ -7055,6 +7287,7 @@
 	pixel_y = 8
 	},
 /obj/effect/spawner/random/ms13/crafting/refined,
+/obj/effect/spawner/random/ms13/crafting/lowrandom,
 /turf/open/floor/plating/ms13/ground/desertalt,
 /area/ms13/town)
 "Za" = (
@@ -7097,6 +7330,10 @@
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/plating/ms13/ground/mountain/drought,
 /area/ms13/underground/mountain)
+"Zr" = (
+/mob/living/basic/ms13/hostile_animal/radroach,
+/turf/open/floor/ms13/concrete,
+/area/ms13/town)
 "Zv" = (
 /obj/structure/closet/crate/ms13/woodcrate,
 /turf/open/floor/wood/ms13/wide,
@@ -10935,7 +11172,7 @@ uD
 uD
 uD
 uD
-jC
+Lr
 uz
 vn
 nZ
@@ -12553,7 +12790,7 @@ nq
 HW
 Qo
 qJ
-fu
+px
 Ka
 nq
 HW
@@ -12748,7 +12985,7 @@ nq
 nq
 nq
 nq
-iS
+Go
 UF
 fu
 SQ
@@ -12945,11 +13182,11 @@ uD
 uD
 uD
 iW
-IS
+gC
 nq
 qJ
 Gw
-ok
+zH
 iW
 NV
 nq
@@ -13553,11 +13790,11 @@ uD
 uD
 HW
 eh
-fu
-qJ
+nq
+Uu
 Ic
 HW
-nq
+Dt
 nq
 SF
 iW
@@ -13758,7 +13995,7 @@ uT
 nq
 nq
 nq
-nR
+vF
 nq
 Ih
 nq
@@ -13957,7 +14194,7 @@ uD
 uD
 HW
 Xt
-Gw
+LG
 Ox
 Qk
 HW
@@ -20251,7 +20488,7 @@ VX
 KH
 wa
 GN
-wr
+eP
 vu
 gW
 Qa
@@ -20330,7 +20567,7 @@ uD
 uD
 uD
 UH
-UH
+Sw
 UH
 lh
 lh
@@ -21545,7 +21782,7 @@ Zg
 Zg
 lh
 al
-GN
+Zr
 GN
 GN
 rV
@@ -21746,7 +21983,7 @@ UH
 lh
 lh
 lh
-al
+LC
 GN
 GN
 ET
@@ -22144,7 +22381,7 @@ uD
 (75,1,1) = {"
 uD
 uD
-hV
+mD
 UH
 BZ
 UH
@@ -25991,7 +26228,7 @@ uD
 uD
 Gs
 Gs
-gG
+rp
 Gs
 Gs
 uD
@@ -29045,7 +29282,7 @@ uD
 uD
 uD
 uD
-PQ
+vN
 rb
 rb
 rb
@@ -30518,7 +30755,7 @@ uD
 uD
 HW
 ci
-Pf
+nq
 nq
 hp
 iW
@@ -30726,7 +30963,7 @@ nq
 iW
 Im
 he
-nq
+Zl
 Qk
 kI
 jk
@@ -30923,11 +31160,11 @@ uD
 HW
 HW
 HW
-ts
+Qy
 HW
 iW
 kI
-MZ
+bj
 iW
 iW
 kI
@@ -31058,7 +31295,7 @@ rb
 rb
 rb
 qy
-PQ
+Ub
 rb
 rb
 rb
@@ -31332,12 +31569,12 @@ dG
 nq
 SQ
 nq
-Pf
+iC
 Oa
 nq
 nq
 Dt
-Pf
+nq
 xC
 nq
 HW
@@ -31942,7 +32179,7 @@ HW
 wb
 CY
 qJ
-nq
+iC
 Zb
 Qk
 HW
@@ -32339,14 +32576,14 @@ Fx
 nq
 HW
 QB
-Pf
+iC
 nq
 Hu
 HW
 Es
 Hc
+iC
 nq
-Pf
 ER
 mY
 HW
@@ -34272,7 +34509,7 @@ SQ
 nq
 HW
 ci
-Dp
+fN
 nq
 dZ
 nq
@@ -36490,9 +36727,9 @@ uD
 HW
 gF
 kA
-nR
+PL
 nq
-nq
+Dp
 nq
 nq
 SQ
@@ -36897,7 +37134,7 @@ HW
 HW
 HW
 qV
-LG
+RP
 RW
 KP
 HW
@@ -47508,7 +47745,7 @@ uD
 Rk
 fP
 fP
-jB
+nX
 fP
 fL
 YP
@@ -47910,7 +48147,7 @@ uD
 uD
 uD
 Rk
-fP
+JD
 up
 wo
 wo
@@ -48721,7 +48958,7 @@ wo
 wo
 wo
 Rk
-fh
+cE
 wo
 wo
 wo
@@ -49184,8 +49421,8 @@ uD
 uD
 uD
 wo
-UL
-iy
+do
+vs
 wo
 qd
 xm
@@ -49588,7 +49825,7 @@ wo
 wo
 wo
 wo
-fh
+cE
 wo
 wo
 fP
@@ -49792,7 +50029,7 @@ ZN
 Wb
 fP
 fP
-jB
+aO
 fP
 fP
 fP
@@ -49951,7 +50188,7 @@ uD
 uD
 kI
 eA
-eN
+gZ
 nC
 wl
 kI
@@ -49989,14 +50226,14 @@ uD
 uD
 uD
 wo
-Zv
+yV
 fP
 fP
 fP
 fP
 wo
-Lq
-fP
+Ix
+uQ
 ZN
 wo
 uD
@@ -50351,12 +50588,12 @@ uD
 uD
 HW
 uu
-GA
+eN
 Tw
 iW
 mY
 nq
-Se
+nq
 WE
 iW
 LU
@@ -50555,7 +50792,7 @@ HW
 Ci
 nq
 SQ
-iS
+Ce
 nq
 nq
 nq
@@ -50595,7 +50832,7 @@ uD
 uD
 uD
 wo
-Zv
+Bx
 fP
 fP
 fP
@@ -50756,7 +50993,7 @@ uD
 HW
 xI
 nq
-qJ
+eI
 iW
 xz
 he
@@ -50961,7 +51198,7 @@ HW
 HW
 iW
 kI
-MZ
+jr
 iW
 kI
 iW
@@ -51160,7 +51397,7 @@ uD
 uD
 uD
 HW
-Vh
+Su
 nq
 Oa
 Eu
@@ -51368,9 +51605,9 @@ Se
 SF
 nq
 nq
-iS
+qF
 SQ
-Se
+nq
 nq
 Tq
 HW
@@ -51568,7 +51805,7 @@ Nl
 qJ
 nq
 nq
-nq
+Se
 ql
 HW
 kS

--- a/mojave/effects/spawners/locked_stuff.dm
+++ b/mojave/effects/spawners/locked_stuff.dm
@@ -108,7 +108,7 @@
 
 /obj/effect/spawner/random/ms13/locked/random/medchance
 	name = "random lock medium chance spawner"
-	spawn_loot_chance = 45
+	spawn_loot_chance = 50
 	loot = list(
 		/obj/effect/mapping_helpers/atom_injector/element_injector/ms13/lockedpickable/beginner,
 		/obj/effect/mapping_helpers/atom_injector/element_injector/ms13/lockedpickable/novice,
@@ -118,7 +118,7 @@
 
 /obj/effect/spawner/random/ms13/locked/random/highchance
 	name = "random lock high chance spawner"
-	spawn_loot_chance = 65
+	spawn_loot_chance = 70
 	loot = list(
 		/obj/effect/mapping_helpers/atom_injector/element_injector/ms13/lockedpickable/beginner,
 		/obj/effect/mapping_helpers/atom_injector/element_injector/ms13/lockedpickable/novice,

--- a/mojave/effects/spawners/lootdrop/foodloot.dm
+++ b/mojave/effects/spawners/lootdrop/foodloot.dm
@@ -232,6 +232,7 @@
 
 /obj/effect/spawner/random/ms13/food/trash
 	name = "random pre-war food trash spawner"
+	spawn_loot_chance = 40
 	loot = list(
 		/obj/item/trash/ms13/cans/dogfood,
 		/obj/item/trash/ms13/cans/porknbeans,
@@ -245,5 +246,6 @@
 		/obj/item/trash/ms13/packaging/poofs,
 		/obj/item/trash/ms13/packaging/sugarbombs,
 		/obj/item/trash/ms13/packaging/yumegg,
-		/obj/item/trash/ms13/packaging/instamash
+		/obj/item/trash/ms13/packaging/instamash,
+		/obj/item/reagent_containers/food/drinks/bottle/ms13/plain
 		)

--- a/mojave/effects/spawners/lootdrop/guarenteed/foodloot.dm
+++ b/mojave/effects/spawners/lootdrop/guarenteed/foodloot.dm
@@ -241,5 +241,6 @@
 		/obj/item/trash/ms13/packaging/poofs,
 		/obj/item/trash/ms13/packaging/sugarbombs,
 		/obj/item/trash/ms13/packaging/yumegg,
-		/obj/item/trash/ms13/packaging/instamash
+		/obj/item/trash/ms13/packaging/instamash,
+		/obj/item/reagent_containers/food/drinks/bottle/ms13/plain
 	)

--- a/mojave/effects/spawners/lootdrop/guarenteed/miscloot.dm
+++ b/mojave/effects/spawners/lootdrop/guarenteed/miscloot.dm
@@ -108,7 +108,8 @@
 			/obj/item/stack/sheet/ms13/plastic/two,
 			/obj/item/stack/sheet/ms13/rubber/two,
 			/obj/item/stack/sheet/ms13/scrap_parts/two,
-			/obj/item/stack/sheet/ms13/scrap/two
+			/obj/item/stack/sheet/ms13/scrap/two,
+			/obj/item/restraints/handcuffs/ms13/rope
 	)
 
 /obj/effect/spawner/random/ms13/guaranteed/crafting/highrandom

--- a/mojave/effects/spawners/lootdrop/miscloot.dm
+++ b/mojave/effects/spawners/lootdrop/miscloot.dm
@@ -196,7 +196,7 @@
 
 /obj/effect/spawner/random/ms13/smokeable/general
 	name = "general smokeables spawner"
-	spawn_loot_chance = 65
+	spawn_loot_chance = 75
 	loot = list(
 			/obj/effect/spawner/random/ms13/guaranteed/smokeable/highrandom = 30,
 			/obj/effect/spawner/random/ms13/guaranteed/smokeable/lowrandom = 70,

--- a/mojave/effects/spawners/lootdrop/miscloot.dm
+++ b/mojave/effects/spawners/lootdrop/miscloot.dm
@@ -196,7 +196,7 @@
 
 /obj/effect/spawner/random/ms13/smokeable/general
 	name = "general smokeables spawner"
-	spawn_loot_chance = 75
+	spawn_loot_chance = 80
 	loot = list(
 			/obj/effect/spawner/random/ms13/guaranteed/smokeable/highrandom = 30,
 			/obj/effect/spawner/random/ms13/guaranteed/smokeable/lowrandom = 70,

--- a/mojave/items/misc/smokeables/lightables.dm
+++ b/mojave/items/misc/smokeables/lightables.dm
@@ -271,13 +271,13 @@
 	lefthand_file = 'mojave/icons/mob/inhands/misc/lightables_lefthand.dmi'
 	righthand_file = 'mojave/icons/mob/inhands/misc/lightables_righthand.dmi'
 	inhand_icon_state = "zippo"
-	var/max_fuel = 40
+	var/max_fuel = 50
 	overlay_list = null
 	var/is_open = FALSE
 
 /obj/item/lighter/ms13/zippo/Initialize(mapload)
 	. = ..()
-	var/fuel_start = rand(5, max_fuel)
+	var/fuel_start = rand(10, max_fuel)
 	create_reagents(fuel_start)
 	reagents.add_reagent(/datum/reagent/fuel, fuel_start)
 	AddElement(/datum/element/world_icon, null, icon, 'mojave/icons/objects/tools/lightables_inventory.dmi', world_state, inventory_state)

--- a/mojave/items/tools/tools.dm
+++ b/mojave/items/tools/tools.dm
@@ -143,7 +143,7 @@
 	subtractible_armour_penetration = 10
 	wound_bonus = 5
 	bare_wound_bonus = 0
-	max_fuel = 40
+	max_fuel = 75
 	light_color = "#7c84a7"
 	w_class = WEIGHT_CLASS_NORMAL
 	log_pickup_and_drop = TRUE
@@ -153,7 +153,11 @@
 
 /obj/item/weldingtool/ms13/Initialize()
 	. = ..()
+	var/fuel_start = rand(25, max_fuel)
+	create_reagents(fuel_start)
+	reagents.add_reagent(/datum/reagent/fuel, fuel_start)
 	AddElement(/datum/element/world_icon, null, icon, 'mojave/icons/objects/tools/tools_inventory.dmi')
+	update_appearance()
 
 /obj/item/weldingtool/ms13/update_icon_state()
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

Distributes some more loot spawners around Drought, as well as the new smoking spawners. Slightly adjusts some spawner values. Also distributes more locks around the map. 

The distribution of the spawners + the locks should hopefully control the pace at which the map runs out of loot at least a bit. 

## Why It's Good For The Game

Smoking spawners are awesome and good loot distribution so the map isn't barren in 50m is awesome. 