### PR TITLE
Post Test Tweaks 8/1

### DIFF
--- a/mojave/areas/area.dm
+++ b/mojave/areas/area.dm
@@ -28,25 +28,25 @@
 	power_light = TRUE
 	ambientsounds = null
 	atmosphere_sound = BUILDING_ATMOSPHERE
-	dissipation_rate = 0.1 //not much escapes enclosed rooms
+	dissipation_rate = 0.18 //not much escapes enclosed rooms
 
 /area/ms13/farmhouse
 	name = "Farmhouse"
 	icon_state = "farmhouse"
 	atmosphere_sound = BUILDING_ATMOSPHERE
-	dissipation_rate = 0.1 //not much escapes enclosed rooms
+	dissipation_rate = 0.18 //not much escapes enclosed rooms
 
 /area/ms13/powerplant
 	name = "Power Plant"
 	icon_state = "powerplant"
 	atmosphere_sound = INDUSTRIAL_ATMOSPHERE
-	dissipation_rate = 0.1 //not much escapes enclosed rooms
+	dissipation_rate = 0.18 //not much escapes enclosed rooms
 
 /area/ms13/factory
 	name = "Factory"
 	icon_state = "factory"
 	atmosphere_sound = INDUSTRIAL_ATMOSPHERE
-	dissipation_rate = 0.1 //not much escapes enclosed rooms
+	dissipation_rate = 0.18 //not much escapes enclosed rooms
 
 /area/ms13/army_base
 	name = "Army Base"
@@ -56,7 +56,7 @@
 	name = "Army Base building"
 	icon_state = "army_base_building"
 	atmosphere_sound = BUILDING_ATMOSPHERE
-	dissipation_rate = 0.1 //not much escapes enclosed rooms
+	dissipation_rate = 0.18 //not much escapes enclosed rooms
 
 /area/ms13/underground/vault_atrium_upper
 	name = "Vault atrium upper"
@@ -86,7 +86,7 @@
 	name = "Supermarket"
 	icon_state = "supermarket"
 	atmosphere_sound = BUILDING_ATMOSPHERE
-	dissipation_rate = 0.1 //not much escapes enclosed rooms
+	dissipation_rate = 0.18 //not much escapes enclosed rooms
 
 /area/ms13/supermarket/basement
 	name = "Supermarket Basement"
@@ -119,13 +119,13 @@
 	name = "Snowcrest Building"
 	icon_state = "snowcrest_building"
 	atmosphere_sound = BUILDING_ATMOSPHERE
-	dissipation_rate = 0.1
+	dissipation_rate = 0.18
 
 /area/ms13/snowcrest/republic
 	name = "Snowcrest NCR building"
 	icon_state = "snowcrest_ncr"
 	atmosphere_sound = INDUSTRIAL_ATMOSPHERE
-	dissipation_rate = 0.1
+	dissipation_rate = 0.18
 
 // Generic Underground Areas //
 
@@ -214,7 +214,7 @@
 /area/ms13/ncr/building
 	name = "NCR building"
 	icon_state = "NCR_building"
-	dissipation_rate = 0.1 //not much escapes enclosed rooms
+	dissipation_rate = 0.18 //not much escapes enclosed rooms
 
 /area/ms13/underground/bos
 	name = "BoS"
@@ -229,13 +229,13 @@
 /area/ms13/raiders/building
 	name = "Raider building"
 	icon_state = "raiders_building"
-	dissipation_rate = 0.1 //not much escapes enclosed rooms
+	dissipation_rate = 0.18 //not much escapes enclosed rooms
 
 /area/ms13/tribal_abandoned
 	name = "abandoned Tribal building"
 	icon_state = "town"
 	atmosphere_sound = BUILDING_ATMOSPHERE
-	dissipation_rate = 0.1 //not much escapes enclosed rooms
+	dissipation_rate = 0.18 //not much escapes enclosed rooms
 
 /area/ms13/underground/military_crypt
 	name = "Abandoned Outpost Bunker"
@@ -263,7 +263,7 @@
 	icon_state = "legion_building"
 	outdoors = FALSE
 	atmosphere_sound = BUILDING_ATMOSPHERE
-	dissipation_rate = 0.1 //not much escapes enclosed rooms
+	dissipation_rate = 0.18 //not much escapes enclosed rooms
 
 
 /area/ms13/drylanders
@@ -275,7 +275,7 @@
 	icon_state = "drylander_building"
 	outdoors = FALSE
 	atmosphere_sound = BUILDING_ATMOSPHERE
-	dissipation_rate = 0.1 //not much escapes enclosed rooms
+	dissipation_rate = 0.18 //not much escapes enclosed rooms
 
 /area/ms13/rangeroutpost
 	name = "Desert Ranger Outpost"
@@ -291,7 +291,7 @@
 	name = "Desert Ranger Outpost building"
 	icon_state = "rangerbase"
 	outdoors = FALSE
-	dissipation_rate = 0.1 //not much escapes enclosed rooms
+	dissipation_rate = 0.18 //not much escapes enclosed rooms
 
 /area/ms13/water_baron
 	name = "The Barony"
@@ -302,7 +302,7 @@
 /area/ms13/water_baron/interior
 	name = "The Barony building"
 	icon_state = "baronyinterior"
-	dissipation_rate = 0.1 //not much escapes enclosed rooms
+	dissipation_rate = 0.18 //not much escapes enclosed rooms
 
 // Mall/Eagle Lakes Areas //
 

--- a/mojave/code/modules/jobs/job_types/bos/head_paladin.dm
+++ b/mojave/code/modules/jobs/job_types/bos/head_paladin.dm
@@ -29,7 +29,7 @@
 		/obj/item/stock_parts/cell/ms13/mfc=1,\
 		/obj/item/stack/medical/gauze/ms13/half=1, \
 		/obj/item/stack/medical/ointment/ms13/half=1, \
-		/obj/item/stack/ms13/currency/prewar/eighty=1)
+		/obj/item/stack/ms13/currency/prewar/hunned=1)
 
 /datum/outfit/job/ms13/bos/head_paladin/pre_equip(mob/living/carbon/human/H)
 	..()

--- a/mojave/code/modules/jobs/job_types/bos/head_scribe.dm
+++ b/mojave/code/modules/jobs/job_types/bos/head_scribe.dm
@@ -28,7 +28,7 @@
 	backpack_contents = list(
 		/obj/item/stack/medical/gauze/ms13/half=1, \
 		/obj/item/stack/medical/ointment/ms13/half=1, \
-		/obj/item/stack/ms13/currency/prewar/eighty=1, \
+		/obj/item/stack/ms13/currency/prewar/hunned=1, \
 		/obj/item/radio/ms13/broadcast/advanced=1)
 
 /datum/outfit/job/ms13/bos/head_scribe/pre_equip(mob/living/carbon/human/H)

--- a/mojave/code/modules/jobs/job_types/bos/paladin.dm
+++ b/mojave/code/modules/jobs/job_types/bos/paladin.dm
@@ -28,7 +28,7 @@
 	backpack_contents = list(
 		/obj/item/stack/medical/gauze/ms13/half=1, \
 		/obj/item/stack/medical/ointment/ms13/half=1, \
-		/obj/item/stack/ms13/currency/prewar/sixty=1)
+		/obj/item/stack/ms13/currency/prewar/seventy=1)
 
 /datum/outfit/job/ms13/bos/paladin/pre_equip(mob/living/carbon/human/H)
 	..()

--- a/mojave/code/modules/jobs/job_types/ncr/milly_police.dm
+++ b/mojave/code/modules/jobs/job_types/ncr/milly_police.dm
@@ -39,9 +39,15 @@
 	else
 		glasses = null
 
-	suit_store = pick(
+	if(prob(35))
+		suit_store = pick(
+			/obj/item/gun/ballistic/automatic/ms13/semi/service,\
+			/obj/item/gun/ballistic/automatic/ms13/full/smg9mm)
+	else
+		suit_store = pick(
 			/obj/item/gun/ballistic/revolver/ms13/caravan,\
-			/obj/item/gun/ballistic/rifle/ms13/varmint)
+			/obj/item/gun/ballistic/rifle/ms13/varmint, \
+			/obj/item/gun/ballistic/rifle/ms13/hunting/surplus)
 
 
 /datum/outfit/job/ms13/ncr/mp/post_equip(mob/living/carbon/human/H, visualsOnly)

--- a/mojave/code/modules/jobs/job_types/ncr/mp_medic.dm
+++ b/mojave/code/modules/jobs/job_types/ncr/mp_medic.dm
@@ -24,7 +24,7 @@
 	backpack_contents = list(
 		/obj/item/stack/medical/gauze/ms13/half=1, \
 		/obj/item/stack/medical/ointment/ms13/half=1, \
-		/obj/item/stack/ms13/currency/ncr_dollar/twenty=1)
+		/obj/item/stack/ms13/currency/ncr_dollar/thirty=1)
 
 /datum/outfit/job/ms13/ncr/mp_medic/pre_equip(mob/living/carbon/human/H)
 	..()

--- a/mojave/code/modules/jobs/job_types/ncr/mp_sergeant.dm
+++ b/mojave/code/modules/jobs/job_types/ncr/mp_sergeant.dm
@@ -11,7 +11,7 @@
 
 /datum/outfit/job/ms13/ncr/mp_sergeant
 	name = "_NCR MP Sergeant"
-	jobtype = /datum/job/ms13/ncr/mp_sergeant
+	jobtype = 	 /datum/job/ms13/ncr/mp_sergeant
 	id = 		 /obj/item/card/id/ms13/ncr/sergeant/mp
 	uniform =    /obj/item/clothing/under/ms13/ncr/fatigues/nco
 	head = 	     /obj/item/clothing/head/helmet/ms13/ncr/beret/nco
@@ -25,7 +25,7 @@
 		/obj/item/stack/medical/gauze/ms13/half=1, \
 		/obj/item/ammo_box/ms13/shotgun/buckshot=1, \
 		/obj/item/ammo_box/magazine/ms13/m45=2, \
-		/obj/item/stack/ms13/currency/ncr_dollar/sixty=1, \
+		/obj/item/stack/ms13/currency/ncr_dollar/eighty=1, \
 		/obj/item/claymore/ms13/baton=1, \
 		/obj/item/knife/ms13/hunting=1, \
 		/obj/item/stack/medical/ointment/ms13/half=1, \

--- a/mojave/code/modules/jobs/job_types/raiders/mon_captain.dm
+++ b/mojave/code/modules/jobs/job_types/raiders/mon_captain.dm
@@ -22,11 +22,11 @@
 	head =		 /obj/item/clothing/head/helmet/ms13/combat/mon_city
 	id =		 /obj/item/card/id/ms13/mon_captain
 	belt =		 /obj/item/gun/ballistic/automatic/pistol/ms13/m10mm/military
-	suit_store = /obj/item/gun/ballistic/automatic/ms13/full/assaultrifle
+	suit_store = /obj/item/gun/ballistic/automatic/ms13/semi/marksman
 	r_pocket =	 /obj/item/knife/ms13/combat
 	l_pocket =	 /obj/item/flashlight/ms13
 	backpack_contents = list(
-			/obj/item/stack/ms13/currency/prewar/seventy=1,\
+			/obj/item/stack/ms13/currency/prewar/eighty=1,\
 			/obj/item/stack/medical/gauze/ms13/half=1,\
 			/obj/item/ammo_box/magazine/ms13/m10mm=2,\
 			/obj/item/ammo_box/magazine/ms13/r20=1,\

--- a/mojave/code/modules/jobs/job_types/raiders/mon_captain.dm
+++ b/mojave/code/modules/jobs/job_types/raiders/mon_captain.dm
@@ -32,7 +32,7 @@
 			/obj/item/ammo_box/magazine/ms13/r20=1,\
 			/obj/item/radio/ms13/broadcast=1,\
 			/obj/item/reagent_containers/hypospray/medipen/ms13/stimpak=1, \
-			/obj/item/restraints/handcuffs/ms13=1)
+			/obj/item/restraints/handcuffs/ms13=2)
 
 /datum/outfit/job/ms13/raiders/mon_captain/pre_equip(mob/living/carbon/human/H)
 	..()

--- a/mojave/code/modules/jobs/job_types/raiders/mon_grunt.dm
+++ b/mojave/code/modules/jobs/job_types/raiders/mon_grunt.dm
@@ -42,8 +42,8 @@
 		mask = /obj/item/clothing/mask/gas/ms13/mon_city
 
 	suit_store = pick(
-		/obj/item/gun/energy/ms13/laser/pistol/wattz_heavy,\
-		/obj/item/gun/ballistic/revolver/ms13/rev44)
+		/obj/item/gun/ballistic/shotgun/ms13/lever,\
+			/obj/item/gun/ballistic/shotgun/ms13/lever/cowboy,\)
 
 /datum/outfit/job/ms13/raiders/mon_grunt/post_equip(mob/living/carbon/human/H, visualsOnly)
 	. = ..()

--- a/mojave/code/modules/jobs/job_types/raiders/mon_grunt.dm
+++ b/mojave/code/modules/jobs/job_types/raiders/mon_grunt.dm
@@ -42,8 +42,8 @@
 		mask = /obj/item/clothing/mask/gas/ms13/mon_city
 
 	suit_store = pick(
-		/obj/item/gun/ballistic/shotgun/ms13/lever,\
-			/obj/item/gun/ballistic/shotgun/ms13/lever/cowboy,\)
+			/obj/item/gun/ballistic/shotgun/ms13/lever,\
+			/obj/item/gun/ballistic/shotgun/ms13/lever/cowboy)
 
 /datum/outfit/job/ms13/raiders/mon_grunt/post_equip(mob/living/carbon/human/H, visualsOnly)
 	. = ..()

--- a/mojave/code/modules/jobs/job_types/raiders/mon_grunt.dm
+++ b/mojave/code/modules/jobs/job_types/raiders/mon_grunt.dm
@@ -22,7 +22,6 @@
 	mask =		 /obj/item/clothing/mask/gas/ms13/mon_city
 	head =		 /obj/item/clothing/head/helmet/ms13/cowboy/mon_city
 	belt =		 /obj/item/gun/ballistic/revolver/ms13/rev10mm
-	suit_store = /obj/item/gun/ballistic/shotgun/automatic/ms13/sks
 	r_pocket =	 /obj/item/knife/ms13/combat
 	l_pocket =	 /obj/item/flashlight/flare/ms13
 	backpack_contents = list(
@@ -41,6 +40,10 @@
 		mask = /obj/item/clothing/mask/gas/ms13/mon_city/full
 	else
 		mask = /obj/item/clothing/mask/gas/ms13/mon_city
+
+	suit_store = pick(
+		/obj/item/gun/energy/ms13/laser/pistol/wattz_heavy,\
+		/obj/item/gun/ballistic/revolver/ms13/rev44)
 
 /datum/outfit/job/ms13/raiders/mon_grunt/post_equip(mob/living/carbon/human/H, visualsOnly)
 	. = ..()

--- a/mojave/code/modules/jobs/job_types/raiders/slicker.dm
+++ b/mojave/code/modules/jobs/job_types/raiders/slicker.dm
@@ -15,7 +15,7 @@
 	name = "_Slickback"
 	jobtype = /datum/job/ms13/raiders/slicker
 
-	l_pocket =	 /obj/item/stack/ms13/currency/prewar/seventy
+	l_pocket =	 /obj/item/stack/ms13/currency/prewar/eighty
 	shoes =		 /obj/item/clothing/shoes/ms13/fancy
 	backpack_contents = list(
 		/obj/item/stack/medical/gauze/ms13/three=1)

--- a/mojave/code/modules/jobs/job_types/town/bartender.dm
+++ b/mojave/code/modules/jobs/job_types/town/bartender.dm
@@ -21,7 +21,7 @@
 	shoes =  	 /obj/item/clothing/shoes/ms13/fancy
 	suit_store = /obj/item/gun/ballistic/revolver/ms13/caravan
 	r_pocket   = /obj/item/ammo_box/ms13/shotgun/buckshot
-	l_pocket =   /obj/item/stack/ms13/currency/prewar/hunnedtwenty
+	l_pocket =   /obj/item/stack/ms13/currency/prewar/hunnedfourty
 	back =       null
 
 /datum/outfit/job/ms13/town/bartender/pre_equip(mob/living/carbon/human/H)

--- a/mojave/code/modules/jobs/job_types/town/bodyguard.dm
+++ b/mojave/code/modules/jobs/job_types/town/bodyguard.dm
@@ -18,7 +18,7 @@
 	id =		 /obj/item/card/id/ms13/bodyguard
 	uniform =	 /obj/item/clothing/under/ms13/wasteland/snowcrest/bodyguard
 	head =		 /obj/item/clothing/head/helmet/ms13/snowguard
-	r_pocket =   /obj/item/stack/ms13/currency/prewar/eighty
+	r_pocket =   /obj/item/stack/ms13/currency/prewar/ninety
 	l_pocket =	 /obj/item/flashlight/ms13
 	belt =		 /obj/item/gun/ballistic/revolver/ms13/rev556
 	suit =		 /obj/item/clothing/suit/armor/ms13/vest/snowcrest

--- a/mojave/code/modules/jobs/job_types/town/doctor.dm
+++ b/mojave/code/modules/jobs/job_types/town/doctor.dm
@@ -23,7 +23,7 @@
 	belt = 		 /obj/item/storage/firstaid/ms13/regular
 	shoes = 	 /obj/item/clothing/shoes/ms13/fancy
 	gloves =	 /obj/item/clothing/gloves/ms13/nitrile
-	r_pocket =   /obj/item/stack/ms13/currency/prewar/hunnedfourty
+	r_pocket =   /obj/item/stack/ms13/currency/prewar/hunnedeighty
 	back =       /obj/item/storage/ms13/satchel
 
 /datum/outfit/job/ms13/town/doctor/pre_equip(mob/living/carbon/human/H)

--- a/mojave/code/modules/jobs/job_types/town/mayor.dm
+++ b/mojave/code/modules/jobs/job_types/town/mayor.dm
@@ -20,6 +20,7 @@
 	head = 		 /obj/item/clothing/head/helmet/ms13/tall/regal
 	shoes =  	 /obj/item/clothing/shoes/ms13/fancy
 	belt = 		 /obj/item/ammo_box/ms13/a357box
+	r_hand =	 /obj/item/radio/ms13/broadcast/advanced
 	r_pocket =   /obj/item/gun/ballistic/revolver/ms13/derringer/trimmed
 	l_pocket =   /obj/item/stack/ms13/currency/prewar/mayor
 	back =       null

--- a/mojave/code/modules/jobs/job_types/town/nurse.dm
+++ b/mojave/code/modules/jobs/job_types/town/nurse.dm
@@ -20,7 +20,7 @@
 	id =		 /obj/item/card/id/ms13/doctor/nurse
 	belt = 		 /obj/item/storage/firstaid/ms13/regular
 	uniform = 	 /obj/item/clothing/under/ms13/wasteland/snowcrest/medical
-	r_pocket =   /obj/item/stack/ms13/currency/prewar/ninety
+	r_pocket =   /obj/item/stack/ms13/currency/prewar/hunned
 	shoes = 	 /obj/item/clothing/shoes/ms13/winter
 	back =       /obj/item/storage/ms13/satchel
 

--- a/mojave/effects/spawners/lootdrop/currencyloot.dm
+++ b/mojave/effects/spawners/lootdrop/currencyloot.dm
@@ -16,8 +16,8 @@
 	name = "low tier random Mammoth currency spawner"
 	spawn_loot_chance = 100
 	loot = list(
-		/obj/effect/spawner/random/ms13/currency/mammoth/tier1 = 50,
-		/obj/effect/spawner/random/ms13/currency/mammoth/tier2 = 35,
+		/obj/effect/spawner/random/ms13/currency/mammoth/tier1 = 55,
+		/obj/effect/spawner/random/ms13/currency/mammoth/tier2 = 30,
 		/obj/effect/spawner/random/ms13/currency/mammoth/tier3 = 15)
 
 /obj/effect/spawner/random/ms13/currency/mammoth/highrandom
@@ -30,7 +30,7 @@
 
 /obj/effect/spawner/random/ms13/currency/mammoth/tier1
 	name = "tier 1 Mammoth currency spawner"
-	spawn_loot_chance = 65
+	spawn_loot_chance = 60
 	loot = list(
 		/obj/item/stack/ms13/currency/prewar/ten = 55,
 		/obj/item/stack/ms13/currency/ncr_dollar/five = 35,
@@ -38,7 +38,7 @@
 
 /obj/effect/spawner/random/ms13/currency/mammoth/tier2
 	name = "tier 2 Mammoth currency spawner"
-	spawn_loot_chance = 55
+	spawn_loot_chance = 50
 	loot = list(
 		/obj/item/stack/ms13/currency/prewar/twenty = 55,
 		/obj/item/stack/ms13/currency/ncr_dollar/twelve = 35,
@@ -46,7 +46,7 @@
 
 /obj/effect/spawner/random/ms13/currency/mammoth/tier3
 	name = "tier 3 Mammoth currency spawner"
-	spawn_loot_chance = 45
+	spawn_loot_chance = 40
 	loot = list(
 		/obj/item/stack/ms13/currency/prewar/fifty = 55,
 		/obj/item/stack/ms13/currency/ncr_dollar/thirty = 35,
@@ -68,8 +68,8 @@
 	name = "low tier random Mammoth currency spawner"
 	spawn_loot_chance = 100
 	loot = list(
-		/obj/effect/spawner/random/ms13/currency/mammoth/prewar/tier1 = 50,
-		/obj/effect/spawner/random/ms13/currency/mammoth/prewar/tier2 = 35,
+		/obj/effect/spawner/random/ms13/currency/mammoth/prewar/tier1 = 55,
+		/obj/effect/spawner/random/ms13/currency/mammoth/prewar/tier2 = 30,
 		/obj/effect/spawner/random/ms13/currency/mammoth/prewar/tier3 = 15)
 
 /obj/effect/spawner/random/ms13/currency/mammoth/prewar/highrandom
@@ -82,7 +82,7 @@
 
 /obj/effect/spawner/random/ms13/currency/mammoth/prewar/tier1
 	name = "tier 1 prewar Mammoth currency spawner"
-	spawn_loot_chance = 65
+	spawn_loot_chance = 60
 	loot = list(
 		/obj/item/stack/ms13/currency/prewar/five,
 		/obj/item/stack/ms13/currency/prewar/ten,
@@ -91,7 +91,7 @@
 
 /obj/effect/spawner/random/ms13/currency/mammoth/prewar/tier2
 	name = "tier 2 prewar Mammoth currency spawner"
-	spawn_loot_chance = 55
+	spawn_loot_chance = 50
 	loot = list(
 		/obj/item/stack/ms13/currency/prewar/twenty,
 		/obj/item/stack/ms13/currency/prewar/thirty,
@@ -100,7 +100,7 @@
 
 /obj/effect/spawner/random/ms13/currency/mammoth/prewar/tier3
 	name = "tier 3 prewar Mammoth currency spawner"
-	spawn_loot_chance = 45
+	spawn_loot_chance = 40
 	loot = list(
 		/obj/item/stack/ms13/currency/prewar/thirty,
 		/obj/item/stack/ms13/currency/prewar/fourty,
@@ -125,7 +125,7 @@
 
 /obj/effect/spawner/random/ms13/currency/mammoth/ncr/low
 	name = "low budget NCR currency deficit spawner"
-	spawn_loot_chance = 75
+	spawn_loot_chance = 65
 	loot = list(
 		/obj/item/stack/ms13/currency/ncr_dollar = 5,
 		/obj/item/stack/ms13/currency/ncr_dollar/five = 35,
@@ -136,7 +136,7 @@
 
 /obj/effect/spawner/random/ms13/currency/mammoth/ncr/high
 	name = "high dolla balla status NCR currency spawner"
-	spawn_loot_chance = 50
+	spawn_loot_chance = 45
 	loot = list(
 		/obj/item/stack/ms13/currency/ncr_dollar/thirty = 25,
 		/obj/item/stack/ms13/currency/ncr_dollar/fourty = 30,
@@ -153,8 +153,8 @@
 	name = "low tier random Drought currency spawner"
 	spawn_loot_chance = 100
 	loot = list(
-		/obj/effect/spawner/random/ms13/currency/drought/tier1 = 50,
-		/obj/effect/spawner/random/ms13/currency/drought/tier2 = 35,
+		/obj/effect/spawner/random/ms13/currency/drought/tier1 = 55,
+		/obj/effect/spawner/random/ms13/currency/drought/tier2 = 30,
 		/obj/effect/spawner/random/ms13/currency/drought/tier3 = 15)
 
 /obj/effect/spawner/random/ms13/currency/drought/highrandom
@@ -167,7 +167,7 @@
 
 /obj/effect/spawner/random/ms13/currency/drought/tier1
 	name = "tier 1 Drought currency spawner"
-	spawn_loot_chance = 65
+	spawn_loot_chance = 60
 	loot = list(
 		/obj/item/stack/ms13/currency/cap/four = 40,
 		/obj/item/stack/ms13/currency/cap/ten = 20,
@@ -178,7 +178,7 @@
 
 /obj/effect/spawner/random/ms13/currency/drought/tier2
 	name = "tier 2 Drought currency spawner"
-	spawn_loot_chance = 55
+	spawn_loot_chance = 50
 	loot = list(
 		/obj/item/stack/ms13/currency/cap/twentyfive = 45,
 		/obj/item/stack/ms13/currency/cap/thirtyfive = 25,
@@ -189,7 +189,7 @@
 
 /obj/effect/spawner/random/ms13/currency/drought/tier3
 	name = "tier 3 Drought currency spawner"
-	spawn_loot_chance = 45
+	spawn_loot_chance = 40
 	loot = list(
 		/obj/item/stack/ms13/currency/cap/fifty = 45,
 		/obj/item/stack/ms13/currency/cap/sixty = 25,
@@ -230,7 +230,7 @@
 
 /obj/effect/spawner/random/ms13/currency/drought/legion/tier1
 	name = "tier 1 Legion currency spawner"
-	spawn_loot_chance = 65
+	spawn_loot_chance = 60
 	loot = list(
 		/obj/item/stack/ms13/currency/denarius/two = 25,
 		/obj/item/stack/ms13/currency/denarius/five = 45,
@@ -239,7 +239,7 @@
 
 /obj/effect/spawner/random/ms13/currency/drought/legion/tier2
 	name = "tier 2 Legion currency spawner"
-	spawn_loot_chance = 55
+	spawn_loot_chance = 50
 	loot = list(
 		/obj/item/stack/ms13/currency/denarius/twenty = 35,
 		/obj/item/stack/ms13/currency/denarius/twentyfive = 25,
@@ -248,7 +248,7 @@
 
 /obj/effect/spawner/random/ms13/currency/drought/legion/tier3
 	name = "tier 3 Legion currency spawner"
-	spawn_loot_chance = 45
+	spawn_loot_chance = 40
 	loot = list(
 		/obj/item/stack/ms13/currency/denarius/thirty = 30,
 		/obj/item/stack/ms13/currency/aurelius/twenty = 45,
@@ -263,8 +263,8 @@
 	name = "low tier random Drought currency spawner"
 	spawn_loot_chance = 100
 	loot = list(
-		/obj/effect/spawner/random/ms13/currency/drought/prewar/tier1 = 50,
-		/obj/effect/spawner/random/ms13/currency/drought/prewar/tier2 = 35,
+		/obj/effect/spawner/random/ms13/currency/drought/prewar/tier1 = 55,
+		/obj/effect/spawner/random/ms13/currency/drought/prewar/tier2 = 30,
 		/obj/effect/spawner/random/ms13/currency/drought/prewar/tier3 = 15)
 
 /obj/effect/spawner/random/ms13/currency/drought/prewar/highrandom
@@ -277,7 +277,7 @@
 
 /obj/effect/spawner/random/ms13/currency/drought/prewar/tier1
 	name = "tier 1 prewar Drought currency spawner"
-	spawn_loot_chance = 65
+	spawn_loot_chance = 60
 	loot = list(
 		/obj/item/stack/ms13/currency/prewar/five,
 		/obj/item/stack/ms13/currency/prewar/ten,
@@ -286,7 +286,7 @@
 
 /obj/effect/spawner/random/ms13/currency/drought/prewar/tier2
 	name = "tier 2 prewar Drought currency spawner"
-	spawn_loot_chance = 55
+	spawn_loot_chance = 50
 	loot = list(
 		/obj/item/stack/ms13/currency/prewar/twenty,
 		/obj/item/stack/ms13/currency/prewar/thirty,
@@ -295,7 +295,7 @@
 
 /obj/effect/spawner/random/ms13/currency/drought/prewar/tier3
 	name = "tier 3 prewar Drought currency spawner"
-	spawn_loot_chance = 45
+	spawn_loot_chance = 40
 	loot = list(
 		/obj/item/stack/ms13/currency/prewar/thirty,
 		/obj/item/stack/ms13/currency/prewar/fourty,

--- a/mojave/effects/spawners/lootdrop/guarenteed/currencyloot.dm
+++ b/mojave/effects/spawners/lootdrop/guarenteed/currencyloot.dm
@@ -14,8 +14,8 @@
 /obj/effect/spawner/random/ms13/guaranteed/currency/mammoth/lowrandom
 	name = "low tier random Mammoth currency spawner"
 	loot = list(
-		/obj/effect/spawner/random/ms13/guaranteed/currency/mammoth/tier1 = 50,
-		/obj/effect/spawner/random/ms13/guaranteed/currency/mammoth/tier2 = 35,
+		/obj/effect/spawner/random/ms13/guaranteed/currency/mammoth/tier1 = 55,
+		/obj/effect/spawner/random/ms13/guaranteed/currency/mammoth/tier2 = 30,
 		/obj/effect/spawner/random/ms13/guaranteed/currency/mammoth/tier3 = 15)
 
 /obj/effect/spawner/random/ms13/guaranteed/currency/mammoth/highrandom
@@ -28,30 +28,29 @@
 /obj/effect/spawner/random/ms13/guaranteed/currency/mammoth/tier1
 	name = "tier 1 Mammoth currency spawner"
 	loot = list(
-		/obj/item/stack/ms13/currency/prewar/ten = 60,
-		/obj/item/stack/ms13/currency/ncr_dollar/ten = 25,
-		/obj/item/stack/ms13/currency/ncr_coin = 10,
-		/obj/item/stack/ms13/currency/cap/ten = 5)
+		/obj/item/stack/ms13/currency/prewar/ten = 55,
+		/obj/item/stack/ms13/currency/ncr_dollar/five = 35,
+		/obj/item/stack/ms13/currency/ncr_coin/two = 10)
 
 /obj/effect/spawner/random/ms13/guaranteed/currency/mammoth/tier2
 	name = "tier 2 Mammoth currency spawner"
 	loot = list(
-		/obj/item/stack/ms13/currency/prewar/twenty = 60,
-		/obj/item/stack/ms13/currency/ncr_dollar/twenty = 25,
-		/obj/item/stack/ms13/currency/ncr_coin/five = 15)
+		/obj/item/stack/ms13/currency/prewar/twenty = 55,
+		/obj/item/stack/ms13/currency/ncr_dollar/twelve = 35,
+		/obj/item/stack/ms13/currency/ncr_coin/five = 10)
 
 /obj/effect/spawner/random/ms13/guaranteed/currency/mammoth/tier3
 	name = "tier 3 Mammoth currency spawner"
 	loot = list(
-		/obj/item/stack/ms13/currency/prewar/fifty = 60,
-		/obj/item/stack/ms13/currency/ncr_dollar/fifty = 25,
-		/obj/item/stack/ms13/currency/ncr_coin/ten = 15)
+		/obj/item/stack/ms13/currency/prewar/fifty = 55,
+		/obj/item/stack/ms13/currency/ncr_dollar/thirty = 35,
+		/obj/item/stack/ms13/currency/ncr_coin/ten = 10)
 
 /obj/effect/spawner/random/ms13/guaranteed/currency/mammoth/tier4
 	name = "tier 4 Mammoth currency spawner"
 	loot = list(
 		/obj/item/stack/ms13/currency/prewar/hunned = 60,
-		/obj/item/stack/ms13/currency/ncr_dollar/hunned = 25)
+		/obj/item/stack/ms13/currency/ncr_dollar/sixty = 40)
 
 // Prewar Currency spawner //
 
@@ -61,8 +60,8 @@
 /obj/effect/spawner/random/ms13/guaranteed/currency/mammoth/prewar/lowrandom
 	name = "low tier random Mammoth currency spawner"
 	loot = list(
-		/obj/effect/spawner/random/ms13/guaranteed/currency/mammoth/prewar/tier1 = 50,
-		/obj/effect/spawner/random/ms13/guaranteed/currency/mammoth/prewar/tier2 = 35,
+		/obj/effect/spawner/random/ms13/guaranteed/currency/mammoth/prewar/tier1 = 55,
+		/obj/effect/spawner/random/ms13/guaranteed/currency/mammoth/prewar/tier2 = 30,
 		/obj/effect/spawner/random/ms13/guaranteed/currency/mammoth/prewar/tier3 = 15)
 
 /obj/effect/spawner/random/ms13/guaranteed/currency/mammoth/prewar/highrandom
@@ -112,23 +111,23 @@
 	name = "DO NOT USE ME - NCR currency spawner"
 
 /obj/effect/spawner/random/ms13/guaranteed/currency/mammoth/ncr/low
-	name = "low budget NCR currency deficit spawner (MFW no gold reserves... CWINGE!)"
+	name = "low budget NCR currency deficit spawner"
 	loot = list(
-		/obj/item/stack/ms13/currency/ncr_dollar,
-		/obj/item/stack/ms13/currency/ncr_dollar/five,
-		/obj/item/stack/ms13/currency/ncr_dollar/ten,
-		/obj/item/stack/ms13/currency/ncr_dollar/twenty,
-		/obj/item/stack/ms13/currency/ncr_coin/five,
-		/obj/item/stack/ms13/currency/ncr_coin/ten)
+		/obj/item/stack/ms13/currency/ncr_dollar = 5,
+		/obj/item/stack/ms13/currency/ncr_dollar/five = 35,
+		/obj/item/stack/ms13/currency/ncr_dollar/ten = 20,
+		/obj/item/stack/ms13/currency/ncr_coin = 5,
+		/obj/item/stack/ms13/currency/ncr_coin/two = 25,
+		/obj/item/stack/ms13/currency/ncr_coin/five = 10)
 
 /obj/effect/spawner/random/ms13/guaranteed/currency/mammoth/ncr/high
 	name = "high dolla balla status NCR currency spawner"
 	loot = list(
-		/obj/item/stack/ms13/currency/ncr_dollar/thirty,
-		/obj/item/stack/ms13/currency/ncr_dollar/fourty,
-		/obj/item/stack/ms13/currency/ncr_dollar/fifty,
-		/obj/item/stack/ms13/currency/ncr_coin/ten,
-		/obj/item/stack/ms13/currency/ncr_coin/twenty)
+		/obj/item/stack/ms13/currency/ncr_dollar/thirty = 25,
+		/obj/item/stack/ms13/currency/ncr_dollar/fourty = 30,
+		/obj/item/stack/ms13/currency/ncr_dollar/fifty = 15,
+		/obj/item/stack/ms13/currency/ncr_coin/ten = 20,
+		/obj/item/stack/ms13/currency/ncr_coin/fifteen = 10)
 
 // Drought currency!!!!!
 
@@ -137,15 +136,15 @@
 /obj/effect/spawner/random/ms13/guaranteed/currency/drought/lowrandom
 	name = "low tier random Drought currency spawner"
 	loot = list(
-		/obj/effect/spawner/random/ms13/guaranteed/currency/drought/tier1 = 50,
-		/obj/effect/spawner/random/ms13/guaranteed/currency/drought/tier2 = 35,
+		/obj/effect/spawner/random/ms13/guaranteed/currency/drought/tier1 = 55,
+		/obj/effect/spawner/random/ms13/guaranteed/currency/drought/tier2 = 30,
 		/obj/effect/spawner/random/ms13/guaranteed/currency/drought/tier3 = 15)
 
 /obj/effect/spawner/random/ms13/guaranteed/currency/drought/highrandom
 	name = "high tier random Drought currency spawner"
 	loot = list(
-		/obj/effect/spawner/random/ms13/guaranteed/currency/drought/tier2 = 50,
-		/obj/effect/spawner/random/ms13/guaranteed/currency/drought/tier3 = 35,
+		/obj/effect/spawner/random/ms13/guaranteed/currency/drought/tier2 = 55,
+		/obj/effect/spawner/random/ms13/guaranteed/currency/drought/tier3 = 30,
 		/obj/effect/spawner/random/ms13/guaranteed/currency/drought/tier4 = 15)
 
 /obj/effect/spawner/random/ms13/guaranteed/currency/drought/tier1
@@ -238,16 +237,16 @@
 	name = "low tier random Drought currency spawner"
 	spawn_loot_chance = 100
 	loot = list(
-		/obj/effect/spawner/random/ms13/guaranteed/currency/drought/prewar/tier1 = 50,
-		/obj/effect/spawner/random/ms13/guaranteed/currency/drought/prewar/tier2 = 35,
+		/obj/effect/spawner/random/ms13/guaranteed/currency/drought/prewar/tier1 = 55,
+		/obj/effect/spawner/random/ms13/guaranteed/currency/drought/prewar/tier2 = 30,
 		/obj/effect/spawner/random/ms13/guaranteed/currency/drought/prewar/tier3 = 15)
 
 /obj/effect/spawner/random/ms13/guaranteed/currency/drought/prewar/highrandom
 	name = "high tier random Drought currency spawner"
 	spawn_loot_chance = 100
 	loot = list(
-		/obj/effect/spawner/random/ms13/guaranteed/currency/drought/prewar/tier2 = 50,
-		/obj/effect/spawner/random/ms13/guaranteed/currency/drought/prewar/tier3 = 35,
+		/obj/effect/spawner/random/ms13/guaranteed/currency/drought/prewar/tier2 = 55,
+		/obj/effect/spawner/random/ms13/guaranteed/currency/drought/prewar/tier3 = 30,
 		/obj/effect/spawner/random/ms13/guaranteed/currency/drought/prewar/tier4 = 15)
 
 /obj/effect/spawner/random/ms13/guaranteed/currency/drought/prewar/tier1

--- a/mojave/effects/spawners/lootdrop/guarenteed/gunloot.dm
+++ b/mojave/effects/spawners/lootdrop/guarenteed/gunloot.dm
@@ -92,72 +92,67 @@
 				""
 				)
 	var/loot5 = list(
-				/obj/item/gun/ballistic/shotgun/automatic/ms13/sks,
-				/obj/item/ammo_box/ms13/stripper/r762,
-				/obj/item/ammo_box/ms13/stripper/r762
-				)
-	var/loot6 = list(
 				/obj/item/gun/ballistic/shotgun/ms13/lever/cowboy,
 				/obj/item/ammo_box/ms13/a357box,
 				""
 				)
-	var/loot7 = list(
+	var/loot6 = list(
 				/obj/item/gun/ballistic/revolver/ms13/rev357,
 				/obj/item/ammo_box/ms13/a357box,
 				""
 				)
-	var/loot8 = list(
+	var/loot7 = list(
 				/obj/item/gun/ballistic/revolver/ms13/rev357/police,
 				/obj/item/ammo_box/ms13/a357box,
 				""
 				)
-	var/loot9 = list(
+	var/loot8 = list(
 				/obj/item/gun/energy/ms13/laser/pistol,
 				/obj/item/stock_parts/cell/ms13/ec,
 				""
 				)
-	var/loot10 = list(
+	var/loot9 = list(
 				/obj/item/gun/energy/ms13/laser/pistol/wattz_heavy,
 				/obj/item/stock_parts/cell/ms13/mfc,
 				""
 				)
-	var/loot11 = list(
-				/obj/item/gun/ballistic/shotgun/automatic/ms13/sks/scoped,
-				/obj/item/ammo_box/ms13/stripper/r762,
-				/obj/item/ammo_box/ms13/stripper/r762
+	var/loot10 = list(
+				/obj/item/gun/ballistic/revolver/ms13/rev44,
+				/obj/item/ammo_box/ms13/m44box,
+				""
 				)
-	var/loot12 = list(
+	var/loot11 = list(
 				/obj/item/gun/ballistic/shotgun/ms13/lever,
 				/obj/item/ammo_box/ms13/shotgun/buckshot,
 				""
 				)
-	var/loot13 = list(
+	var/loot12 = list(
 				/obj/item/gun/ballistic/revolver/ms13/caravan/sawed,
 				/obj/item/ammo_box/ms13/shotgun/buckshot,
 				""
 				)
-	var/loot14 = list(
+	var/loot13 = list(
 				/obj/item/gun/ballistic/automatic/pistol/ms13/m10mm,
 				/obj/item/ammo_box/magazine/ms13/m10mm,
 				/obj/item/ammo_box/magazine/ms13/m10mm
 				)
-	var/loot15 = list(
+	var/loot14 = list(
 				/obj/item/gun/ballistic/automatic/ms13/full/smg9mm,
 				/obj/item/ammo_box/magazine/ms13/smgm9mm,
 				""
 				)
 
 /obj/effect/spawner/random/ms13/guaranteed/gun/tier2/Initialize(mapload)
-	loot = pick(loot1, loot2, loot3, loot4, loot5, loot6, loot7, loot8, loot9, loot10, loot11, loot12, loot13, loot14, loot15)
+	loot = pick(loot1, loot2, loot3, loot4, loot5, loot6, loot7, loot8, loot9, loot10, loot11, loot12, loot13, loot14)
 	. = ..()
 
 /obj/effect/spawner/random/ms13/guaranteed/gun/tier3
 	name = "tier 3 gun spawner"
 	spawn_loot_count = 3
 	var/loot1 = list(
-				/obj/item/gun/ballistic/revolver/ms13/rev44,
-				/obj/item/ammo_box/ms13/m44box,
-				""
+				/obj/item/gun/ballistic/shotgun/automatic/ms13/sks,
+				/obj/item/ammo_box/ms13/stripper/r762,
+				/obj/item/ammo_box/ms13/stripper/r762
 				)
 	var/loot2 = list(
 				/obj/item/gun/ballistic/revolver/ms13/mts,
@@ -239,9 +234,14 @@
 				/obj/item/ammo_box/ms13/shotgun/buckshot,
 				""
 				)
+	var/loot18 = list(
+				/obj/item/gun/ballistic/shotgun/automatic/ms13/sks/scoped,
+				/obj/item/ammo_box/ms13/stripper/r762,
+				/obj/item/ammo_box/ms13/stripper/r762
+				)
 
 /obj/effect/spawner/random/ms13/guaranteed/gun/tier3/Initialize(mapload)
-	loot = pick(loot1, loot2, loot3, loot4, loot5, loot6, loot7, loot8, loot9, loot10, loot11, loot12, loot13, loot14, loot15, loot16, loot17)
+	loot = pick(loot1, loot2, loot3, loot4, loot5, loot6, loot7, loot8, loot9, loot10, loot11, loot12, loot13, loot14, loot15, loot16, loot17, loot18)
 	. = ..()
 
 /obj/effect/spawner/random/ms13/guaranteed/gun/tier4

--- a/mojave/effects/spawners/lootdrop/gunloot.dm
+++ b/mojave/effects/spawners/lootdrop/gunloot.dm
@@ -94,63 +94,58 @@
 				""
 				)
 	var/loot5 = list(
-				/obj/item/gun/ballistic/shotgun/automatic/ms13/sks,
-				/obj/item/ammo_box/ms13/stripper/r762,
-				/obj/item/ammo_box/ms13/stripper/r762
-				)
-	var/loot6 = list(
 				/obj/item/gun/ballistic/shotgun/ms13/lever/cowboy,
 				/obj/item/ammo_box/ms13/a357box,
 				""
 				)
-	var/loot7 = list(
+	var/loot6 = list(
 				/obj/item/gun/ballistic/revolver/ms13/rev357,
 				/obj/item/ammo_box/ms13/a357box,
 				""
 				)
-	var/loot8 = list(
+	var/loot7 = list(
 				/obj/item/gun/ballistic/revolver/ms13/rev357/police,
 				/obj/item/ammo_box/ms13/a357box,
 				""
 				)
-	var/loot9 = list(
+	var/loot8 = list(
 				/obj/item/gun/energy/ms13/laser/pistol,
 				/obj/item/stock_parts/cell/ms13/ec,
 				""
 				)
-	var/loot10 = list(
+	var/loot9 = list(
 				/obj/item/gun/energy/ms13/laser/pistol/wattz_heavy,
 				/obj/item/stock_parts/cell/ms13/mfc,
 				""
 				)
-	var/loot11 = list(
-				/obj/item/gun/ballistic/shotgun/automatic/ms13/sks/scoped,
-				/obj/item/ammo_box/ms13/stripper/r762,
-				/obj/item/ammo_box/ms13/stripper/r762
+	var/loot10 = list(
+				/obj/item/gun/ballistic/revolver/ms13/rev44,
+				/obj/item/ammo_box/ms13/m44box,
+				""
 				)
-	var/loot12 = list(
+	var/loot11 = list(
 				/obj/item/gun/ballistic/shotgun/ms13/lever,
 				/obj/item/ammo_box/ms13/shotgun/buckshot,
 				""
 				)
-	var/loot13 = list(
+	var/loot12 = list(
 				/obj/item/gun/ballistic/revolver/ms13/caravan/sawed,
 				/obj/item/ammo_box/ms13/shotgun/buckshot,
 				""
 				)
-	var/loot14 = list(
+	var/loot13 = list(
 				/obj/item/gun/ballistic/automatic/pistol/ms13/m10mm,
 				/obj/item/ammo_box/magazine/ms13/m10mm,
 				/obj/item/ammo_box/magazine/ms13/m10mm
 				)
-	var/loot15 = list(
+	var/loot14 = list(
 				/obj/item/gun/ballistic/automatic/ms13/full/smg9mm,
 				/obj/item/ammo_box/magazine/ms13/smgm9mm,
 				""
 				)
 
 /obj/effect/spawner/random/ms13/gun/tier2/Initialize(mapload)
-	loot = pick(loot1, loot2, loot3, loot4, loot5, loot6, loot7, loot8, loot9, loot10, loot11, loot12, loot13, loot14, loot15)
+	loot = pick(loot1, loot2, loot3, loot4, loot5, loot6, loot7, loot8, loot9, loot10, loot11, loot12, loot13, loot14)
 	. = ..()
 
 /obj/effect/spawner/random/ms13/gun/tier3
@@ -158,9 +153,9 @@
 	spawn_loot_count = 3
 	spawn_loot_chance = 60
 	var/loot1 = list(
-				/obj/item/gun/ballistic/revolver/ms13/rev44,
-				/obj/item/ammo_box/ms13/m44box,
-				""
+				/obj/item/gun/ballistic/shotgun/automatic/ms13/sks,
+				/obj/item/ammo_box/ms13/stripper/r762,
+				/obj/item/ammo_box/ms13/stripper/r762
 				)
 	var/loot2 = list(
 				/obj/item/gun/ballistic/revolver/ms13/mts,
@@ -242,9 +237,14 @@
 				/obj/item/ammo_box/ms13/shotgun/buckshot,
 				""
 				)
+	var/loot18 = list(
+				/obj/item/gun/ballistic/shotgun/automatic/ms13/sks/scoped,
+				/obj/item/ammo_box/ms13/stripper/r762,
+				/obj/item/ammo_box/ms13/stripper/r762
+				)
 
 /obj/effect/spawner/random/ms13/gun/tier3/Initialize(mapload)
-	loot = pick(loot1, loot2, loot3, loot4, loot5, loot6, loot7, loot8, loot9, loot10, loot11, loot12, loot13, loot14, loot15, loot16, loot17)
+	loot = pick(loot1, loot2, loot3, loot4, loot5, loot6, loot7, loot8, loot9, loot10, loot11, loot12, loot13, loot14, loot15, loot16, loot17, loot18)
 	. = ..()
 
 /obj/effect/spawner/random/ms13/gun/tier4

--- a/mojave/effects/spawners/lootdrop/miscloot.dm
+++ b/mojave/effects/spawners/lootdrop/miscloot.dm
@@ -227,7 +227,7 @@
 
 /obj/effect/spawner/random/ms13/smokeable/lowrandom
 	name = "low tier random smokeables spawner"
-	spawn_loot_chance = 40
+	spawn_loot_chance = 35
 	loot = list(
 			/obj/item/storage/fancy/ms13/cigarettes/marlboro/random = 30,
 			/obj/item/storage/fancy/ms13/cigarettes/winston/random = 30,

--- a/mojave/flora/agriculture.dm
+++ b/mojave/flora/agriculture.dm
@@ -765,8 +765,8 @@
 	desc = "A bag of fertilizer. Treasured among the farmers of the post-apocalypse."
 	icon = 'mojave/icons/hydroponics/equipment.dmi'
 	icon_state = "daesack3"
-	amount = 3
-	max_amount = 3
+	amount = 4
+	max_amount = 4
 	singular_name = "use" //so it says X uses left in the fertilizer bag instead of X fertilizer bags left
 	gender = NEUTER //So examine text says "This is a fertilizer" instead of "These are some fertilizer bags"
 	grid_width = 96

--- a/mojave/items/guns/weapons/ballistic/automatic.dm
+++ b/mojave/items/guns/weapons/ballistic/automatic.dm
@@ -88,7 +88,7 @@
 	recoil = 0.6
 	slowdown = 0.75
 	has_scope = TRUE
-	scope_range = 3
+	scope_range = 2.5
 	grid_width = 192
 	grid_height = 64
 

--- a/mojave/items/guns/weapons/ballistic/revolver.dm
+++ b/mojave/items/guns/weapons/ballistic/revolver.dm
@@ -126,9 +126,9 @@
 	fire_sound = 'mojave/sound/ms13weapons/44mag.ogg'
 	far_fire_sound = 'mojave/sound/ms13weapons/distant_shots/44_revolver.ogg'
 	w_class = WEIGHT_CLASS_NORMAL
-	fire_delay = 0.6 SECONDS
+	fire_delay = 0.65 SECONDS
 	spread = 6
-	recoil = 1.25
+	recoil = 1.5
 	slowdown = 0.5
 	grid_width = 64
 	grid_height = 64

--- a/mojave/items/guns/weapons/ballistic/rifle.dm
+++ b/mojave/items/guns/weapons/ballistic/rifle.dm
@@ -52,8 +52,8 @@
 	eject_empty_sound = 'mojave/sound/ms13weapons/gunsounds/rifle/riflemag_unload.ogg'
 	fire_sound = 'mojave/sound/ms13weapons/gunsounds/varmint/varmint_rifle.ogg'
 	far_fire_sound = 'mojave/sound/ms13weapons/distant_shots/varmint_rifle.ogg'
-	fire_delay = 0.65 SECONDS
-	rack_delay = 0.65 SECONDS
+	fire_delay = 0.6 SECONDS
+	rack_delay = 0.6 SECONDS
 	spread = 2
 	recoil = 0.75
 	slowdown = 0.75

--- a/mojave/items/guns/weapons/ballistic/shotgun.dm
+++ b/mojave/items/guns/weapons/ballistic/shotgun.dm
@@ -158,7 +158,7 @@
 	fire_sound = 'mojave/sound/ms13weapons/gunsounds/sks/sks1.ogg'
 	far_fire_sound = 'mojave/sound/ms13weapons/distant_shots/sks.ogg'
 	bolt_wording = "bolt"
-	fire_delay = 0.6 SECONDS
+	fire_delay = 0.55 SECONDS
 	spread = 5
 	recoil = 1.25
 	slowdown = 0.75

--- a/mojave/items/misc/currency.dm
+++ b/mojave/items/misc/currency.dm
@@ -65,11 +65,14 @@
 /obj/item/stack/ms13/currency/prewar/hunnedfourty
 	amount = 140
 
+/obj/item/stack/ms13/currency/prewar/hunnedeighty
+	amount = 180
+
 /obj/item/stack/ms13/currency/prewar/underboss
-	amount = 240
+	amount = 300
 
 /obj/item/stack/ms13/currency/prewar/mayor
-	amount = 325
+	amount = 400
 
 /obj/item/stack/ms13/currency/ncr_dollar
 	name = "\improper NCR dollars"


### PR DESCRIPTION
## About The Pull Request

Adjusts loadouts for a few roles, namely Mon City Grunt, Captain, and NCR MP. Reduces the overall spawn chance as well as the average tier drop for currency spawners and also gives some more money to roles at round start, primarily command roles. Hopefully makes it so it's less common that random Wastelanders are exclusively the richest people in the round but probably won't be perfect. 

Increases dissipation rate for indoor areas by roughly 80%, from 0.1 to 0.18. It was pretty silly how long smoke would stick around. Lastly rebalances the .44 revolver and SKS slightly. SKS fires slightly faster but is bumped up to Tier 3 and taken away from Grunt starting loadout (includes scoped SKS), the .44 fires slightly slower with a bit more recoil and is bumped down to Tier 2 and given as an option for Grunts. (Coinflip between .44 rev and wattz heavy laser pistol) Also slightly buffs the Varmint rifle with a slight fire rate increase. 

## Why It's Good For The Game

Tweaking is so freaking awesome. 