### PR TITLE
The Great PA Nerfening

### DIFF
--- a/_maps/map_files/Mammoth_Mini/Mammoth_mini.dmm
+++ b/_maps/map_files/Mammoth_Mini/Mammoth_mini.dmm
@@ -7253,8 +7253,8 @@
 "gpm" = (
 /obj/structure/table/ms13/wood,
 /obj/machinery/button/ms13{
-	id = "snowcrest-genstore-back";
-	dir = 8
+	dir = 8;
+	id = "snowcrest-genstore-back"
 	},
 /turf/open/floor/wood/ms13/common,
 /area/ms13/snowcrest/building)
@@ -7836,6 +7836,7 @@
 /area/ms13/town)
 "gKx" = (
 /obj/structure/table/ms13/metal/heavy,
+/obj/effect/spawner/random/ms13/power_armor/parts,
 /turf/open/floor/ms13/metal,
 /area/ms13/underground/bos)
 "gKz" = (
@@ -7988,9 +7989,9 @@
 /turf/open/floor/ms13/metal/grate/border,
 /area/ms13/town)
 "gOh" = (
-/obj/item/clothing/suit/space/hardsuit/ms13/power_armor/t45/random,
 /obj/structure/ms13/pa_jack,
 /obj/structure/ms13/pipes/horizontal/single/cont,
+/obj/item/clothing/suit/space/hardsuit/ms13/power_armor,
 /turf/open/floor/ms13/metal,
 /area/ms13/underground/bos)
 "gOi" = (
@@ -12613,6 +12614,8 @@
 /obj/effect/spawner/random/ms13/tools/tool,
 /obj/effect/spawner/random/ms13/tools/tool,
 /obj/effect/spawner/random/ms13/tools/lights,
+/obj/effect/spawner/random/ms13/power_armor/parts,
+/obj/effect/spawner/random/ms13/power_armor/t45_parts,
 /turf/open/floor/ms13/metal,
 /area/ms13/underground/bos)
 "jAE" = (
@@ -23150,12 +23153,12 @@
 	dir = 1;
 	remote_capability = 1;
 	signal_id_1 = "snowcrest-genstore";
-	signal_title_1 = "Window Shutters";
-	termtag = "Snowcrest General Store";
 	signal_id_2 = "snowcrest-genstore-north";
+	signal_id_3 = "snowcrest-genstore-back";
+	signal_title_1 = "Window Shutters";
 	signal_title_2 = "Alley Shutters";
 	signal_title_3 = "Front Alley Shutters";
-	signal_id_3 = "snowcrest-genstore-back"
+	termtag = "Snowcrest General Store"
 	},
 /turf/open/floor/wood/ms13/common,
 /area/ms13/snowcrest/building)

--- a/_maps/map_files/Mammoth_Mini/Mammoth_mini_above.dmm
+++ b/_maps/map_files/Mammoth_Mini/Mammoth_mini_above.dmm
@@ -1194,9 +1194,9 @@
 /turf/open/floor/wood/ms13/carpet/green,
 /area/ms13/town)
 "aie" = (
-/obj/item/clothing/suit/space/hardsuit/ms13/power_armor/t51,
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/mountain,
 /obj/structure/ms13/pa_jack,
+/obj/item/clothing/suit/space/hardsuit/ms13/power_armor/t51/random,
 /turf/open/floor/ms13/metal,
 /area/ms13/underground/bos)
 "ail" = (

--- a/_maps/map_files/Mammoth_Mini/Mammoth_mini_below.dmm
+++ b/_maps/map_files/Mammoth_Mini/Mammoth_mini_below.dmm
@@ -2952,6 +2952,8 @@
 "axi" = (
 /obj/structure/table/ms13/metal/small,
 /obj/structure/ms13/pipes/horizontal/single,
+/obj/effect/spawner/random/ms13/power_armor/parts,
+/obj/effect/spawner/random/ms13/power_armor/parts,
 /turf/open/floor/ms13/concrete/small,
 /area/ms13/underground/bos)
 "axj" = (
@@ -3063,6 +3065,7 @@
 "axU" = (
 /obj/structure/closet/crate/ms13/woodcrate,
 /obj/effect/spawner/random/ms13/tools/lights,
+/obj/effect/spawner/random/ms13/power_armor/parts,
 /turf/open/floor/ms13/concrete/small,
 /area/ms13/underground/bos)
 "axW" = (
@@ -11279,6 +11282,7 @@
 "oBO" = (
 /obj/structure/closet/crate/ms13/woodcrate,
 /obj/effect/spawner/random/ms13/guaranteed/crafting/electrical,
+/obj/effect/spawner/random/ms13/power_armor/parts,
 /turf/open/floor/ms13/concrete/small,
 /area/ms13/underground/bos)
 "oCy" = (

--- a/mojave/code/modules/clothing/spacesuits/power_armor.dm
+++ b/mojave/code/modules/clothing/spacesuits/power_armor.dm
@@ -135,7 +135,7 @@
 	anchored = TRUE
 	strip_delay = 15 SECONDS
 	integrity_failure = 0.5
-	max_integrity = 500
+	max_integrity = 450
 	resistance_flags = FIRE_PROOF | ACID_PROOF
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0,  FIRE = 0, ACID = 0, WOUND = 0)
 	subarmor = list(SUBARMOR_FLAGS = NONE, \
@@ -631,7 +631,7 @@
 	light_range = 4.20
 	light_power = 0.9
 	light_color = "#d1c58d"
-	max_integrity = 380
+	max_integrity = 340
 	radiotype = /obj/item/radio/headset/ms13/powerarmor/t51
 	subarmor = list(SUBARMOR_FLAGS = NONE, \
                 EDGE_PROTECTION = CLASS4_EDGE, \
@@ -666,7 +666,7 @@
 	light_range = 4
 	light_power = 0.8
 	light_color = "#dabc7c"
-	max_integrity = 280
+	max_integrity = 240
 	radiotype = /obj/item/radio/headset/ms13/powerarmor/t45
 	subarmor = list(SUBARMOR_FLAGS = NONE, \
                 EDGE_PROTECTION = CLASS4_EDGE, \

--- a/mojave/code/modules/clothing/spacesuits/power_armor_parts.dm
+++ b/mojave/code/modules/clothing/spacesuits/power_armor_parts.dm
@@ -189,7 +189,7 @@
 	name = "T-51 Power Armor left leg"
 	icon_state = "t51_leftleg"
 	icon_state_pa = "t51_leftleg"
-	max_integrity = 280
+	max_integrity = 250
 	subarmor = list(SUBARMOR_FLAGS = NONE, \
 					EDGE_PROTECTION = CLASS4_EDGE, \
 					CRUSHING = CLASS5_CRUSH, \
@@ -205,7 +205,7 @@
 	name = "T-51 Power Armor right leg"
 	icon_state = "t51_rightleg"
 	icon_state_pa = "t51_rightleg"
-	max_integrity = 280
+	max_integrity = 250
 	subarmor = list(SUBARMOR_FLAGS = NONE, \
 					EDGE_PROTECTION = CLASS4_EDGE, \
 					CRUSHING = CLASS5_CRUSH, \
@@ -221,7 +221,7 @@
 	name = "T-51 Power Armor chest"
 	icon_state = "t51_chest"
 	icon_state_pa = "t51_chest"
-	max_integrity = 550
+	max_integrity = 480
 	subarmor = list(SUBARMOR_FLAGS = NONE, \
 					EDGE_PROTECTION = CLASS4_EDGE, \
 					CRUSHING = CLASS5_CRUSH, \
@@ -237,7 +237,7 @@
 	name = "T-51 Power Armor left arm"
 	icon_state = "t51_lefthand"
 	icon_state_pa = "t51_lefthand"
-	max_integrity = 280
+	max_integrity = 250
 	subarmor = list(SUBARMOR_FLAGS = NONE, \
 					EDGE_PROTECTION = CLASS4_EDGE, \
 					CRUSHING = CLASS5_CRUSH, \
@@ -253,7 +253,7 @@
 	name = "T-51 Power Armor right arm"
 	icon_state = "t51_righthand"
 	icon_state_pa = "t51_righthand"
-	max_integrity = 280
+	max_integrity = 250
 	subarmor = list(SUBARMOR_FLAGS = NONE, \
 					EDGE_PROTECTION = CLASS4_EDGE, \
 					CRUSHING = CLASS5_CRUSH, \
@@ -276,7 +276,7 @@
 	name = "T-45 Power Armor left leg"
 	icon_state = "t45_leftleg"
 	icon_state_pa = "t45_leftleg"
-	max_integrity = 200
+	max_integrity = 175
 	subarmor = list(SUBARMOR_FLAGS = NONE, \
                 EDGE_PROTECTION = CLASS4_EDGE, \
                 CRUSHING = CLASS4_CRUSH, \
@@ -292,7 +292,7 @@
 	name = "T-45 Power Armor right leg"
 	icon_state = "t45_rightleg"
 	icon_state_pa = "t45_rightleg"
-	max_integrity = 200
+	max_integrity = 175
 	subarmor = list(SUBARMOR_FLAGS = NONE, \
                 EDGE_PROTECTION = CLASS4_EDGE, \
                 CRUSHING = CLASS4_CRUSH, \
@@ -308,7 +308,7 @@
 	name = "T-45 Power Armor chest"
 	icon_state = "t45_chest"
 	icon_state_pa = "t45_chest"
-	max_integrity = 400
+	max_integrity = 360
 	subarmor = list(SUBARMOR_FLAGS = NONE, \
                 EDGE_PROTECTION = CLASS4_EDGE, \
                 CRUSHING = CLASS4_CRUSH, \
@@ -324,7 +324,7 @@
 	name = "T-45 Power Armor left arm"
 	icon_state = "t45_lefthand"
 	icon_state_pa = "t45_lefthand"
-	max_integrity = 200
+	max_integrity = 175
 	subarmor = list(SUBARMOR_FLAGS = NONE, \
                 EDGE_PROTECTION = CLASS4_EDGE, \
                 CRUSHING = CLASS4_CRUSH, \
@@ -340,7 +340,7 @@
 	name = "T-45 Power Armor right arm"
 	icon_state = "t45_righthand"
 	icon_state_pa = "t45_righthand"
-	max_integrity = 200
+	max_integrity = 175
 	subarmor = list(SUBARMOR_FLAGS = NONE, \
                 EDGE_PROTECTION = CLASS4_EDGE, \
                 CRUSHING = CLASS4_CRUSH, \


### PR DESCRIPTION
## About The Pull Request

Last test definitely showed me that PA and particularly how BoS gets it is definitely overtuned. Thus PA across the board has gotten a ~10% health nerf, this includes the frame. And BoS has a pretty hefty nerf of getting their random T-45 set replaced with an empty frame and their guaranteed full T-51 set replaced with a random T-51 set. Overall this should make it so they have to work more to become a powerhouse and also will occupy some of their time early in the round getting their PA set up to give some other people more time to run dungeons and such before the big boys come out. 

## Why It's Good For The Game

PA is crazy rn my brotha on god