### PR TITLE
Bug and oversight fixes before the Sat test + QOL

### DIFF
--- a/_maps/map_files/Drought/Drought.dmm
+++ b/_maps/map_files/Drought/Drought.dmm
@@ -629,6 +629,11 @@
 "aKh" = (
 /turf/open/floor/plating/ms13/ground/desertalt,
 /area/ms13/water_baron)
+"aKq" = (
+/obj/structure/table/ms13/no_smooth/counter/metal,
+/obj/structure/ms13/chem_set,
+/turf/open/floor/ms13/tile/full/navy,
+/area/ms13/water_baron/interior)
 "aKs" = (
 /obj/structure/bed/ms13/bedframe/metal,
 /obj/structure/bed/ms13/mattress/dirty,
@@ -5385,6 +5390,10 @@
 /obj/effect/spawner/random/ms13/drugs/prewar,
 /turf/open/floor/ms13/tile/full/white,
 /area/ms13/town)
+"gah" = (
+/obj/structure/ms13/trash/glass/plate,
+/turf/open/floor/plating/ms13/ground/desert,
+/area/ms13/desert)
 "gav" = (
 /obj/structure/ms13/storage/store/metal{
 	dir = 8
@@ -5797,6 +5806,11 @@
 /obj/structure/ms13/wall_decor/flag/legion,
 /turf/open/floor/plating/ms13/ground/desert,
 /area/ms13/legioncamp)
+"gvi" = (
+/obj/structure/ms13/pa_jack,
+/obj/effect/spawner/random/ms13/power_armor/lowrandom,
+/turf/open/floor/ms13/concrete,
+/area/ms13/town)
 "gvI" = (
 /obj/structure/closet/crate/ms13/footlocker{
 	dir = 4
@@ -7344,6 +7358,10 @@
 	},
 /turf/open/floor/plating/ms13/ground/desertalt,
 /area/ms13/desert)
+"ilc" = (
+/obj/structure/table/ms13/no_smooth/counter/metal,
+/turf/open/floor/ms13/tile/full/navy,
+/area/ms13/water_baron/interior)
 "ilf" = (
 /obj/structure/table/ms13/low_wall/concrete,
 /obj/structure/window/fulltile/ms13/glass,
@@ -8086,6 +8104,7 @@
 /area/ms13/desert)
 "jeD" = (
 /obj/structure/table/ms13/no_smooth/counter/metal,
+/obj/structure/ms13/chem_set,
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "jeR" = (
@@ -16595,6 +16614,10 @@
 /obj/effect/spawner/random/ms13/crafting/electrical,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
+"spO" = (
+/obj/structure/ms13/trash/food/glass,
+/turf/open/floor/plating/ms13/ground/desertalt,
+/area/ms13/desert)
 "sqo" = (
 /obj/effect/decal/cleanable/blood/gibs/limb,
 /turf/open/floor/ms13/concrete,
@@ -17103,13 +17126,6 @@
 /obj/machinery/light/ms13/bulb{
 	dir = 8
 	},
-/turf/open/floor/ms13/concrete,
-/area/ms13/town)
-"sSM" = (
-/obj/structure/table/ms13/no_smooth/counter/metal{
-	dir = 1
-	},
-/obj/effect/spawner/random/ms13/power_armor/parts,
 /turf/open/floor/ms13/concrete,
 /area/ms13/town)
 "sSW" = (
@@ -19086,6 +19102,10 @@
 "uYc" = (
 /obj/machinery/iv_drip/ms13,
 /turf/open/floor/wood/ms13/wide,
+/area/ms13/town)
+"uYK" = (
+/mob/living/basic/ms13/robot/handy/saw,
+/turf/open/floor/ms13/concrete,
 /area/ms13/town)
 "uYW" = (
 /obj/structure/table/ms13/no_smooth/large/wood/stand,
@@ -35989,7 +36009,7 @@ qzs
 rpg
 low
 oAi
-nDJ
+ilc
 nDJ
 nDJ
 swK
@@ -36191,7 +36211,7 @@ eMV
 dlW
 xQn
 oAi
-nDJ
+aKq
 nDJ
 nDJ
 vYq
@@ -45394,7 +45414,7 @@ qOn
 qOn
 ylS
 ylS
-ylS
+uYK
 chx
 pyt
 oSs
@@ -45796,7 +45816,7 @@ rtE
 fMc
 oyI
 rtE
-xyg
+gvi
 ylS
 oUr
 cXR
@@ -46190,7 +46210,7 @@ hgp
 oSs
 hgp
 hgp
-jJD
+ehD
 jJD
 eeM
 hQa
@@ -46203,7 +46223,7 @@ qOn
 ylS
 ylS
 ylS
-sSM
+mgh
 pyt
 oSs
 oSs
@@ -47011,7 +47031,7 @@ oSs
 hgp
 hgp
 hgp
-oSs
+gah
 oSs
 oSs
 oSs
@@ -47609,7 +47629,7 @@ hgp
 hgp
 hgp
 hgp
-hgp
+lLH
 hgp
 oSs
 oSs
@@ -49010,7 +49030,7 @@ oSs
 oSs
 oSs
 hgp
-hgp
+vAv
 oSs
 hgp
 hgp
@@ -50429,7 +50449,7 @@ hgp
 aJA
 pOP
 pOP
-hgp
+spO
 hgp
 hgp
 hgp
@@ -50636,7 +50656,7 @@ hgp
 hgp
 hgp
 hgp
-hgp
+lLH
 hgp
 oSs
 oSs

--- a/_maps/map_files/Drought/Drought_above.dmm
+++ b/_maps/map_files/Drought/Drought_above.dmm
@@ -4016,8 +4016,18 @@
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "nK" = (
-/obj/machinery/ms13/agriculture,
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
+/obj/structure/closet/crate/ms13/footlocker,
+/obj/item/card/id/ms13/drought_visa,
+/obj/item/card/id/ms13/drought_visa,
+/obj/item/card/id/ms13/drought_visa,
+/obj/item/card/id/ms13/drought_visa,
+/obj/item/card/id/ms13/drought_visa,
+/obj/item/card/id/ms13/drought_visa,
+/obj/item/card/id/ms13/drought_medical,
+/obj/item/card/id/ms13/drought_medical,
+/obj/item/card/id/ms13/drought_visa,
+/obj/item/card/id/ms13/drought_visa,
 /turf/open/floor/ms13/concrete,
 /area/ms13/water_baron)
 "nL" = (
@@ -5602,6 +5612,8 @@
 	pixel_y = 26
 	},
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
+/obj/structure/table/ms13/metal/constructed,
+/obj/structure/ms13/chem_set,
 /turf/open/floor/wood/ms13/mosaic,
 /area/ms13/town)
 "to" = (
@@ -6009,6 +6021,7 @@
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /obj/effect/spawner/random/ms13/medical/lowrandom,
 /obj/effect/spawner/random/ms13/medical/lowrandom,
+/obj/effect/spawner/random/ms13/guaranteed/medical/lowrandom,
 /turf/open/floor/ms13/tile/long,
 /area/ms13/rangeroutpost/building)
 "uL" = (
@@ -6068,6 +6081,7 @@
 /obj/structure/table/ms13/metal/grate,
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
 /obj/effect/spawner/random/ms13/medical/lowrandom,
+/obj/effect/spawner/random/ms13/guaranteed/medical/lowrandom,
 /turf/open/floor/ms13/tile/long,
 /area/ms13/rangeroutpost/building)
 "uW" = (
@@ -13717,8 +13731,7 @@
 "Vi" = (
 /obj/structure/table/ms13/metal/grate,
 /obj/effect/mapping_helpers/sunlight/pseudo_roof_setter/wood,
-/obj/effect/spawner/random/ms13/guaranteed/medical/lowrandom,
-/obj/effect/spawner/random/ms13/guaranteed/medical/lowrandom,
+/obj/structure/ms13/chem_set,
 /turf/open/floor/ms13/tile/long,
 /area/ms13/rangeroutpost/building)
 "Vj" = (

--- a/_maps/map_files/Drought/Drought_below.dmm
+++ b/_maps/map_files/Drought/Drought_below.dmm
@@ -136,6 +136,7 @@
 /obj/item/pen/ms13{
 	pixel_y = 8
 	},
+/obj/item/ms13/fluff/chems,
 /turf/open/floor/ms13/tile/full/navy,
 /area/ms13/town)
 "bc" = (
@@ -1591,10 +1592,7 @@
 "kJ" = (
 /obj/structure/table/ms13/metal/alt,
 /obj/structure/ms13/storage/vent,
-/obj/item/ms13/fluff/microscope{
-	pixel_y = 9
-	},
-/obj/item/ms13/fluff/chems,
+/obj/structure/ms13/chem_set,
 /turf/open/floor/ms13/tile/full/white,
 /area/ms13/town)
 "kL" = (
@@ -1694,6 +1692,7 @@
 "lK" = (
 /obj/structure/closet/crate/ms13/woodcrate/compact/army,
 /obj/effect/spawner/random/ms13/melee/highrandom,
+/obj/effect/spawner/random/ms13/gun/tier3,
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/town)
 "lL" = (
@@ -4230,6 +4229,7 @@
 /obj/machinery/light/ms13{
 	dir = 1
 	},
+/obj/structure/ms13/chem_set,
 /turf/open/floor/ms13/tile/long/blue,
 /area/ms13/town)
 "CF" = (
@@ -5136,6 +5136,7 @@
 "Jc" = (
 /obj/structure/table/ms13/metal/grate,
 /obj/effect/spawner/random/ms13/tools/tool,
+/obj/effect/spawner/random/ms13/tools/lights,
 /turf/open/floor/ms13/concrete,
 /area/ms13/town)
 "Jf" = (
@@ -7443,7 +7444,10 @@
 /area/ms13/town)
 "Zc" = (
 /obj/structure/table/ms13/metal/grate,
-/obj/effect/spawner/random/ms13/tools/lights,
+/obj/effect/spawner/random/ms13/melee/tier3,
+/obj/machinery/button/ms13{
+	id = "car_junk_storage1"
+	},
 /turf/open/floor/ms13/concrete,
 /area/ms13/town)
 "Ze" = (
@@ -43621,7 +43625,7 @@ uD
 vu
 UP
 zG
-VU
+SN
 uc
 vu
 vu

--- a/mojave/code/modules/jobs/job_types/rangers/doctor.dm
+++ b/mojave/code/modules/jobs/job_types/rangers/doctor.dm
@@ -9,6 +9,8 @@
 
 	display_order = JOB_DISPLAY_ORDER_MS13_RANGERDOCTOR
 
+	mind_traits = list(TRAIT_MEDICAL_TRAINING)
+
 /datum/outfit/job/ms13/ranger/doctor
 	name = "_Desert Ranger Doctor"
 	jobtype = 	 /datum/job/ms13/ranger/rdoctor

--- a/mojave/code/modules/jobs/job_types/town_drought/clinician.dm
+++ b/mojave/code/modules/jobs/job_types/town_drought/clinician.dm
@@ -11,7 +11,7 @@
 
 	display_order = JOB_DISPLAY_ORDER_MS13_CLINICIAN
 
-	mind_traits = list(TRAIT_MEDICAL_TRAINING)
+	mind_traits = list(TRAIT_MEDICAL_TRAINING, TRAIT_DRUGGIE)
 
 /datum/outfit/job/ms13/town_drought/clinician
 	name = "_Barony Clinician"
@@ -25,6 +25,8 @@
 	r_hand =     /obj/item/storage/firstaid/ms13/bag/filled
 	r_pocket =   /obj/item/stack/ms13/currency/cap/hunnedtwentyfive
 	back =       /obj/item/storage/ms13/satchel
+	backpack_contents = list(
+		/obj/item/card/id/ms13/drought_medical=1)
 
 /datum/outfit/job/ms13/town_drought/clinician/pre_equip(mob/living/carbon/human/H)
 	..()

--- a/mojave/code/modules/mob/robots/handies.dm
+++ b/mojave/code/modules/mob/robots/handies.dm
@@ -77,3 +77,4 @@
 	ranged_cooldown = 2 SECONDS
 	casingtype = /obj/item/ammo_casing/energy/ms13/plasma/gutsy
 	projectilesound = 'mojave/sound/ms13weapons/gunsounds/plasrifle/plasma_3.ogg'
+	attack_sound = list('mojave/sound/ms13weapons/meleesounds/ripper_hit1.ogg', 'mojave/sound/ms13weapons/meleesounds/ripper_hit2.ogg')

--- a/mojave/items/cards_ids.dm
+++ b/mojave/items/cards_ids.dm
@@ -306,21 +306,51 @@
 	icon_state = "drought_town"
 	assignment = "Barony Denizen"
 
+/obj/item/card/id/ms13/drought_visa
+	name = "\improper Barony identification papers"
+	desc = "Freshly stamped identification papers for a new citizen of the Barony. The freshness of these papers likely indicate these are for a recent arrival to the Barony."
+	icon_state = "drought_town"
+	assignment = "Barony Migrant"
+
+/obj/item/card/id/ms13/drought_visa/attackby(obj/item/W, mob/user, params)
+	if(istype(W, /obj/item/card/id/ms13/drought_baron))
+		registered_name = stripped_input(user, "Who do you want to grant these papers to?", , "", MAX_NAME_LEN)
+		to_chat(user, "You scribble [registered_name] for the name on the papers.")
+		update_label()
+	return ..()
+
 /obj/item/card/id/ms13/drought_slave
+	name = "\improper Barony identification papers"
 	desc = "Stamped identification papers for a citizen of the Barony. This has special clearance for labor and maintenance duties included."
 	assignment = "Barony Laborer"
 	icon_state = "drought_town"
 
 /obj/item/card/id/ms13/drought_barkeep
+	name = "\improper Barony identification papers"
 	desc = "Stamped identification papers for a citizen of the Barony. This has special clearance for operation of a dining and drinking establishment within the Barony."
 	assignment = "Barony Barkeep"
 	icon_state = "drought_town"
 
 /obj/item/card/id/ms13/drought_doctor
+	name = "\improper Barony identification papers"
 	desc = "Stamped identification papers for a citizen of the Barony. This has special clearance for operation of a clinic and medical duties within the Barony."
 	assignment = "Barony Clinician"
 	icon_state = "drought_town"
 	access = list(ACCESS_BARONY_DOCTOR)
+
+/obj/item/card/id/ms13/drought_medical
+	name = "\improper Barony identification papers"
+	desc = "Freshly stamped identification papers for a citizen of the Barony. This is specifically designated for individuals assisting the operation of the Barony's clinic."
+	assignment = "Barony Medical Support"
+	icon_state = "drought_town"
+	access = list(ACCESS_BARONY_DOCTOR)
+
+/obj/item/card/id/ms13/drought_medical/attackby(obj/item/W, mob/user, params)
+	if(istype(W, /obj/item/card/id/ms13/drought_doctor))
+		registered_name = stripped_input(user, "Who do you want to grant these papers to?", , "", MAX_NAME_LEN)
+		to_chat(user, "You scribble [registered_name] for the name on the papers.")
+		update_label()
+	return ..()
 
 /obj/item/card/id/ms13/drought_enforcer
 	name = "enforcer's golden pin"


### PR DESCRIPTION
## About The Pull Request

Fixes some bugs and oversights:

- Ranger Doctor now has the medical crafting trait
- Barony Clinician now has the druggie trait and chem sets have been placed around Drought. The Barony can be a drug empire if they wish. 
- Button to open the lootington room in the junkyard is so back.
- Barony IDs are properly named
- Gutsy has a proper hit sound now that he has a saw

And then some QoL, mainly in the form of giving the Barony some fresh ID papers for new migrants and the Clinician in the Barony a spare set of medical ID papers for appointing an assistant, or the Baron gets two in his ID chest in the event the Clinician either disappears or never spawns. 

## Why It's Good For The Game

We love squashing bugs and fixing oversights and QoL!! Yeah!!!