### PR TITLE
LEGION POWERCREEPENING: TOOL GANG EDITION

### DIFF
--- a/mojave/code/modules/jobs/job_types/legion/legion_smith.dm
+++ b/mojave/code/modules/jobs/job_types/legion/legion_smith.dm
@@ -27,7 +27,10 @@
 	backpack_contents = list(
 		/obj/item/ammo_box/ms13/shotgun/junkshot=1,\
 		/obj/item/ms13/handsaw=1,\
-		/obj/item/stack/ms13/currency/denarius/five=1)
+		/obj/item/stack/ms13/currency/denarius/five=1,
+		/obj/item/screwdriver/ms13=1,
+		/obj/item/weldingtool/ms13,
+		/obj/item/clothing/head/welding/ms13)
 
 /datum/outfit/job/ms13/legion/legion_smith/pre_equip(mob/living/carbon/human/H)
 	..()

--- a/mojave/code/modules/jobs/job_types/legion/legion_smith.dm
+++ b/mojave/code/modules/jobs/job_types/legion/legion_smith.dm
@@ -28,9 +28,9 @@
 		/obj/item/ammo_box/ms13/shotgun/junkshot=1,\
 		/obj/item/ms13/handsaw=1,\
 		/obj/item/stack/ms13/currency/denarius/five=1,
-		/obj/item/screwdriver/ms13=1,
-		/obj/item/weldingtool/ms13,
-		/obj/item/clothing/head/welding/ms13)
+		/obj/item/ms13/handdrill=1,
+		/obj/item/weldingtool/ms13=1,
+		/obj/item/clothing/glasses/ms13/welding=1)
 
 /datum/outfit/job/ms13/legion/legion_smith/pre_equip(mob/living/carbon/human/H)
 	..()


### PR DESCRIPTION
## About The Pull Request

Completely destroys all pretense of balance in MS13 by giving the legion blacksmith a welding tool, welding helmet, and screwdriver as part of his starting kit.

## Why It's Good For The Game

Most other crafting roles start with similar tools, so its nice for the smith to have them too, especially since he needs them even more, what with most of his recipes requiring one of these items he was missing. I was gonna give him a drill too since some of his recipes need that, but eh, nobody else had one and the only recipe that really needs that is the spear and bumper sword.

## Changelog

:cl:
add: Gives the legion blacksmith some new tools
/:cl:


