### PR TITLE
CHOKE SLAMMED (shotgun choke variable)

### DIFF
--- a/code/modules/projectiles/ammunition/_firing.dm
+++ b/code/modules/projectiles/ammunition/_firing.dm
@@ -1,12 +1,15 @@
 //MOJAVE EDIT CHANGE BEGIN - FIRE_CASING
 //obj/item/ammo_casing/proc/fire_casing(atom/target, mob/living/user, params, distro, quiet, zone_override, spread, atom/fired_from) - Mojave EDIT - ORIGINAL
-/obj/item/ammo_casing/proc/fire_casing(atom/target, mob/living/user, params, distro, quiet, zone_override, spread, atom/fired_from, extra_damage, extra_penetration)
+/obj/item/ammo_casing/proc/fire_casing(atom/target, mob/living/user, params, distro, quiet, zone_override, spread, atom/fired_from, extra_damage, extra_penetration, spread_reduction)
+	if(isgun(fired_from))
+		var/obj/item/gun/G = fired_from
+		spread_reduction = G.spread_reduction
+	distro += (variance - spread_reduction)
 	//MOJAVE EDIT CHANGE END
-	distro += variance
 	var/targloc = get_turf(target)
 	//MOJAVE EDIT CHANGE BEGIN - FIRE_CASING
 	//ready_proj(target, user, quiet, zone_override, fired_from) - Mojave EDIT - ORIGINAL
-	ready_proj(target, user, quiet, zone_override, fired_from, extra_damage, extra_penetration)
+	ready_proj(target, user, quiet, zone_override, fired_from, extra_damage, extra_penetration, spread_reduction)
 	//MOJAVE EDIT CHANGE END
 	if(pellets == 1)
 		if(distro) //We have to spread a pixel-precision bullet. throw_proj was called before so angles should exist by now...

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -2,6 +2,12 @@
 #define DUALWIELD_PENALTY_EXTRA_MULTIPLIER 1.4
 #define FIRING_PIN_REMOVAL_DELAY 50
 
+//MS13 EDIT BEGIN
+#define CHOKE_WIDE 0
+#define CHOKE_MODERATE 7
+#define CHOKE_TIGHT 11
+//MS13 EDIT END
+
 /obj/item/gun
 	name = "gun"
 	desc = "It's a gun. It's pretty terrible, though."
@@ -53,6 +59,7 @@
 	//MOJAVE EDIT ADDITION BEGIN - /OBJ/ITEM/GUN
 	var/extra_damage = 0				//Number of damage to add to individual bullets.
 	var/extra_penetration = 0			//Number to add to armor penetration of individual bullets.
+	var/spread_reduction = CHOKE_WIDE //Mostly for shotguns, increases or decreases the variance of buckshot
 	//MOJAVE EDIT ADDITION END
 
 	var/spread = 0 //Spread induced by the gun itself.

--- a/mojave/items/guns/weapons/ballistic/revolver.dm
+++ b/mojave/items/guns/weapons/ballistic/revolver.dm
@@ -10,6 +10,7 @@
 	slot_flags = ITEM_SLOT_BACK
 	recoil = 1.5
 	slowdown = 0.75
+	spread_reduction = CHOKE_MODERATE
 	mag_type = /obj/item/ammo_box/magazine/internal/shot/ms13/caravan
 	load_sound = 'mojave/sound/ms13weapons/gunsounds/caravan/caravanload2.ogg'
 	load_empty_sound = 'mojave/sound/ms13weapons/gunsounds/caravan/caravanload2.ogg'
@@ -30,6 +31,7 @@
 	inhand_icon_state = "sawedoff"
 	force = 15
 	subtractible_armour_penetration = 0
+	spread_reduction = CHOKE_WIDE
 	fire_delay = 0.5 SECONDS
 	slot_flags = ITEM_SLOT_SUITSTORE | ITEM_SLOT_BELT
 	slowdown = 0.5
@@ -49,6 +51,7 @@
 	slot_flags = ITEM_SLOT_BACK
 	recoil = 1.5
 	slowdown = 0.75
+	spread_reduction = CHOKE_TIGHT
 	mag_type = /obj/item/ammo_box/magazine/internal/shot/ms13/single
 	load_sound = 'mojave/sound/ms13weapons/gunsounds/caravan/caravanload2.ogg'
 	load_empty_sound = 'mojave/sound/ms13weapons/gunsounds/caravan/caravanload2.ogg'

--- a/mojave/items/guns/weapons/ballistic/revolver.dm
+++ b/mojave/items/guns/weapons/ballistic/revolver.dm
@@ -1,7 +1,7 @@
 //Guns
 /obj/item/gun/ballistic/revolver/ms13/caravan
 	name = "caravan shotgun"
-	desc = "A well worn but reliable double barrel shotgun."
+	desc = "A well worn but reliable double barrel shotgun with a tighter spread than other shotguns."
 	icon_state = "caravan"
 	inhand_icon_state = "caravan"
 	force = 20
@@ -42,7 +42,7 @@
 
 /obj/item/gun/ballistic/revolver/ms13/single
 	name = "single shotgun"
-	desc = "A very cheap and very common lightweight shotgun with only a single round, better make it count."
+	desc = "A very cheap and very common lightweight shotgun with only a single round, better make it count. It has a very tight choke that enhances its effective range."
 	icon_state = "singleshot"
 	inhand_icon_state = "singleshot"
 	force = 20


### PR DESCRIPTION
## About The Pull Request

Adds a weapon stat called spread_reduction, which is used to reduce the spread of buckshot. Its only applied to the Caravan shotgun and single shot shotgun, giving those guns a further effective range at the cost of making it easier for others to dodge.

## Why It's Good For The Game

Adds a little extra variety for shotguns. Right now, its only applied to the two weakest of the shotguns, so it'll be nice to see how they change up the shotgun user dynamic.

## Changelog
