### PR TITLE
Power Armor Sovl

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -870,4 +870,6 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 
 #define TRAIT_IN_POWERARMOUR "in_powerarmour" //If this person is wearing power armour actively
 
+#define TRAIT_SHOVEIMMUNE "shove_immune"//Makes the user completely immune to shoving
+
 // MOJAVE JOB TRAITS END

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -261,6 +261,14 @@
 	var/shove_blocked = FALSE //Used to check if a shove is blocked so that if it is knockdown logic can be applied
 	var/turf/target_old_turf = target.loc
 
+	//MOJAVE EDIT BEGIN
+	if(HAS_TRAIT(target, TRAIT_SHOVEIMMUNE))
+		target.visible_message(span_danger("[name] tries to shove [target.name], but [target.name] won't budge! "),
+				span_userdanger("[name] tries to shove you, but you stand your ground!"), span_hear("You hear aggressive shuffling followed by a loud thud!"), COMBAT_MESSAGE_RANGE, src)
+		to_chat(src, span_danger("You try to shove [target.name], but they won't budge!"))
+		return
+	//MOJAVE EDIT END
+
 	//Are we hitting anything? or
 	if(SEND_SIGNAL(target_shove_turf, COMSIG_CARBON_DISARM_PRESHOVE) & COMSIG_CARBON_ACT_SOLID)
 		shove_blocked = TRUE

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -107,7 +107,8 @@ GLOBAL_LIST_EMPTY(features_by_species)
 	///Highest possible punch damage this species can give.
 	var/punchdamagehigh = 10
 	///Damage at which punches from this race will stun
-	var/punchstunthreshold = 10 //yes it should be to the attacked race but it's not useful that way even if it's logical
+	//var/punchstunthreshold = 10 //yes it should be to the attacked race but it's not useful that way even if it's logical
+	var/punchstunthreshold = 100 //MOJAVE SUN EDIT - ORIGINAL ABOVE
 	///Base electrocution coefficient.  Basically a multiplier for damage from electrocutions.
 	var/siemens_coeff = 1
 	///What kind of damage overlays (if any) appear on our species when wounded? If this is "", does not add an overlay.
@@ -1356,7 +1357,7 @@ GLOBAL_LIST_EMPTY(features_by_species)
 		//MOJAVE EDIT BEGIN
 		if(HAS_TRAIT(user, TRAIT_IN_POWERARMOUR))
 			damage += 15
-			attack_sound = 'mojave/sound/ms13weapons/meleesounds/heavyblunt_hit1.ogg'
+			user.dna.species.attack_sound = 'mojave/sound/ms13weapons/meleesounds/heavyblunt_hit1.ogg'
 		//MOJAVE EDIT END
 
 		var/obj/item/bodypart/affecting = target.get_bodypart(ran_zone(user.zone_selected))

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -108,8 +108,7 @@ GLOBAL_LIST_EMPTY(features_by_species)
 	///Highest possible punch damage this species can give.
 	var/punchdamagehigh = 10
 	///Damage at which punches from this race will stun
-	//var/punchstunthreshold = 10 //yes it should be to the attacked race but it's not useful that way even if it's logical
-	var/punchstunthreshold = 100 //MOJAVE SUN EDIT - ORIGINAL ABOVE
+	var/punchstunthreshold = 10 //yes it should be to the attacked race but it's not useful that way even if it's logical
 	///Base electrocution coefficient.  Basically a multiplier for damage from electrocutions.
 	var/siemens_coeff = 1
 	///What kind of damage overlays (if any) appear on our species when wounded? If this is "", does not add an overlay.
@@ -1359,6 +1358,7 @@ GLOBAL_LIST_EMPTY(features_by_species)
 		if(HAS_TRAIT(user, TRAIT_IN_POWERARMOUR))
 			damage += 15
 			user.dna.species.attack_sound = 'mojave/sound/ms13weapons/meleesounds/heavyblunt_hit1.ogg'
+			user.dna.species.punchstunthreshold = 24 //slightly higher knockdown chance
 		//MOJAVE EDIT END
 
 		var/obj/item/bodypart/affecting = target.get_bodypart(ran_zone(user.zone_selected))
@@ -1430,7 +1430,7 @@ GLOBAL_LIST_EMPTY(features_by_species)
 								edge_protection = edge_protection, \
 								subarmor_flags = subarmor_flags)
 			//MOJAVE EDIT END
-			target.apply_damage(no_defended*1.5, STAMINA, affecting, armor_block)
+			//target.apply_damage(no_defended*1.5, STAMINA, affecting, armor_block) MOJAVE EDIT - Removes stamina damage on punches
 			log_combat(user, target, "punched")
 
 		if((target.stat != DEAD) && damage >= user.dna.species.punchstunthreshold)

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1353,6 +1353,12 @@ GLOBAL_LIST_EMPTY(features_by_species)
 
 		var/damage = rand(user.dna.species.punchdamagelow, user.dna.species.punchdamagehigh)
 
+		//MOJAVE EDIT BEGIN
+		if(HAS_TRAIT(user, TRAIT_IN_POWERARMOUR))
+			damage += 15
+			attack_sound = 'mojave/sound/ms13weapons/meleesounds/heavyblunt_hit1.ogg'
+		//MOJAVE EDIT END
+
 		var/obj/item/bodypart/affecting = target.get_bodypart(ran_zone(user.zone_selected))
 
 		var/miss_chance = 100//calculate the odds that a punch misses entirely. considers stamina and brute damage of the puncher. punches miss by default to prevent weird cases

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -103,7 +103,8 @@ GLOBAL_LIST_EMPTY(features_by_species)
 	///Type of damage attack does. Ethereals attack with burn damage for example.
 	var/attack_type = BRUTE
 	///Lowest possible punch damage this species can give. If this is set to 0, punches will always miss.
-	var/punchdamagelow = 1
+	//var/punchdamagelow = 1
+	var/punchdamagelow = 5 //MOJAVE SUN EDIT - ORIGINAL ABOVE
 	///Highest possible punch damage this species can give.
 	var/punchdamagehigh = 10
 	///Damage at which punches from this race will stun

--- a/mojave/code/modules/clothing/spacesuits/power_armor.dm
+++ b/mojave/code/modules/clothing/spacesuits/power_armor.dm
@@ -506,6 +506,7 @@
 	ADD_TRAIT(user, TRAIT_PUSHIMMUNE, "power_armor")
 	ADD_TRAIT(user, TRAIT_NON_FLAMMABLE, "power_armor")
 	ADD_TRAIT(user, TRAIT_IN_POWERARMOUR, "power_armor")
+	ADD_TRAIT(user, TRAIT_SHOVEIMMUNE, "power_armor")
 	RegisterSignal(user, COMSIG_ATOM_CAN_BE_PULLED, .proc/reject_pulls)
 
 /obj/item/clothing/suit/space/hardsuit/ms13/power_armor/dropped(mob/living/carbon/human/user)
@@ -527,6 +528,7 @@
 	REMOVE_TRAIT(user, TRAIT_PUSHIMMUNE, "power_armor")
 	REMOVE_TRAIT(user, TRAIT_NON_FLAMMABLE, "power_armor")
 	REMOVE_TRAIT(user, TRAIT_IN_POWERARMOUR, "power_armor")
+	REMOVE_TRAIT(user, TRAIT_SHOVEIMMUNE, "power_armor")
 	UnregisterSignal(user, COMSIG_ATOM_CAN_BE_PULLED)
 
 /obj/item/clothing/suit/space/hardsuit/ms13/power_armor/proc/reject_pulls(datum/source, mob/living/puller)


### PR DESCRIPTION
## About The Pull Request

Adds a new trait that grants shove immunity to the user, and applies it to power armor. No longer must you fear being pushed around by weaklings, now you're an iron man mountain.

Additionally, buffs PA punches and gives them a different attack sound. It's still better to use a real melee weapon if you have one, but you'll never be truly unarmed as long as you're in your trusty exoskeleton.

This PR also removes stamina damage on punch and makes unarmed attacks slightly stronger.

## Why It's Good For The Game

Adds more SOVL, and removes some possible ways to cheese PA users.

## Changelog
