### PR TITLE
Double Tapping

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -60,6 +60,7 @@
 	var/extra_damage = 0				//Number of damage to add to individual bullets.
 	var/extra_penetration = 0			//Number to add to armor penetration of individual bullets.
 	var/spread_reduction = CHOKE_WIDE //Mostly for shotguns, increases or decreases the variance of buckshot
+	var/double_tap = FALSE 				//meant to be used for double barrel shotguns, makes the weapon fire two rounds at once
 	//MOJAVE EDIT ADDITION END
 
 	var/spread = 0 //Spread induced by the gun itself.
@@ -503,7 +504,7 @@
 
 	else if(bayonet && can_bayonet) //if it has a bayonet, and the bayonet can be removed
 		return remove_gun_attachment(user, I, bayonet, "unfix")
-
+/* MOJAVE EDIT BEGIN
 	else if(pin && user.is_holding(src))
 		user.visible_message(span_warning("[user] attempts to remove [pin] from [src] with [I]."),
 		span_notice("You attempt to remove [pin] from [src]. (It will take [DisplayTimeText(FIRING_PIN_REMOVAL_DELAY)].)"), null, 3)
@@ -514,6 +515,7 @@
 								span_warning("You pry [pin] out with [I], destroying the pin in the process."), null, 3)
 			QDEL_NULL(pin)
 			return TRUE
+*/ //MOJAVE EDIT END
 
 /obj/item/gun/welder_act(mob/living/user, obj/item/I)
 	. = ..()

--- a/code/modules/projectiles/guns/ballistic.dm
+++ b/code/modules/projectiles/guns/ballistic.dm
@@ -92,6 +92,10 @@
 	/// Check if you are able to see if a weapon has a bullet loaded in or not.
 	var/hidden_chambered = FALSE
 
+	//MOJAVE EDIT BEGIN
+	var/can_be_made_double_tap = FALSE
+	//MOJAVE EDIT END
+
 	///Gun internal magazine modification and misfiring
 
 	///Can we modify our ammo type in this gun's internal magazine?
@@ -370,6 +374,11 @@
 	if (can_be_sawn_off)
 		if (sawoff(user, A))
 			return
+	//MOJAVE EDIT BEGIN
+	if(can_be_made_double_tap)
+		if(doubletap(user, A))
+			return
+	//MOJAVE EDIT END
 
 	if(can_misfire && istype(A, /obj/item/stack/sheet/cloth))
 		if(guncleaning(user, A))
@@ -512,6 +521,10 @@
 		. += "The [bolt_wording] is locked back and needs to be released before firing or de-fouling."
 	if (suppressed)
 		. += "It has a suppressor attached that can be removed with <b>alt+click</b>."
+	//MOJAVE SUN EDIT BEGIN
+	if (double_tap)
+		. += "It has been modified to fire both barrels at once."
+	//MOJAVE SUN EDIT END
 	if(can_misfire)
 		. += span_danger("You get the feeling this might explode if you fire it....")
 		if(misfire_probability > 0)
@@ -608,6 +621,44 @@ GLOBAL_LIST_INIT(gun_saw_types, typecacheof(list(
 		sawn_off = TRUE
 		update_appearance()
 		return TRUE
+
+//MOJAVE EDIT BEGIN
+/obj/item/gun/ballistic/proc/doubletap(mob/user, obj/item/I)
+
+	if(!istype(I, /obj/item/wrench))
+		return FALSE
+
+	user.changeNext_move(CLICK_CD_MELEE)
+	user.visible_message(span_notice("[user] begins to modify [src]."), span_notice("You begin to modify [src]..."))
+
+	if(blow_up(user))
+		user.visible_message(span_danger("[src] goes off!"), span_danger("[src] goes off in your face!"))
+		return FALSE
+
+	if(do_after(user, 30, target = src))
+		user.visible_message(span_notice("[user] modifies [src]!"), span_notice("You modifies [src]."))
+		if(!double_tap)
+			burst_size = 2
+			fire_delay = 1
+		if(double_tap)
+			burst_size = 1
+			fire_delay = 0
+		double_tap = !double_tap
+	return TRUE
+/*
+	//if there's any live ammo inside the gun, makes it go off
+	if(blow_up(user))
+		user.visible_message(span_danger("[src] goes off!"), span_danger("[src] goes off in your face!"))
+		return
+
+	if(do_after(user, 30, target = src))
+		burst_size = 2
+		fire_delay = 1
+		return TRUE
+		if(double_tap == TRUE)
+			return FALSE
+		*/
+//MOJAVE EDIT END
 
 /obj/item/gun/ballistic/proc/guncleaning(mob/user, obj/item/A)
 	if(misfire_probability == 0)

--- a/mojave/items/guns/weapons/ballistic/revolver.dm
+++ b/mojave/items/guns/weapons/ballistic/revolver.dm
@@ -26,7 +26,7 @@
 
 /obj/item/gun/ballistic/revolver/ms13/caravan/sawed
 	name = "sawed-off shotgun"
-	desc = "A double barrel sawed-off shotgun. Can be used and fired with only one hand, making it a deadly weapon in a pinch."
+	desc = "A double barrel sawed-off shotgun. Can be used and fired with only one hand, making it a deadly weapon in a pinch. It can be modified to fire both barrels at once."
 	icon_state = "sawedoff"
 	inhand_icon_state = "sawedoff"
 	force = 15
@@ -39,6 +39,7 @@
 	weapon_weight = WEAPON_MEDIUM
 	grid_width = 96
 	grid_height = 64
+	can_be_made_double_tap = TRUE
 
 /obj/item/gun/ballistic/revolver/ms13/single
 	name = "single shotgun"
@@ -92,7 +93,7 @@
 ////////////////////////// revolvers////////////////
 /obj/item/gun/ballistic/revolver/ms13/derringer
 	name = "derringer"
-	desc = "A small and sneaky 2 shot pistol that is often concealed. Chambered for .357."
+	desc = "A small and sneaky 2 shot pistol that is often concealed. Chambered for .357, and can be modified to fire both barrels at once."
 	icon_state = "derringer"
 	inhand_icon_state = "derringer"
 	force = 5
@@ -110,12 +111,14 @@
 	spread = 6
 	grid_width = 64
 	grid_height = 32
+	can_be_made_double_tap = TRUE
 
 /obj/item/gun/ballistic/revolver/ms13/derringer/trimmed
 	name = "gold trimmed derringer"
-	desc = "A small and sneaky 2 shot pistol that is often concealed. This one has some gold trim."
+	desc = "A small and sneaky 2 shot pistol that is often concealed. This one has some gold trim and has been pre-modified to fire both barrels at once."
 	icon_state = "derringer_t"
 	inhand_icon_state = "derringer_t"
+	double_tap = TRUE
 
 /obj/item/gun/ballistic/revolver/ms13/rev44
 	name = ".44 magnum revolver"


### PR DESCRIPTION
## About The Pull Request

Adds in support for double tapping. By using a wrench, you can modify certain weapons to fire in a quick 2 round burst. This currently does not add any weapons that can be modified this way, it only adds the code support.

This also commits out the ability to remove firing pins. Its kind of a silly feature so eh.

## Why It's Good For The Game

Adds in a neat little trait that could be applied to weapons like double-barrel shotguns or derringers. Now you can miss both shots even faster than you could before!

