### PR TITLE
Fixes street sign layering

### DIFF
--- a/_maps/map_files/Mammoth/Mammoth.dmm
+++ b/_maps/map_files/Mammoth/Mammoth.dmm
@@ -5781,7 +5781,7 @@
 /turf/open/floor/wood/ms13/carpet,
 /area/ms13/town)
 "dKD" = (
-/obj/machinery/power/ms13/trafficlight/alt,
+/o/obj/machinery/power/ms13/streetlamp/trafficlight/alt,
 /turf/open/floor/plating/ms13/ground/sidewalk,
 /area/ms13)
 "dKO" = (
@@ -12701,7 +12701,7 @@
 /turf/open/floor/ms13/tile/brown,
 /area/ms13/town)
 "hzN" = (
-/obj/machinery/power/ms13/trafficlight{
+/obj/machinery/power/ms13/streetlamp/trafficlight{
 	dir = 8
 	},
 /obj/structure/ms13/street_sign/warnings{
@@ -13998,7 +13998,7 @@
 /area/ms13/ncr)
 "iie" = (
 /obj/machinery/power/ms13/streetlamp/corner,
-/obj/machinery/power/ms13/trafficlight{
+/obj/machinery/power/ms13/streetlamp/trafficlight{
 	dir = 4
 	},
 /turf/open/floor/plating/ms13/ground/sidewalk,

--- a/_maps/map_files/Mammoth_Mini/Mammoth_mini.dmm
+++ b/_maps/map_files/Mammoth_Mini/Mammoth_mini.dmm
@@ -4597,7 +4597,7 @@
 /turf/open/floor/wood/ms13/wide,
 /area/ms13/town)
 "dKD" = (
-/obj/machinery/power/ms13/trafficlight/alt,
+/obj/machinery/power/ms13/streetlamp/trafficlight/alt,
 /turf/open/floor/plating/ms13/ground/sidewalk,
 /area/ms13)
 "dLi" = (
@@ -9971,7 +9971,7 @@
 /turf/open/floor/ms13/tile/brown,
 /area/ms13/town)
 "hzN" = (
-/obj/machinery/power/ms13/trafficlight{
+/obj/machinery/power/ms13/streetlamp/trafficlight{
 	dir = 8
 	},
 /obj/structure/ms13/street_sign/warnings{
@@ -11166,7 +11166,7 @@
 /area/ms13/army_base/building)
 "iie" = (
 /obj/machinery/power/ms13/streetlamp/corner,
-/obj/machinery/power/ms13/trafficlight{
+/obj/machinery/power/ms13/streetlamp/trafficlight{
 	dir = 4
 	},
 /turf/open/floor/plating/ms13/ground/sidewalk,
@@ -23746,7 +23746,7 @@
 /turf/open/floor/ms13/concrete/industrial,
 /area/ms13/underground/tunnel/maintenance)
 "qpT" = (
-/obj/machinery/power/ms13/trafficlight,
+/obj/machinery/power/ms13/streetlamp/trafficlight,
 /turf/open/floor/plating/ms13/ground/snow,
 /area/ms13/snow/lightforest)
 "qqp" = (

--- a/_maps/map_files/generic/MojaveCom.dmm
+++ b/_maps/map_files/generic/MojaveCom.dmm
@@ -92,7 +92,7 @@
 /turf/open/floor/ms13/concrete,
 /area/ms13/start_area/museum)
 "lX" = (
-/obj/machinery/power/ms13/trafficlight{
+/obj/machinery/power/ms13/streetlamp/trafficlight{
 	pixel_x = -23;
 	pixel_y = -14
 	},

--- a/mojave/structures/street_decorations.dm
+++ b/mojave/structures/street_decorations.dm
@@ -5,7 +5,7 @@
 	icon_state = "streetlight"
 	anchored = TRUE
 	density = TRUE
-	layer = ABOVE_ALL_MOB_LAYER
+	layer = ABOVE_MOB_LAYER
 	plane = ABOVE_GAME_PLANE
 	max_integrity = 2000
 	pixel_x = -32
@@ -45,31 +45,12 @@
 	desc = "A pre-war street lamp, what more is there to say?"
 	icon_state = "streetlightduo"
 
-/obj/machinery/power/ms13/trafficlight
+/obj/machinery/power/ms13/streetlamp/trafficlight
 	name = "\improper traffic light"
 	desc = "A relic of a more civilized time, where people for some reason weren't alright with plowing over a family while going ninety down a road."
-	icon = 'mojave/icons/structure/streetpoles.dmi'
-	anchored = TRUE
-	max_integrity = 2000
-	pixel_x = -32
 	icon_state = "trafficlightright"
-	resistance_flags = INDESTRUCTIBLE
 
-/obj/machinery/power/ms13/trafficlight/CanAllowThrough(atom/movable/mover, turf/target)
-	. = ..()
-	if(locate(/obj/machinery/power/ms13/trafficlight) in get_turf(mover))
-		return TRUE
-	else if(istype(mover, /obj/projectile))
-		if(!anchored)
-			return TRUE
-		var/obj/projectile/proj = mover
-		if(proj.firer && Adjacent(proj.firer))
-			return TRUE
-		if(prob(75)) // These things are pretty thin
-			return TRUE
-		return FALSE
-
-/obj/machinery/power/ms13/trafficlight/alt
+/obj/machinery/power/ms13/streetlamp/trafficlight/alt
 	icon_state = "trafficlightleft"
 
 // Street Signs //
@@ -80,7 +61,8 @@
 	icon = 'mojave/icons/structure/street_signs.dmi'
 	anchored = TRUE
 	density = TRUE
-	layer = ABOVE_MOB_LAYER
+	layer = ABOVE_ALL_MOB_LAYER
+	plane = ABOVE_GAME_PLANE // Added to prevent layering issues with street lamps 
 	max_integrity = 500 // Hardy but not immortal
 	projectile_passchance = 95
 

--- a/mojave/structures/street_decorations.dm
+++ b/mojave/structures/street_decorations.dm
@@ -5,7 +5,7 @@
 	icon_state = "streetlight"
 	anchored = TRUE
 	density = TRUE
-	layer = ABOVE_ALL_MOB_LAYER
+	layer = ABOVE_MOB_LAYER
 	plane = ABOVE_GAME_PLANE
 	max_integrity = 2000
 	pixel_x = -32
@@ -45,31 +45,13 @@
 	desc = "A pre-war street lamp, what more is there to say?"
 	icon_state = "streetlightduo"
 
-/obj/machinery/power/ms13/trafficlight
+/obj/machinery/power/ms13/streetlamp/trafficlight
 	name = "\improper traffic light"
 	desc = "A relic of a more civilized time, where people for some reason weren't alright with plowing over a family while going ninety down a road."
-	icon = 'mojave/icons/structure/streetpoles.dmi'
-	anchored = TRUE
-	max_integrity = 2000
-	pixel_x = -32
 	icon_state = "trafficlightright"
 	resistance_flags = INDESTRUCTIBLE
 
-/obj/machinery/power/ms13/trafficlight/CanAllowThrough(atom/movable/mover, turf/target)
-	. = ..()
-	if(locate(/obj/machinery/power/ms13/trafficlight) in get_turf(mover))
-		return TRUE
-	else if(istype(mover, /obj/projectile))
-		if(!anchored)
-			return TRUE
-		var/obj/projectile/proj = mover
-		if(proj.firer && Adjacent(proj.firer))
-			return TRUE
-		if(prob(75)) // These things are pretty thin
-			return TRUE
-		return FALSE
-
-/obj/machinery/power/ms13/trafficlight/alt
+/obj/machinery/power/ms13/streetlamp/trafficlight/alt
 	icon_state = "trafficlightleft"
 
 // Street Signs //
@@ -80,7 +62,8 @@
 	icon = 'mojave/icons/structure/street_signs.dmi'
 	anchored = TRUE
 	density = TRUE
-	layer = ABOVE_MOB_LAYER
+	layer = ABOVE_ALL_MOB_LAYER
+	plane = ABOVE_GAME_PLANE
 	max_integrity = 500 // Hardy but not immortal
 	projectile_passchance = 95
 


### PR DESCRIPTION
## About The Pull Request

Fixes issue with street signs layering atop streetlamps. 
Refer to issue #2267

Also makes traffic lights a child of streetlamps, since code was nearly identical, thus making it so mob sprites pass beneath. Replaces traffic lights on maps that had old path with new path.